### PR TITLE
fix/log: enforce log level filtering on logger

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -56,7 +56,7 @@ func NewLogger(logLevel string) *zerolog.Logger {
 		return fmt.Sprintf("| %s |", l)
 	}
 
-	logger := zerolog.New(output).With().Timestamp().Logger()
+	logger := zerolog.New(output).Level(level).With().Timestamp().Logger()
 
 	return &logger
 }


### PR DESCRIPTION
> fixes #68 

> - [ ] Satellite does not respect the log_level set in config.json


Enforce strict log level filtering, so that the log_level set in config.json is respected.

// @bupd @Vad1mo 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved consistency in log level handling to ensure logger output matches the configured log level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->