### PR TITLE
Fix: Run process at startup

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -104,6 +104,9 @@ func (s *BasicScheduler) Schedule(process Process) error {
 	s.logger.Info().Msgf("Process %s scheduled with cron expression %s", process.GetName(), process.GetCronExpr())
 	process.SetID(cronEntryId)
 
+    // TODO: a more comprehensive fix to running the process at startup would require a
+    // large refactor of the process scheduling logic, to ensure that ZTR is performed before
+    // attempting to execute any of the other processes.
 	go func() {
 		if !process.IsRunning() {
 			if err := s.executeProcess(process); err != nil {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -95,6 +95,7 @@ func (s *BasicScheduler) Schedule(process Process) error {
 		if err != nil {
 			s.logger.Error().Err(err).Msgf("Error executing process %s", process.GetName())
 		}
+
 	})
 	if err != nil {
 		return fmt.Errorf("error adding process to scheduler: %w", err)
@@ -102,6 +103,15 @@ func (s *BasicScheduler) Schedule(process Process) error {
 	s.processes[process.GetName()] = process
 	s.logger.Info().Msgf("Process %s scheduled with cron expression %s", process.GetName(), process.GetCronExpr())
 	process.SetID(cronEntryId)
+
+	go func() {
+		if !process.IsRunning() {
+			if err := s.executeProcess(process); err != nil {
+				s.logger.Error().Err(err).Msgf("Error executing process %s at startup", process.GetName())
+			}
+		}
+	}()
+
 	return nil
 }
 


### PR DESCRIPTION
This PR adds a simple logical fix. Closes #112 
However, a more comprehensive fix would require a refactor of the scheduler itself. The issue is that ztr must be performed before we attempt to perform replication, but the success of ztr is non-deterministic. 