### PR TITLE
Fix Dagger go version

### DIFF
--- a/.dagger/go.mod
+++ b/.dagger/go.mod
@@ -1,6 +1,6 @@
 module harbor-satellite/ci
 
-go 1.24.0
+go 1.23.6
 
 require (
 	github.com/99designs/gqlgen v0.17.66


### PR DESCRIPTION
- To match the dagger runtime version, Downgrade the `.dagger/go.mod` version from `1.24.0` to `1.23.6` 
- Checked that it works in my local environment ✅ 

Solve: https://github.com/container-registry/harbor-satellite/issues/100