### PR TITLE
removed duplicate step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,15 +53,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Push images
+      - name: Publish and Sign Tagged Image
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
         uses: ./.github/actions/publish-and-sign
         with:
-          IMAGE_TAGS: latest, ${{ github.ref_name }}
+          IMAGE_TAGS: "latest,${{ github.ref_name }}"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
           REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS }}
           REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
+          PROJECT_NAME: ${{ vars.PROJECT_NAME }}
 
       - name: Create Release
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
@@ -73,13 +74,3 @@ jobs:
           verb: call
           args: "release --github-token=env:GITHUB_TOKEN"
 
-      - name: Publish and Sign Tagged Image
-        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
-        uses: ./.github/actions/publish-and-sign
-        with:
-          IMAGE_TAGS: "latest, ${{ github.ref_name }}"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
-          REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS }}
-          REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
-          PROJECT_NAME: ${{ vars.PROJECT_NAME }}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed a duplicate "Publish and Sign Tagged Image" step from the release workflow to simplify the pipeline.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow for publishing and signing images, ensuring more consistent parameters and removing duplicate steps. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->