### PR TITLE
Feat: Integrate DB_Migrator into Ground Control

### DIFF
--- a/.dagger/e2e.go
+++ b/.dagger/e2e.go
@@ -86,11 +86,6 @@ func (m *HarborSatellite) startGroundControl(ctx context.Context) {
 		WithEnvVariable("HARBOR_USERNAME", harborAdminUser).
 		WithEnvVariable("HARBOR_PASSWORD", harborAdminPassword).
 		WithEnvVariable("HARBOR_URL", harborDomain).
-		WithExec([]string{"go", "install", "github.com/pressly/goose/v3/cmd/goose@latest"}).
-		WithEnvVariable("CACHEBUSTER", time.Now().String()).
-		WithWorkdir("/app/sql/schema").
-		WithExec([]string{"goose", "postgres",
-			"postgres://postgres:password@postgres:5432/groundcontrol?sslmode=disable", "up"}).
 		WithWorkdir("/app").
 		WithExec([]string{"go", "build", "-o", "gc", "main.go"}).
 		WithExposedPort(8080, dagger.ContainerWithExposedPortOpts{ExperimentalSkipHealthcheck: true}).

--- a/.dagger/e2e.go
+++ b/.dagger/e2e.go
@@ -86,6 +86,8 @@ func (m *HarborSatellite) startGroundControl(ctx context.Context) {
 		WithEnvVariable("HARBOR_USERNAME", harborAdminUser).
 		WithEnvVariable("HARBOR_PASSWORD", harborAdminPassword).
 		WithEnvVariable("HARBOR_URL", harborDomain).
+		WithEnvVariable("CACHEBUSTER", time.Now().String()).
+		WithDirectory("/migrations", gcDir.Directory("./sql/schema")).
 		WithWorkdir("/app").
 		WithExec([]string{"go", "build", "-o", "gc", "main.go"}).
 		WithExposedPort(8080, dagger.ContainerWithExposedPortOpts{ExperimentalSkipHealthcheck: true}).

--- a/.dagger/publish_image.go
+++ b/.dagger/publish_image.go
@@ -66,8 +66,7 @@ func (m *HarborSatellite) PublishImage(
 
 		if component == "ground-control" {
 			ctr = ctr.
-				WithDirectory("/migrations", source.Directory("./ground-control/sql/schema")).
-				WithWorkdir("/migrations")
+				WithDirectory("/migrations", source.Directory("./ground-control/sql/schema"))
 		}
 		releaseImages = append(releaseImages, ctr)
 	}

--- a/.dagger/publish_image.go
+++ b/.dagger/publish_image.go
@@ -26,8 +26,6 @@ func (m *HarborSatellite) PublishImage(
 		directory = source
 	case component == "ground-control":
 		directory = source.Directory(GROUND_CONTROL_PATH)
-	case component == "db-migrator":
-		directory = source.Directory(GROUND_CONTROL_PATH)
 	default:
 		panic(fmt.Sprintf("unknown component: %s", component))
 	}
@@ -66,12 +64,10 @@ func (m *HarborSatellite) PublishImage(
 			WithFile(component, builder.File(component)).
 			WithEntrypoint([]string{"/" + component})
 
-		if component == "db-migrator" {
-			// ctr = ctr.From("golang:"+GO_VERSION).
+		if component == "ground-control" {
 			ctr = ctr.
 				WithDirectory("/migrations", source.Directory("./ground-control/sql/schema")).
 				WithWorkdir("/migrations")
-			// WithExec([]string{"go", "install", "github.com/pressly/goose/v3/cmd/goose@latest"})
 		}
 		releaseImages = append(releaseImages, ctr)
 	}
@@ -191,9 +187,7 @@ func (m *HarborSatellite) getBuildContainer(
 				WithEnvVariable("GOOS", goos).
 				WithEnvVariable("GOARCH", goarch)
 
-			if component == "db-migrator" {
-				bldr = bldr.WithExec([]string{"go", "build", "-o", bin_path + component, "./migrator/main.go"})
-			} else if component == "satellite" {
+			if component == "satellite" {
 				bldr = bldr.WithExec([]string{"go", "build", "-o", bin_path + component, "./cmd/main.go"})
 			} else {
 				bldr = bldr.WithExec([]string{"go", "build", "-o", bin_path + component, "."})

--- a/ground-control/docker-compose.yml
+++ b/ground-control/docker-compose.yml
@@ -9,19 +9,7 @@ services:
     ports:
       - "8100:5432"
     volumes:
-      - db:/var/lib/postgresql/data
-
-  db-migrator:
-    image: 8gears.container-registry.com/harbor-satellite/db-migrator:test
-    container_name: db-migrator
-    environment:
-      DB_HOST: postgres
-      DB_PORT: 5432
-      DB_DATABASE: groundcontrol
-      DB_USERNAME: postgres
-      DB_PASSWORD: password
-    depends_on:
-      - postgres
+      - ./db:/var/lib/postgresql/data
 
   groundcontrol:
     image: 8gears.container-registry.com/harbor-satellite/ground-control:test
@@ -41,7 +29,7 @@ services:
       - "8080:8080"
     depends_on:
       - postgres
-      - db-migrator
+      # - db-migrator
 
 volumes:
   db:

--- a/ground-control/main.go
+++ b/ground-control/main.go
@@ -12,10 +12,12 @@ import (
 	"time"
 
 	"github.com/container-registry/harbor-satellite/ground-control/internal/server"
+	"github.com/container-registry/harbor-satellite/ground-control/migrator"
 	_ "github.com/joho/godotenv/autoload"
 )
 
 func main() {
+	migrator.DoMigrations()
 	server := server.NewServer()
 
 	go func() {

--- a/ground-control/migrator/migrator.go
+++ b/ground-control/migrator/migrator.go
@@ -1,4 +1,4 @@
-package main
+package migrator
 
 import (
 	"context"
@@ -77,7 +77,7 @@ func runMigrations(db *sql.DB) {
 	log.Println("Migrations completed successfully.")
 }
 
-func main() {
+func DoMigrations() {
 	cfg := parseDBConfig()
 
 	db, err := sql.Open("postgres", cfg.URL)

--- a/ground-control/migrator/migrator.go
+++ b/ground-control/migrator/migrator.go
@@ -3,9 +3,8 @@ package migrator
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"log"
-	"net"
-	"net/url"
 	"os"
 	"time"
 
@@ -19,26 +18,28 @@ type DBConfig struct {
 	Port string
 }
 
+var (
+	dbName   = os.Getenv("DB_DATABASE")
+	password = os.Getenv("DB_PASSWORD")
+	username = os.Getenv("DB_USERNAME")
+	PORT     = os.Getenv("DB_PORT")
+	HOST     = os.Getenv("DB_HOST")
+)
+
 func parseDBConfig() DBConfig {
-	dbURL := os.Getenv("DATABASE_URL")
-	if dbURL == "" {
-		log.Fatal("DATABASE_URL is required")
-	}
-
-	u, err := url.Parse(dbURL)
-	if err != nil {
-		log.Fatalf("invalid DATABASE_URL: %v", err)
-	}
-
-	host, port, err := net.SplitHostPort(u.Host)
-	if err != nil {
-		log.Fatalf("missing or invalid port in DATABASE_URL: %v", err)
-	}
+	dbURL := fmt.Sprintf(
+		"postgres://%s:%s@%s:%s/%s?sslmode=disable",
+		username,
+		password,
+		HOST,
+		PORT,
+		dbName,
+	)
 
 	return DBConfig{
 		URL:  dbURL,
-		Host: host,
-		Port: port,
+		Host: HOST,
+		Port: PORT,
 	}
 }
 

--- a/ground-control/migrator/migrator.go
+++ b/ground-control/migrator/migrator.go
@@ -65,7 +65,7 @@ func waitForPostgresReady(db *sql.DB, timeout time.Duration) {
 }
 
 func runMigrations(db *sql.DB) {
-	provider, err := goose.NewProvider(goose.DialectPostgres, db, os.DirFS("."))
+	provider, err := goose.NewProvider(goose.DialectPostgres, db, os.DirFS("/migrations"))
 	if err != nil {
 		log.Fatalf("failed to create goose provider: %v", err)
 	}


### PR DESCRIPTION
## Changes Made
- Remove db-migrator component and added it into the Ground control startup
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Integrates database migrations into Ground Control startup and removes the standalone db-migrator service/image. This simplifies deployment and keeps the DB up to date on boot.

- **New Features**
  - Ground Control runs migrations on start via migrator.DoMigrations().
  - Ground Control image bundles migrations from sql/schema; Dagger pipeline updated accordingly.
  - docker-compose removes the db-migrator service; Ground Control only depends on postgres.

- **Migration**
  - Remove db-migrator from deploys/CI and stop publishing its image.
  - Set DB_HOST, DB_PORT, DB_DATABASE, DB_USERNAME, DB_PASSWORD for Ground Control; DATABASE_URL is no longer used.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ground Control now runs database migrations automatically on startup.

* **Chores**
  * Removed the separate db-migrator service from Docker Compose.
  * Ground Control no longer pins a container name and now only depends on Postgres.
  * Postgres now uses a local bind mount (./db) for data persistence.
  * Simplified build and startup flow: Ground Control handles migrations directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->