### PR TITLE
feat: add validation for satellite_name & group_name

### DIFF
--- a/ground-control/internal/server/handlers.go
+++ b/ground-control/internal/server/handlers.go
@@ -18,6 +18,10 @@ import (
 	"github.com/gorilla/mux"
 )
 
+const (
+	invalidNameMessage = "Invalid %s name: must be 1-255 chars, start with letter/number, and contain only lowercase letters, numbers, and ._-"
+)
+
 type RegisterSatelliteParams struct {
 	Name   string    `json:"name"`
 	Groups *[]string `json:"groups,omitempty"`
@@ -57,6 +61,15 @@ func (s *Server) groupsSyncHandler(w http.ResponseWriter, r *http.Request) {
 	var req models.StateArtifact
 	if err := DecodeRequestBody(r, &req); err != nil {
 		log.Println(err)
+		HandleAppError(w, err)
+		return
+	}
+
+	if !utils.IsValidName(req.Group) {
+		err := &AppError{
+			Message: fmt.Sprintf(invalidNameMessage, "group"),
+			Code:    http.StatusBadRequest,
+		}
 		HandleAppError(w, err)
 		return
 	}
@@ -161,10 +174,9 @@ func (s *Server) registerSatelliteHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if len(req.Name) < 1 {
-		log.Println("name should be at least one character long.")
+	if !utils.IsValidName(req.Name) {
 		err := &AppError{
-			Message: "Error: name should be at least one character long.",
+			Message: fmt.Sprintf(invalidNameMessage, "satellite"),
 			Code:    http.StatusBadRequest,
 		}
 		HandleAppError(w, err)

--- a/ground-control/internal/utils/helper.go
+++ b/ground-control/internal/utils/helper.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -258,6 +259,20 @@ func tagImage(destination string, options []crane.Option) error {
 
 func getStateArtifactDestination(registry, repository string) string {
 	return fmt.Sprintf("%s/%s/%s", registry, repository, "state")
+}
+
+// IsValidName validates if a name meets the requirements:
+// 1. 1-255 characters long
+// 2. Only lowercase characters, numbers, and ._- are allowed
+// 3. Must start with a letter or number
+func IsValidName(name string) bool {
+	if len(name) < 1 || len(name) > 255 {
+		return false
+	}
+
+	pattern := `^[a-z0-9][a-z0-9._-]*$`
+	matched, _ := regexp.MatchString(pattern, name)
+	return matched
 }
 
 func envSanityCheck() error {


### PR DESCRIPTION
Validation of `satellite_name` and `group_name` is necessary, as servers return unhelpful error messages when creating a satellite or group. Improving these validation error messages would enhance the user experience.


Before -> 

```bash
satellite_name -> 
{"message":"Error: creating robot account error creating robot account: error: create robot account in adapter: [POST /robots][400] createRobotBadRequest  \u0026{Errors:[0xc0004342a0]}","code":400}


group_name -> 
{"message":"Internal Server Error","code":500}

```


After -> 

```bash
{"message":"Invalid satellite name: must be 1-255 chars, start with letter/number, and contain only lowercase letters, numbers, and ._-","code":400}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced input validation for group and satellite names to ensure they meet specific formatting rules.
	- Users now receive consistent, clear error messages when name entries do not adhere to the required criteria.
	- Introduced a new function for validating name formats, improving overall user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->