### PR TITLE
add cli command and script for robot creation

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -13,6 +13,42 @@ In this guide, we'll use a Harbor registry instance.
 
 - **Registry Login**: Obtain the username and password for your registry, ensuring it has appropriate permissions.
 
+### 2.1 Create Robot Account for Ground Control (Recommended)
+
+Instead of using Harbor admin credentials for Ground Control operations, it's recommended to create a dedicated robot account with limited permissions. This approach is more secure because:
+
+1. It follows the principle of least privilege
+2. It isolates Ground Control's access from administrator privileges
+3. If compromised, the robot account has restricted capabilities
+
+#### One-time setup with admin credentials:
+
+Admin credentials are needed **only once** to create the robot account:
+
+```bash
+# Set your Harbor admin credentials (used only for robot account creation)
+export HARBOR_URL=https://your-harbor-instance
+export HARBOR_USERNAME=admin
+export HARBOR_PASSWORD=your-admin-password
+
+# Make the script executable (required for Linux/macOS)
+chmod +x scripts/harbor-robot/create-gc-robot.sh
+
+# Run the script to create the robot account
+./scripts/harbor-robot/create-gc-robot.sh
+```
+
+After running the script, you'll see output similar to:
+
+```
+✅ Robot account created successfully!
+Robot ID: 42
+Robot Name: robot$ground-control-robot
+Robot Secret: eyJhbGciOiJIUzI1NiIsIn...
+```
+
+Copy these credentials and use them in the Ground Control configurations in the next step instead of admin credentials
+
 ### 3. Configure Ground Control
 Navigate to the `ground-control` directory and set up the following environment variables:
 

--- a/cmd/robot/create.go
+++ b/cmd/robot/create.go
@@ -1,0 +1,99 @@
+package robot
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/container-registry/harbor-satellite/ground-control/reg/harbor"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/robot"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/spf13/cobra"
+)
+
+func NewCreateRobotCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create-gc-robot",
+		Short: "Create a robot account for Ground Control operations",
+		Long: `Create a robot account in Harbor with appropriate permissions for Ground Control operations.
+This follows security best practices by using a dedicated robot account instead of admin credentials.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Get from env
+			harborURL := os.Getenv("HARBOR_URL")
+			harborUsername := os.Getenv("HARBOR_USERNAME")
+			harborPassword := os.Getenv("HARBOR_PASSWORD")
+
+			if harborURL == "" || harborUsername == "" || harborPassword == "" {
+				return fmt.Errorf("HARBOR_URL, HARBOR_USERNAME, and HARBOR_PASSWORD must be set")
+			}
+
+			// Create a client
+			client := harbor.GetClient()
+			if client == nil {
+				return fmt.Errorf("failed to create Harbor client")
+			}
+
+			// Create robot account with system level permissions
+			robotReq := &models.RobotCreate{
+				Name:        "ground-control-robot",
+				Description: "Robot account for Ground Control operations",
+				Level:       "system",
+				Disable:     false,
+				Duration:    -1, // Never expires for now
+				Permissions: []*models.RobotPermission{
+					{
+						Kind:      "system",
+						Namespace: "/",
+						Access: []*models.Access{
+							{Resource: "project", Action: "create"},
+							{Resource: "project", Action: "read"},
+							{Resource: "project", Action: "update"},
+							{Resource: "repository", Action: "pull"},
+							{Resource: "repository", Action: "push"},
+							{Resource: "artifact", Action: "read"},
+							{Resource: "artifact", Action: "list"},
+						},
+					},
+				},
+			}
+
+			// We create the robot
+			created, err := client.Robot.CreateRobot(
+				robot.NewCreateRobotParams().WithRobot(robotReq),
+				nil,
+			)
+
+			if err != nil {
+				return fmt.Errorf("failed to create robot account: %v", err)
+			}
+
+			robotAccount := created.Payload
+
+			robotGet, err := client.Robot.GetRobotByID(
+				robot.NewGetRobotByIDParams().WithRobotID(robotAccount.ID),
+				nil,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to verify robot account: %v", err)
+			}
+
+			if robotGet.Payload.ID != robotAccount.ID {
+				return fmt.Errorf("verification failed: robot account ID mismatch")
+			}
+
+			fmt.Println("✅ Robot account created and verified successfully!")
+			fmt.Printf("Robot ID: %d\n", robotAccount.ID)
+			fmt.Printf("Robot Name: %s\n", robotAccount.Name)
+			fmt.Printf("Robot Secret: %s\n", robotAccount.Secret)
+			fmt.Println()
+			fmt.Println("To use these credentials with Ground Control, set these environment variables:")
+			fmt.Printf("export HARBOR_USERNAME=%s\n", robotAccount.Name)
+			fmt.Printf("export HARBOR_PASSWORD=%s\n", robotAccount.Secret)
+			fmt.Printf("export HARBOR_URL=%s\n", harborURL)
+
+			return nil
+		},
+	}
+
+	return cmd
+
+}

--- a/scripts/harbor-robot/create-gc-robot.sh
+++ b/scripts/harbor-robot/create-gc-robot.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -e
+
+# Check if required environment variables are set
+if [ -z "$HARBOR_URL" ] || [ -z "$HARBOR_USERNAME" ] || [ -z "$HARBOR_PASSWORD" ]; then
+    echo "Error: HARBOR_URL, HARBOR_USERNAME, and HARBOR_PASSWORD environment variables must be set"
+    echo "Example:"
+    echo "  export HARBOR_URL=https://your-harbor-instance"
+    echo "  export HARBOR_USERNAME=admin"
+    echo "  export HARBOR_PASSWORD=your-admin-password"
+    exit 1
+fi
+
+ROBOT_NAME="ground-control-robot"
+HARBOR_API_URL="${HARBOR_URL}/api/v2.0"
+
+echo "Creating robot account for Ground Control operations..."
+
+# Login and get cookie for authentication
+COOKIE_JAR="harbor-cookie.txt"
+curl -s -c "$COOKIE_JAR" -X POST "${HARBOR_API_URL}/login" \
+    -H "Content-Type: application/json" \
+    -d "{\"username\":\"${HARBOR_USERNAME}\",\"password\":\"${HARBOR_PASSWORD}\"}"
+
+# Create robot account with system level permissions
+response=$(curl -s -b "$COOKIE_JAR" -X POST "${HARBOR_API_URL}/robots" \
+    -H "Content-Type: application/json" \
+    -d "{
+        \"name\": \"${ROBOT_NAME}\",
+        \"description\": \"Robot account for Ground Control operations\",
+        \"level\": \"system\",
+        \"disable\": false,
+        \"duration\": -1,
+        \"permissions\": [
+            {
+                \"kind\": \"system\",
+                \"namespace\": \"/\",
+                \"access\": [
+                    {\"resource\": \"project\", \"action\": \"create\"},
+                    {\"resource\": \"project\", \"action\": \"read\"},
+                    {\"resource\": \"project\", \"action\": \"update\"},
+                    {\"resource\": \"repository\", \"action\": \"pull\"},
+                    {\"resource\": \"repository\", \"action\": \"push\"},
+                    {\"resource\": \"artifact\", \"action\": \"read\"},
+                    {\"resource\": \"artifact\", \"action\": \"list\"}
+                ]
+            }
+        ]
+    }")
+
+# Clean up cookie file
+rm -f "$COOKIE_JAR"
+
+# Extract robot credentials from response
+ROBOT_ID=$(echo $response | grep -o '"id":[0-9]*' | grep -o '[0-9]*')
+ROBOT_SECRET=$(echo $response | grep -o '"secret":"[^"]*"' | grep -o ':"[^"]*"' | cut -d'"' -f2)
+ROBOT_FULL_NAME=$(echo $response | grep -o '"name":"[^"]*"' | grep -o ':"[^"]*"' | cut -d'"' -f2)
+
+if [ -z "$ROBOT_SECRET" ]; then
+    echo "Error creating robot account. Server response:"
+    echo $response
+    exit 1
+fi
+
+echo "✅ Robot account created successfully!"
+echo "Robot ID: $ROBOT_ID"
+echo "Robot Name: $ROBOT_FULL_NAME"
+echo "Robot Secret: $ROBOT_SECRET"
+echo
+echo "To use these credentials with Ground Control, set these environment variables:"
+echo "export HARBOR_USERNAME=$ROBOT_FULL_NAME"
+echo "export HARBOR_PASSWORD=$ROBOT_SECRET"
+echo
+echo "Verifying robot account permissions..."
+
+# Verify robot account by making a test API call
+VERIFY_RESPONSE=$(curl -s -u "${ROBOT_FULL_NAME}:${ROBOT_SECRET}" "${HARBOR_API_URL}/projects")
+if [ $? -eq 0 ]; then
+    echo "✅ Verification successful! Robot account has proper permissions."
+else
+    echo "❌ Verification failed. Robot account may not have sufficient permissions."
+    echo $VERIFY_RESPONSE
+fi


### PR DESCRIPTION
#70

added a script to create a robot and verify it

Added CLI command to do the same(WIP)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a CLI command and a shell script to automate the creation of a dedicated Harbor robot account for Ground Control operations.
- **Documentation**
	- Updated setup instructions to recommend using a robot account for improved security, including step-by-step guidance for account creation and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->