### PR TITLE
Fix: Build error

### DIFF
--- a/internal/state/replicator.go
+++ b/internal/state/replicator.go
@@ -81,6 +81,7 @@ func (r *BasicReplicator) Replicate(ctx context.Context, replicationEntities []E
 	}
 
 	for _, replicationEntity := range replicationEntities {
+        // check if image already exists in zot registry/ local registry
 
 		log.Info().Msgf("Pulling image %s from repository %s at registry %s with tag %s", replicationEntity.GetName(), replicationEntity.GetRepository(), r.sourceRegistry, replicationEntity.GetTag())
 		// Pull the image from the source registry

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -1,18 +1,9 @@
 package e2e
 
-import "flag"
-
 const (
 	appDir                  = "/app"
 	appBinary               = "app"
 	sourceFile              = "main.go"
-	relative_path           = "./testdata/config.json"
-	absolute_path           = "test/e2e/testdata/config.json"
+	absolute_path           = "/test/e2e/testdata/config.json"
 	satellite_ping_endpoint = "/api/v1/satellite/ping"
 )
-
-var ABS bool
-
-func init() {
-	flag.BoolVar(&ABS, "abs", true, "Use absolute path for the config file")
-}

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -4,6 +4,6 @@ const (
 	appDir                  = "/app"
 	appBinary               = "app"
 	sourceFile              = "main.go"
-	absolute_path           = "/test/e2e/testdata/config.json"
+	test_config_path           = "/test/e2e/testdata/config.json"
 	satellite_ping_endpoint = "/api/v1/satellite/ping"
 )


### PR DESCRIPTION
The error is still prevalent, but the test case itself has been refactored.
The source of the e2e test failing is that dagger is not authenticated with docker and docker rate limits dagger from pulling images due to this.

Options:
1. What we can do is, use our own private registry with credentials/ docker account with credentials for testing purposes if we have any. We can configure the test environment with github secret and make use of the credentials as normal env variables.
2. We may need to temporarily remove the test case and keep the issue open until we find a way to authenticate our dagger service. 
3. I tried pulling images from other services (amazon, for example) without authentication but they all require some form of authorization for pulling. We could create a dummy account for this purpose and try if it works.

Need some help here. @Mehul-Kumar-27 @Vad1mo @bupd 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Consolidated configuration handling by unifying the test configuration file path and removing redundant initialization logic.

- **Tests**
  - Streamlined the test setup by eliminating unnecessary registry setup steps and simplifying image push validations.
  - Enhanced error handling in tests to improve clarity when processing image data.

- **Refactor**
  - Improved internal code clarity by adding descriptive comments to outline future enhancements for image verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->