### PR TITLE
Update the satellite code to accept the new state artifact

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -47,7 +47,7 @@ func Run() error {
 
 	localRegistryConfig := satellite.NewRegistryConfig(config.GetRemoteRegistryURL(), config.GetRemoteRegistryUsername(), config.GetRemoteRegistryPassword())
 	sourceRegistryConfig := satellite.NewRegistryConfig(config.GetSourceRegistryURL(), config.GetSourceRegistryUsername(), config.GetSourceRegistryPassword())
-	satelliteService := satellite.NewSatellite(ctx, scheduler.GetSchedulerKey(), localRegistryConfig, sourceRegistryConfig, config.UseUnsecure(), config.GetStates())
+	satelliteService := satellite.NewSatellite(ctx, scheduler.GetSchedulerKey(), localRegistryConfig, sourceRegistryConfig, config.UseUnsecure(), config.GetState())
 
 	wg.Go(func() error {
 		return satelliteService.Run(ctx)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 
 	"github.com/container-registry/harbor-satellite/internal/config"
+	"github.com/container-registry/harbor-satellite/internal/logger"
 	"github.com/container-registry/harbor-satellite/internal/satellite"
 	"github.com/container-registry/harbor-satellite/internal/server"
+	"github.com/container-registry/harbor-satellite/internal/state"
 	"github.com/container-registry/harbor-satellite/internal/utils"
-	"github.com/container-registry/harbor-satellite/internal/logger"
 	"github.com/container-registry/harbor-satellite/registry"
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
@@ -45,8 +46,8 @@ func Run() error {
 	}
 	defer scheduler.Stop()
 
-	localRegistryConfig := satellite.NewRegistryConfig(config.GetRemoteRegistryURL(), config.GetRemoteRegistryUsername(), config.GetRemoteRegistryPassword())
-	sourceRegistryConfig := satellite.NewRegistryConfig(config.GetSourceRegistryURL(), config.GetSourceRegistryUsername(), config.GetSourceRegistryPassword())
+	localRegistryConfig := state.NewRegistryConfig(config.GetRemoteRegistryURL(), config.GetRemoteRegistryUsername(), config.GetRemoteRegistryPassword())
+	sourceRegistryConfig := state.NewRegistryConfig(config.GetSourceRegistryURL(), config.GetSourceRegistryUsername(), config.GetSourceRegistryPassword())
 	satelliteService := satellite.NewSatellite(ctx, scheduler.GetSchedulerKey(), localRegistryConfig, sourceRegistryConfig, config.UseUnsecure(), config.GetState())
 
 	wg.Go(func() error {

--- a/ground-control/internal/models/models.go
+++ b/ground-control/internal/models/models.go
@@ -19,8 +19,8 @@ type Artifact struct {
 }
 
 type ZtrResult struct {
-	States []string `json:"states"`
-	Auth   Account  `json:"auth"`
+	State string  `json:"state"`
+	Auth  Account `json:"auth"`
 }
 
 type Account struct {

--- a/ground-control/internal/server/handlers.go
+++ b/ground-control/internal/server/handlers.go
@@ -393,7 +393,6 @@ func (s *Server) registerSatelliteHandler(w http.ResponseWriter, r *http.Request
 	WriteJSONResponse(w, http.StatusOK, tk)
 }
 
-// we need to update the state here to reflect the satellite's state artifact
 func (s *Server) ztrHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	token := vars["token"]

--- a/ground-control/internal/server/handlers.go
+++ b/ground-control/internal/server/handlers.go
@@ -213,7 +213,7 @@ func (s *Server) registerSatelliteHandler(w http.ResponseWriter, r *http.Request
 		}
 	}()
 	// Create satellite
-	satellite, err := q.CreateSatellite(r.Context(), req.Name)
+    satellite, err := q.CreateSatellite(r.Context(), req.Name)
 	if err != nil {
 		log.Println(err)
 		err := &AppError{

--- a/ground-control/internal/server/handlers.go
+++ b/ground-control/internal/server/handlers.go
@@ -152,8 +152,8 @@ func (s *Server) groupsSyncHandler(w http.ResponseWriter, r *http.Request) {
 	WriteJSONResponse(w, http.StatusOK, result)
 }
 
+// There is a CreateStateArtifact that we can try to model after.
 func (s *Server) registerSatelliteHandler(w http.ResponseWriter, r *http.Request) {
-	// The groups, as soon as they are created, already have their own state artifact.
 	var req RegisterSatelliteParams
 	if err := DecodeRequestBody(r, &req); err != nil {
 		log.Println(err)
@@ -395,6 +395,7 @@ func (s *Server) registerSatelliteHandler(w http.ResponseWriter, r *http.Request
 	WriteJSONResponse(w, http.StatusOK, tk)
 }
 
+// we need to update the state here to reflect the satellite's state artifact
 func (s *Server) ztrHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	token := vars["token"]
@@ -703,6 +704,9 @@ func (s *Server) addSatelliteToGroup(w http.ResponseWriter, r *http.Request) {
 		projects = append(projects, grp.Projects...)
 		groupStates = append(groupStates, utils.AssembleGroupState(grp.GroupName))
 	}
+
+	// 1. We need the list of state artifacts for the groups that satellite belongs to
+	// 2. Update the satellite state artifact accordingly
 
 	_, err = utils.UpdateRobotProjects(r.Context(), projects, robotAcc.RobotID)
 	if err != nil {

--- a/ground-control/internal/server/handlers.go
+++ b/ground-control/internal/server/handlers.go
@@ -213,7 +213,7 @@ func (s *Server) registerSatelliteHandler(w http.ResponseWriter, r *http.Request
 		}
 	}()
 	// Create satellite
-    satellite, err := q.CreateSatellite(r.Context(), req.Name)
+	satellite, err := q.CreateSatellite(r.Context(), req.Name)
 	if err != nil {
 		log.Println(err)
 		err := &AppError{

--- a/ground-control/internal/server/handlers.go
+++ b/ground-control/internal/server/handlers.go
@@ -153,6 +153,8 @@ func (s *Server) groupsSyncHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // There is a CreateStateArtifact that we can try to model after.
+// There is a function called AssembleGroupState that we can readily use while preparing the contents
+// of the satellite state artifact.
 func (s *Server) registerSatelliteHandler(w http.ResponseWriter, r *http.Request) {
 	var req RegisterSatelliteParams
 	if err := DecodeRequestBody(r, &req); err != nil {

--- a/ground-control/internal/server/handlers.go
+++ b/ground-control/internal/server/handlers.go
@@ -503,7 +503,7 @@ func (s *Server) ztrHandler(w http.ResponseWriter, r *http.Request) {
 
 	// we need to update the state here to reflect the satellite's state artifact
 	result := models.ZtrResult{
-		States: []string{satelliteState},
+		State: satelliteState,
 		Auth: models.Account{
 			Name:     robot.RobotName,
 			Secret:   robot.RobotSecret,

--- a/ground-control/internal/server/handlers.go
+++ b/ground-control/internal/server/handlers.go
@@ -152,9 +152,6 @@ func (s *Server) groupsSyncHandler(w http.ResponseWriter, r *http.Request) {
 	WriteJSONResponse(w, http.StatusOK, result)
 }
 
-// There is a CreateStateArtifact that we can try to model after.
-// There is a function called AssembleGroupState that we can readily use while preparing the contents
-// of the satellite state artifact.
 func (s *Server) registerSatelliteHandler(w http.ResponseWriter, r *http.Request) {
 	var req RegisterSatelliteParams
 	if err := DecodeRequestBody(r, &req); err != nil {
@@ -227,8 +224,7 @@ func (s *Server) registerSatelliteHandler(w http.ResponseWriter, r *http.Request
 		tx.Rollback()
 		return
 	}
-
-	var groupStates []string
+    var groupStates []string
 
 	// Check if Groups is nil before dereferencing
 	if req.Groups != nil {

--- a/ground-control/internal/server/handlers.go
+++ b/ground-control/internal/server/handlers.go
@@ -702,9 +702,6 @@ func (s *Server) addSatelliteToGroup(w http.ResponseWriter, r *http.Request) {
 		groupStates = append(groupStates, utils.AssembleGroupState(grp.GroupName))
 	}
 
-	// 1. We need the list of state artifacts for the groups that satellite belongs to
-	// 2. Update the satellite state artifact accordingly
-
 	_, err = utils.UpdateRobotProjects(r.Context(), projects, robotAcc.RobotID)
 	if err != nil {
 		log.Printf("Error: Failed to Add permission to robot account: %v", err)

--- a/ground-control/internal/utils/helper.go
+++ b/ground-control/internal/utils/helper.go
@@ -177,6 +177,7 @@ func CreateOrUpdateSatStateArtifact(satelliteName string, states []string) error
 	auth := authn.FromConfig(authn.AuthConfig{Username: username, Password: password})
 	options := []crane.Option{crane.WithAuth(auth)}
 
+	// Construct the destination repository and strip protocol, if present
 	destinationRepo := getStateArtifactDestination(registry, repo)
 	destinationRepo = stripProtocol(destinationRepo)
 
@@ -255,7 +256,6 @@ func tagImage(destination string, options []crane.Option) error {
 	}
 	return nil
 }
-
 func getStateArtifactDestination(registry, repository string) string {
 	return fmt.Sprintf("%s/%s/%s", registry, repository, "state")
 }

--- a/ground-control/internal/utils/helper.go
+++ b/ground-control/internal/utils/helper.go
@@ -177,7 +177,6 @@ func CreateOrUpdateSatStateArtifact(satelliteName string, states []string) error
 	auth := authn.FromConfig(authn.AuthConfig{Username: username, Password: password})
 	options := []crane.Option{crane.WithAuth(auth)}
 
-	// Construct the destination repository and strip protocol, if present
 	destinationRepo := getStateArtifactDestination(registry, repo)
 	destinationRepo = stripProtocol(destinationRepo)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,8 +41,8 @@ type LocalJsonConfig struct {
 }
 
 type StateConfig struct {
-	Auth   Auth     `json:"auth,omitempty"`
-	States []string `json:"states,omitempty"`
+	Auth  Auth   `json:"auth,omitempty"`
+	State string `json:"state,omitempty"`
 }
 
 type Config struct {
@@ -139,11 +139,11 @@ func InitConfig(configPath string) ([]error, []Warning) {
 	return err, warnings
 }
 
-func UpdateStateAuthConfig(name, registry, secret string, states []string) error {
+func UpdateStateAuthConfig(name, registry, secret string, state string) error {
 	appConfig.StateConfig.Auth.SourceUsername = name
 	appConfig.StateConfig.Auth.Registry = registry
 	appConfig.StateConfig.Auth.SourcePassword = secret
-	appConfig.StateConfig.States = states
+	appConfig.StateConfig.State = state
 	return WriteConfig(DefaultConfigPath)
 }
 

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -44,8 +44,8 @@ func GetSourceRegistryURL() string {
 	return appConfig.StateConfig.Auth.Registry
 }
 
-func GetStates() []string {
-	return appConfig.StateConfig.States
+func GetState() string {
+	return appConfig.StateConfig.State
 }
 
 func GetToken() string {

--- a/internal/satellite/satellite.go
+++ b/internal/satellite/satellite.go
@@ -30,16 +30,16 @@ type Satellite struct {
 	LocalRegistryConfig   RegistryConfig
 	SourcesRegistryConfig RegistryConfig
 	UseUnsecure           bool
-	states                []string
+	state                 string
 }
 
-func NewSatellite(ctx context.Context, schedulerKey scheduler.SchedulerKey, localRegistryConfig, sourceRegistryConfig RegistryConfig, useUnsecure bool, states []string) *Satellite {
+func NewSatellite(ctx context.Context, schedulerKey scheduler.SchedulerKey, localRegistryConfig, sourceRegistryConfig RegistryConfig, useUnsecure bool, state string) *Satellite {
 	return &Satellite{
 		schedulerKey:          schedulerKey,
 		LocalRegistryConfig:   localRegistryConfig,
 		SourcesRegistryConfig: sourceRegistryConfig,
 		UseUnsecure:           useUnsecure,
-		states:                states,
+		state:                 state,
 	}
 }
 
@@ -53,11 +53,7 @@ func (s *Satellite) Run(ctx context.Context) error {
 	// Create a simple notifier and add it to the process
 	notifier := notifier.NewSimpleNotifier(ctx)
 	// Creating a process to fetch and replicate the state
-	var satelliteState string
-	if len(config.GetStates()) > 0 {
-		satelliteState = config.GetStates()[0]
-	}
-	fetchAndReplicateStateProcess := state.NewFetchAndReplicateStateProcess(replicateStateCron, notifier, s.SourcesRegistryConfig.URL, s.SourcesRegistryConfig.UserName, s.SourcesRegistryConfig.Password, s.LocalRegistryConfig.URL, s.LocalRegistryConfig.UserName, s.LocalRegistryConfig.Password, s.UseUnsecure, satelliteState)
+	fetchAndReplicateStateProcess := state.NewFetchAndReplicateStateProcess(replicateStateCron, notifier, s.SourcesRegistryConfig.URL, s.SourcesRegistryConfig.UserName, s.SourcesRegistryConfig.Password, s.LocalRegistryConfig.URL, s.LocalRegistryConfig.UserName, s.LocalRegistryConfig.Password, s.UseUnsecure, config.GetState())
 	configFetchProcess := state.NewFetchConfigFromGroundControlProcess(updateConfigCron, "", "")
 	err := scheduler.Schedule(configFetchProcess)
 	if err != nil {

--- a/internal/satellite/satellite.go
+++ b/internal/satellite/satellite.go
@@ -48,6 +48,7 @@ func (s *Satellite) Run(ctx context.Context) error {
 	log.Info().Msg("Starting Satellite")
 	replicateStateCron := config.GetStateReplicationInterval()
 	updateConfigCron := config.GetUpdateConfigInterval()
+	ztrCron := config.GetRegistrationInterval()
 	// Get the scheduler from the context
 	scheduler := ctx.Value(s.schedulerKey).(scheduler.Scheduler)
 	// Create a simple notifier and add it to the process
@@ -55,6 +56,7 @@ func (s *Satellite) Run(ctx context.Context) error {
 	// Creating a process to fetch and replicate the state
 	fetchAndReplicateStateProcess := state.NewFetchAndReplicateStateProcess(replicateStateCron, notifier, s.SourcesRegistryConfig.URL, s.SourcesRegistryConfig.UserName, s.SourcesRegistryConfig.Password, s.LocalRegistryConfig.URL, s.LocalRegistryConfig.UserName, s.LocalRegistryConfig.Password, s.UseUnsecure, config.GetState())
 	configFetchProcess := state.NewFetchConfigFromGroundControlProcess(updateConfigCron, "", "")
+	ztrProcess := state.NewZtrProcess(ztrCron)
 	err := scheduler.Schedule(configFetchProcess)
 	if err != nil {
 		log.Error().Err(err).Msg("Error scheduling process")
@@ -66,6 +68,7 @@ func (s *Satellite) Run(ctx context.Context) error {
 		log.Error().Err(err).Msg("Error scheduling process")
 		return err
 	}
+
 	// Schedule Register Satellite Process
 	if utils.IsZTRDone() {
 		log.Info().Msg("ZTR already performed, skipping the process")

--- a/internal/state/fetcher.go
+++ b/internal/state/fetcher.go
@@ -77,7 +77,7 @@ func (f *URLStateFetcher) FetchStateArtifact(state interface{}, log *zerolog.Log
 		return f.fetchGroupState(s, log)
 
 	default:
-		return fmt.Errorf("unexpected state type", s)
+		return fmt.Errorf("unexpected state type: %T", s)
 	}
 }
 

--- a/internal/state/fetcher.go
+++ b/internal/state/fetcher.go
@@ -19,8 +19,8 @@ type StateFetcher interface {
 }
 
 type baseStateFetcher struct {
-	username              string
-	password              string
+	username string
+	password string
 }
 
 type URLStateFetcher struct {
@@ -37,8 +37,8 @@ func NewURLStateFetcher(stateURL, userName, password string) StateFetcher {
 	url := utils.FormatRegistryURL(stateURL)
 	return &URLStateFetcher{
 		baseStateFetcher: baseStateFetcher{
-			username:              userName,
-			password:              password,
+			username: userName,
+			password: password,
 		},
 		url: url,
 	}
@@ -47,8 +47,8 @@ func NewURLStateFetcher(stateURL, userName, password string) StateFetcher {
 func NewFileStateFetcher(filePath, userName, password string) StateFetcher {
 	return &FileStateArtifactFetcher{
 		baseStateFetcher: baseStateFetcher{
-			username:              userName,
-			password:              password,
+			username: userName,
+			password: password,
 		},
 		filePath: filePath,
 	}
@@ -66,7 +66,7 @@ func (f *FileStateArtifactFetcher) FetchStateArtifact(state interface{}) error {
 	return nil
 }
 
-func (f *URLStateFetcher) FetchStateArtifact(state interface{}) error {
+func (f *URLStateFetcher) FetchStateArtifact(state *SatelliteState) error {
 	auth := authn.FromConfig(authn.AuthConfig{
 		Username: f.username,
 		Password: f.password,
@@ -110,7 +110,7 @@ func (f *URLStateFetcher) FetchStateArtifact(state interface{}) error {
 	if artifactsJSON == nil {
 		return fmt.Errorf("artifacts.json not found in the state artifact")
 	}
-	err = json.Unmarshal(artifactsJSON, &state)
+	err = json.Unmarshal(artifactsJSON, state)
 	if err != nil {
 		return fmt.Errorf("failed to parse the artifacts.json file: %v", err)
 	}

--- a/internal/state/fetcher.go
+++ b/internal/state/fetcher.go
@@ -66,7 +66,11 @@ func (f *FileStateArtifactFetcher) FetchStateArtifact(state interface{}) error {
 	return nil
 }
 
-func (f *URLStateFetcher) FetchStateArtifact(state *SatelliteState) error {
+func (f *URLStateFetcher) FetchStateArtifact(state interface{}) error {
+	state, ok := state.(*SatelliteState)
+	if !ok {
+		return fmt.Errorf("state is not of expected type SatelliteState")
+	}
 	auth := authn.FromConfig(authn.AuthConfig{
 		Username: f.username,
 		Password: f.password,

--- a/internal/state/fetcher.go
+++ b/internal/state/fetcher.go
@@ -138,9 +138,7 @@ func (f *URLStateFetcher) extractArtifactJSON(url string, img v1.Image, out inte
 				log.Error().Msgf("Failed to read the artifacts.json of the state artifact: %s", url)
 				return fmt.Errorf("failed to read the artifacts.json file: %v", err)
 			}
-			err = json.Unmarshal(artifactsJSON, out)
-			log.Info().Msgf("The unmarshalled artifacts.json from the state artifact: %s is %s", url, out)
-			return err
+			return json.Unmarshal(artifactsJSON, out)
 		}
 	}
 	log.Error().Msgf("artifacts.json not present for the state artifact: %s", url)

--- a/internal/state/helpers.go
+++ b/internal/state/helpers.go
@@ -8,7 +8,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
-func processInput(input, username, password string, log *zerolog.Logger) (StateFetcher, error) {
+func getStateFetcherForInput(input, username, password string, log *zerolog.Logger) (StateFetcher, error) {
 
 	if utils.IsValidURL(input) {
 		return processURLInput(utils.FormatRegistryURL(input), username, password, log)

--- a/internal/state/registration_process.go
+++ b/internal/state/registration_process.go
@@ -70,7 +70,7 @@ func (z *ZtrProcess) Execute(ctx context.Context) error {
 		return fmt.Errorf("failed to register satellite: invalid state auth config received")
 	}
 	// Update the state config in app config
-	if err := config.UpdateStateAuthConfig(stateConfig.Auth.SourceUsername, stateConfig.Auth.Registry, stateConfig.Auth.SourcePassword, stateConfig.States); err != nil {
+	if err := config.UpdateStateAuthConfig(stateConfig.Auth.SourceUsername, stateConfig.Auth.Registry, stateConfig.Auth.SourcePassword, stateConfig.State); err != nil {
 		log.Error().Msgf("Failed to register satellite: could not update state auth config")
 		return fmt.Errorf("failed to register satellite: could not update state auth config")
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -24,9 +24,12 @@ type State struct {
 	Artifacts []Artifact `json:"artifacts"`
 }
 
+type SatelliteState struct {
+	States []string
+}
+
 func NewState() StateReader {
-	state := &State{}
-	return state
+	return &State{}
 }
 
 func (a *State) GetRegistryURL() string {

--- a/internal/state/state_process.go
+++ b/internal/state/state_process.go
@@ -103,9 +103,12 @@ func (f *FetchAndReplicateStateProcess) Execute(ctx context.Context) error {
 		log.Error().Err(err).Msgf("Error fetching state artifact from url: %s", f.satelliteState)
 		return err
 	}
-	// Create the statemap of the states that the satellite should track
-	// using the list of states present in the satellite's state
-	f.stateMap = NewStateMap(satelliteState.States)
+
+	if f.stateMap == nil {
+		// Create the statemap of the states that the satellite should track
+		// using the list of states present in the satellite's state
+		f.stateMap = NewStateMap(satelliteState.States)
+	}
 
 	// Loop through each state and reconcile the satellite
 	for i := range f.stateMap {

--- a/internal/state/state_process.go
+++ b/internal/state/state_process.go
@@ -260,11 +260,12 @@ func (f *FetchAndReplicateStateProcess) FetchAndProcessState(fetcher StateFetche
 	satelliteState := &SatelliteState{}
 	// let's first print out the new state config
 	err := fetcher.FetchStateArtifact(satelliteState)
-    fmt.Print("The Satellite State Artifact is: ", satelliteState)
+	fmt.Print("The Satellite State Artifact is: ", satelliteState)
 	if err != nil {
 		log.Error().Err(err).Msg("Error fetching state artifact")
 		return nil, err
 	}
+	// update this function to now fetch the list of states from earlier
 	return ProcessState(&state)
 }
 

--- a/internal/state/state_process.go
+++ b/internal/state/state_process.go
@@ -94,13 +94,13 @@ func (f *FetchAndReplicateStateProcess) Execute(ctx context.Context) error {
 	log.Info().Msgf("Processing satellite state from the url: %s", f.satelliteState)
 	satelliteStateFetcher, err := getStateFetcherForInput(f.satelliteState, f.authConfig.SourceRegistryUserName, f.authConfig.SourceRegistryPassword, log)
 	if err != nil {
-		log.Error().Err(err).Msg("Error processing input")
+		log.Error().Err(err).Msg("Error processing satellite state")
 		return err
 	}
 
 	satelliteState := &SatelliteState{}
-	if err := satelliteStateFetcher.FetchStateArtifact(&satelliteStateFetcher); err != nil {
-		log.Error().Err(err).Msg("Error fetching state artifact")
+	if err := satelliteStateFetcher.FetchStateArtifact(satelliteState, log); err != nil {
+		log.Error().Err(err).Msgf("Error fetching state artifact from url: %s", f.satelliteState)
 		return err
 	}
 	// Create the statemap of the states that the satellite should track
@@ -276,10 +276,7 @@ func ProcessState(state *StateReader) (*StateReader, error) {
 
 func (f *FetchAndReplicateStateProcess) FetchAndProcessState(fetcher StateFetcher, log *zerolog.Logger) (*StateReader, error) {
 	state := NewState()
-	satelliteState := &SatelliteState{}
-	// let's first print out the new state config
-	err := fetcher.FetchStateArtifact(satelliteState)
-	fmt.Print("The Satellite State Artifact is: ", satelliteState)
+	err := fetcher.FetchStateArtifact(state, log)
 	if err != nil {
 		log.Error().Err(err).Msg("Error fetching state artifact")
 		return nil, err

--- a/internal/state/state_process.go
+++ b/internal/state/state_process.go
@@ -257,7 +257,10 @@ func ProcessState(state *StateReader) (*StateReader, error) {
 
 func (f *FetchAndReplicateStateProcess) FetchAndProcessState(fetcher StateFetcher, log *zerolog.Logger) (*StateReader, error) {
 	state := NewState()
-	err := fetcher.FetchStateArtifact(&state)
+	satelliteState := &SatelliteState{}
+	// let's first print out the new state config
+	err := fetcher.FetchStateArtifact(satelliteState)
+    fmt.Print("The Satellite State Artifact is: ", satelliteState)
 	if err != nil {
 		log.Error().Err(err).Msg("Error fetching state artifact")
 		return nil, err

--- a/internal/state/state_process.go
+++ b/internal/state/state_process.go
@@ -83,6 +83,12 @@ func (f *FetchAndReplicateStateProcess) Execute(ctx context.Context) error {
 		log.Warn().Msgf("Process %s is already running", f.name)
 		return nil
 	}
+
+	// To get the satellite state, we need to perform ZTR. However, the outcome of this process is non-deterministic.
+	// So we may be initializing the FetchAndReplicateProcess with an empty satelliteState
+	// As a sanity check, we need to update the satelliteState.
+	f.satelliteState = config.GetState()
+
 	canExecute, reason := f.CanExecute(ctx)
 	if !canExecute {
 		log.Warn().Msgf("Cannot execute process: %s", reason)

--- a/internal/state/state_process.go
+++ b/internal/state/state_process.go
@@ -104,6 +104,30 @@ func (f *FetchAndReplicateStateProcess) Execute(ctx context.Context) error {
 		return err
 	}
 
+	var newStates []string
+	for _, state := range satelliteState.States {
+		found := false
+		for _, stateMap := range f.stateMap {
+			if stateMap.url == state {
+				found = true
+				break
+			}
+		}
+		if !found {
+			newStates = append(newStates, state)
+		}
+	}
+
+	// Remove states that are no longer needed
+	var updatedStateMap []StateMap
+	for _, stateMap := range f.stateMap {
+		if contains(satelliteState.States, stateMap.url) {
+			updatedStateMap = append(updatedStateMap, stateMap)
+		}
+	}
+
+	// Add new states
+	f.stateMap = append(updatedStateMap, NewStateMap(newStates)...)
 
 	// Loop through each state and reconcile the satellite
 	for i := range f.stateMap {

--- a/internal/state/state_process.go
+++ b/internal/state/state_process.go
@@ -97,6 +97,7 @@ func (f *FetchAndReplicateStateProcess) Execute(ctx context.Context) error {
 		log.Error().Err(err).Msg("Error processing input")
 		return err
 	}
+
 	satelliteState := &SatelliteState{}
 	if err := satelliteStateFetcher.FetchStateArtifact(&satelliteStateFetcher); err != nil {
 		log.Error().Err(err).Msg("Error fetching state artifact")
@@ -212,7 +213,7 @@ func (f *FetchAndReplicateStateProcess) CanExecute(ctx context.Context) (bool, s
 		condition bool
 		message   string
 	}{
-		{f.stateMap == nil, "state map is nil"},
+		{f.satelliteState == "", "satelliteState is empty"},
 		{f.authConfig.RemoteRegistryURL == "", "remote registry URL is empty"},
 		{f.authConfig.SourceRegistry == "", "source registry is empty"},
 		{f.authConfig.SourceRegistryUserName == "", "username is empty"},


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1c3f466f-2857-40ad-a073-e7d694b6c5d4)

The architecture will now follow this diagram.
Note, this PR implements the satellite side changes, along with the changes in GC (for ease of merging later on). This PR should ideally be reviewed and merged after #95.

Satellite  can now interpret the new state artifact and reconcile images like its supposed to.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined state management across the platform by transitioning from a multi-value to a unified single state representation.
  - Updated API responses to consistently deliver a single state value.
  - Introduced a new `RegistryConfig` struct to encapsulate registry credentials.

- **Chores**
  - Enhanced logging and error handling during state fetching and processing.
  - Made minor code formatting adjustments to improve overall quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->