### PR TITLE
feat: Implement Ground Control sync endpoint and configuration fetching

### DIFF
--- a/ground-control/internal/models/models.go
+++ b/ground-control/internal/models/models.go
@@ -19,12 +19,17 @@ type Artifact struct {
 }
 
 type ZtrResult struct {
-	State string  `json:"state"`
-	Auth  Account `json:"auth"`
+	State         string  `json:"state"`
+	SatelliteName string  `json:"satellite_name"`
+	Auth          Account `json:"auth"`
 }
 
 type Account struct {
 	Name     string `json:"name"`
 	Secret   string `json:"secret"`
 	Registry string `json:"registry"`
+}
+
+type GroundControlPayload struct {
+	States []string `json:"states"`
 }

--- a/ground-control/internal/server/routes.go
+++ b/ground-control/internal/server/routes.go
@@ -29,6 +29,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 	r.HandleFunc("/satellites/list", s.listSatelliteHandler).Methods("GET")
 	r.HandleFunc("/satellites/{satellite}", s.GetSatelliteByName).Methods("GET")
 	r.HandleFunc("/satellites/{satellite}", s.DeleteSatelliteByName).Methods("DELETE")
+	r.HandleFunc("/satellites/{satellite}/sync", s.satelliteSyncHandler).Methods("GET")
 	// r.HandleFunc("/satellites/{satellite}/images", s.GetImagesForSatellite).Methods("GET")
 
 	return r

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,8 +42,9 @@ type LocalJsonConfig struct {
 }
 
 type StateConfig struct {
-	Auth  Auth   `json:"auth,omitempty"`
-	State string `json:"state,omitempty"`
+	Auth          Auth   `json:"auth,omitempty"`
+	State         string `json:"state,omitempty"`
+	SatelliteName string `json:"satellite_name,omitempty"`
 }
 
 type Config struct {
@@ -140,11 +141,12 @@ func InitConfig(configPath string) ([]error, []Warning) {
 	return err, warnings
 }
 
-func UpdateStateAuthConfig(name, registry, secret string, state string) error {
+func UpdateStateAuthConfig(name, registry, secret string, state string, satelliteName string) error {
 	appConfig.StateConfig.Auth.SourceUsername = name
 	appConfig.StateConfig.Auth.Registry = registry
 	appConfig.StateConfig.Auth.SourcePassword = secret
 	appConfig.StateConfig.State = state
+	appConfig.StateConfig.SatelliteName = satelliteName
 	return WriteConfig(DefaultConfigPath)
 }
 

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -56,6 +56,10 @@ func GetGroundControlURL() string {
 	return appConfig.LocalJsonConfig.GroundControlURL
 }
 
+func GetSatelliteName() string {
+	return appConfig.StateConfig.SatelliteName
+}
+
 func SetGroundControlURL(url string) {
 	appConfig.LocalJsonConfig.GroundControlURL = url
 }

--- a/internal/config/state.go
+++ b/internal/config/state.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"fmt"
+)
+
+func UpdateStates(states []string) error {
+	if appConfig == nil {
+		return fmt.Errorf("config not initialized")
+	}
+
+	appConfig.StateConfig.State = states[0]
+
+	// Write the updated config to file
+	if err := WriteConfig(DefaultConfigPath); err != nil {
+		return fmt.Errorf("failed to write updated config: %v", err)
+	}
+
+	return nil
+}
+
+// GetStates returns the current states from the configuration
+func GetStates() []string {
+	if appConfig == nil {
+		return nil
+	}
+	return []string{appConfig.StateConfig.State}
+}

--- a/internal/satellite/satellite.go
+++ b/internal/satellite/satellite.go
@@ -41,7 +41,7 @@ func (s *Satellite) Run(ctx context.Context) error {
 	notifier := notifier.NewSimpleNotifier(ctx)
 	// Creating a process to fetch and replicate the state
 	fetchAndReplicateStateProcess := state.NewFetchAndReplicateStateProcess(replicateStateCron, notifier, s.SourcesRegistryConfig, s.LocalRegistryConfig, s.UseUnsecure, config.GetState())
-	configFetchProcess := state.NewFetchConfigFromGroundControlProcess(updateConfigCron, "", "")
+	configFetchProcess := state.NewFetchConfigFromGroundControlProcess(updateConfigCron, config.GetToken(), config.GetGroundControlURL(), config.GetSatelliteName())
 	ztrProcess := state.NewZtrProcess(ztrCron)
 	err := scheduler.Schedule(configFetchProcess)
 	if err != nil {

--- a/internal/state/config_process.go
+++ b/internal/state/config_process.go
@@ -2,17 +2,20 @@ package state
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"sync"
 
 	"github.com/container-registry/harbor-satellite/internal/config"
+	"github.com/container-registry/harbor-satellite/internal/logger"
 	"github.com/container-registry/harbor-satellite/internal/scheduler"
 	"github.com/robfig/cron/v3"
 )
 
 const FetchConfigFromGroundControlEventName string = "fetch-config-from-ground-control-event"
 
-const GroundControlSyncPath string = "/satellites/sync"
+const GroundControlSyncPath string = "/satellites/%s/sync"
 
 type FetchConfigFromGroundControlProcess struct {
 	id               cron.EntryID
@@ -23,9 +26,10 @@ type FetchConfigFromGroundControlProcess struct {
 	groundControlURL string
 	mu               *sync.Mutex
 	eventBroker      *scheduler.EventBroker
+	satelliteName    string
 }
 
-func NewFetchConfigFromGroundControlProcess(cronExpr string, token string, groundControlURL string) *FetchConfigFromGroundControlProcess {
+func NewFetchConfigFromGroundControlProcess(cronExpr string, token string, groundControlURL string, satelliteName string) *FetchConfigFromGroundControlProcess {
 	return &FetchConfigFromGroundControlProcess{
 		name:             config.UpdateConfigJobName,
 		cronExpr:         cronExpr,
@@ -33,6 +37,7 @@ func NewFetchConfigFromGroundControlProcess(cronExpr string, token string, groun
 		token:            token,
 		groundControlURL: groundControlURL,
 		mu:               &sync.Mutex{},
+		satelliteName:    satelliteName,
 	}
 }
 
@@ -57,7 +62,48 @@ func NewGroundControlConfigEvent(states []string) scheduler.Event {
 }
 
 func (f *FetchConfigFromGroundControlProcess) Execute(ctx context.Context) error {
-	// TODO: Implement the logic to fetch the configuration from Ground Control one the endpoint is available on the Ground Control side
+	log := logger.FromContext(ctx)
+
+	client := &http.Client{}
+
+	satelliteName := config.GetSatelliteName()
+	if satelliteName == "" {
+		return fmt.Errorf("satellite name not configured")
+	}
+
+	syncPath := fmt.Sprintf(GroundControlSyncPath, satelliteName)
+	log.Info().Msgf("Fetching config from Ground Control: %s", f.groundControlURL+syncPath)
+	req, err := http.NewRequestWithContext(ctx, "GET", f.groundControlURL+syncPath, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %v", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("received non-200 status code: %d", resp.StatusCode)
+	}
+
+	var payload GroundControlPayload
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return fmt.Errorf("failed to decode response: %v", err)
+	}
+
+	log.Info().Msgf("Received %d states from Ground Control", len(payload.States))
+
+	if err := config.UpdateStates(payload.States); err != nil {
+		return fmt.Errorf("failed to update states in config: %v", err)
+	}
+
+	event := NewGroundControlConfigEvent(payload.States)
+	if f.eventBroker != nil {
+		f.eventBroker.Publish(event, ctx)
+	}
+
 	return nil
 }
 

--- a/internal/state/registration_process.go
+++ b/internal/state/registration_process.go
@@ -70,7 +70,12 @@ func (z *ZtrProcess) Execute(ctx context.Context) error {
 		return fmt.Errorf("failed to register satellite: invalid state auth config received")
 	}
 	// Update the state config in app config
-	if err := config.UpdateStateAuthConfig(stateConfig.Auth.SourceUsername, stateConfig.Auth.Registry, stateConfig.Auth.SourcePassword, stateConfig.State); err != nil {
+	if err := config.UpdateStateAuthConfig(
+		stateConfig.Auth.SourceUsername,
+		stateConfig.Auth.Registry,
+		stateConfig.Auth.SourcePassword,
+		stateConfig.State,
+		stateConfig.SatelliteName); err != nil {
 		log.Error().Msgf("Failed to register satellite: could not update state auth config")
 		return fmt.Errorf("failed to register satellite: could not update state auth config")
 	}
@@ -138,6 +143,8 @@ func (z *ZtrProcess) CanExecute(ctx context.Context) (bool, string) {
 	}{
 		{config.GetToken() == "", "token"},
 		{config.GetGroundControlURL() == "", "ground control URL"},
+		{config.GetState() == "", "state"},
+		{config.GetSatelliteName() == "", "satellite name"},
 	}
 	var missing []string
 	for _, check := range checks {


### PR DESCRIPTION
Fixes #137


Currently, Satellite can only track the state files provided by the user at startup.

As a result, when a new group is added to Satellite, it does not automatically track the newly added group's state file.

Our changes add support for automatically starting to track the state file of any newly added group.



// @Mehul-Kumar-27 @bupd 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new satellite synchronization endpoint to enable direct updates of satellite statuses.
  - Expanded configuration capabilities with satellite identification, enhancing state management and validation.
  - Improved state fetching and update processes with better error handling and logging.

These enhancements provide a more reliable and streamlined experience for managing satellite operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->