### PR TITLE
enhancement : add endpoint to check token consumption status

### DIFF
--- a/ground-control/internal/server/routes.go
+++ b/ground-control/internal/server/routes.go
@@ -30,6 +30,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 	// Ground Control interface
 	r.HandleFunc("/satellites/register", s.registerSatelliteHandler).Methods("POST")
 	r.HandleFunc("/satellites/ztr/{token}", s.ztrHandler).Methods("GET")
+	r.HandleFunc("/satellites/status/{token}", s.ztrStatusHandler).Methods("GET")
 	r.HandleFunc("/satellites/list", s.listSatelliteHandler).Methods("GET")
 	r.HandleFunc("/satellites/{satellite}", s.GetSatelliteByName).Methods("GET")
 	r.HandleFunc("/satellites/{satellite}", s.DeleteSatelliteByName).Methods("DELETE")

--- a/ground-control/internal/server/satellite_handlers.go
+++ b/ground-control/internal/server/satellite_handlers.go
@@ -220,7 +220,7 @@ func (s *Server) ztrHandler(w http.ResponseWriter, r *http.Request) {
 			token[:4],
 			token[len(token)-4:],
 		)
-        log.Printf("Invalid Satellite Token %s: %v", masked, err)
+		log.Printf("Invalid Satellite Token %s: %v", masked, err)
 		err := &AppError{
 			Message: "Error: Invalid Token",
 			Code:    http.StatusBadRequest,
@@ -324,7 +324,12 @@ func (s *Server) ztrStatusHandler(w http.ResponseWriter, r *http.Request) {
 			// If the token is not found, it means it has already been consumed (or maybe invalid)
 			isTokenConsumed = true
 		} else {
-			masked := fmt.Sprintf("%s…%s", token[:4], token[len(token)-4:])
+			var masked string
+			if len(token) >= 8 {
+				masked = fmt.Sprintf("%s…%s", token[:4], token[len(token)-4:])
+			} else {
+				masked = "***"
+			}
 			log.Printf("Error fetching satellite by token %s: %v", masked, err)
 			appErr := &AppError{
 				Message: "Error: Invalid Token",

--- a/ground-control/internal/server/satellite_handlers.go
+++ b/ground-control/internal/server/satellite_handlers.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 
 	"github.com/container-registry/harbor-satellite/ground-control/internal/database"
-
 	"github.com/container-registry/harbor-satellite/ground-control/internal/utils"
 	"github.com/container-registry/harbor-satellite/ground-control/reg/harbor"
 	"github.com/container-registry/harbor-satellite/pkg/config"

--- a/internal/satellite/satellite.go
+++ b/internal/satellite/satellite.go
@@ -25,7 +25,6 @@ func NewSatellite(cm *config.ConfigManager) *Satellite {
 	}
 }
 
-
 func (s *Satellite) Run(ctx context.Context) error {
 	log := logger.FromContext(ctx)
 	log.Info().Msg("Starting Satellite")
@@ -49,15 +48,15 @@ func (s *Satellite) Run(ctx context.Context) error {
 	if response.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to register satellite: %s", response.Status)
 	}
-	
+
 	var respBody struct {
 		TokenConsumed bool `json:"token_consumed"`
 	}
-	
+
 	if err := json.NewDecoder(response.Body).Decode(&respBody); err != nil {
 		return fmt.Errorf("failed to decode response: %w", err)
 	}
-	
+
 	if !respBody.TokenConsumed {
 		// schedule ztr
 		go ScheduleFunc(ctx, log, s.cm.GetRegistrationInterval(), ztrProcess)

--- a/internal/satellite/satellite.go
+++ b/internal/satellite/satellite.go
@@ -46,7 +46,7 @@ func (s *Satellite) Run(ctx context.Context) error {
 		return err
 	}
 	if response.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to register satellite: %s", response.Status)
+		return fmt.Errorf("failed to check token status: %s", response.Status)
 	}
 
 	var respBody struct {


### PR DESCRIPTION
fixes #166 

Adds a new route to ground control which can check the status of ZTR consumption by checking its existence in the db

Before : checks if ztr is done by seeing if config is populated
After : checks if ztr is done by pinging the new endpoint using a GET request

For some reason this does not work using the docker compose file, I am looking into and will raise PR soon for the docker compose file as well
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new endpoint to check if a satellite token has been consumed, and updated the satellite client to use this check before scheduling registration.

- **New Features**
  - Added GET /satellites/status/{token} to report token consumption status.
  - Satellite client now checks token status before starting registration.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added an endpoint to check the status of a satellite token, allowing users to verify if a token has been consumed.
- **Bug Fixes**
  - Improved error handling and response messaging for invalid or consumed tokens when querying token status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->