### PR TITLE
Persist groundcontrol data with volume

### DIFF
--- a/ground-control/docker-compose.yml
+++ b/ground-control/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       POSTGRES_PASSWORD: password
     ports:
       - "8100:5432"
+    volumes:
+      - db:/var/lib/postgresql/data
 
   db-migrator:
     image: 8gears.container-registry.com/harbor-satellite/db-migrator:test
@@ -40,3 +42,6 @@ services:
     depends_on:
       - postgres
       - db-migrator
+
+volumes:
+  db:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a persistent Docker volume for the Postgres database in groundcontrol to keep data across container restarts.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the database service configuration to ensure data persists across restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->