### PR TITLE
refactor: Optimize group lookup in addSatelliteToGroups to only fetch ID

### DIFF
--- a/ground-control/internal/database/groups.sql.go
+++ b/ground-control/internal/database/groups.sql.go
@@ -162,3 +162,15 @@ func (q *Queries) ListGroups(ctx context.Context) ([]Group, error) {
 	}
 	return items, nil
 }
+
+const getGroupIDByName = `-- name: GetGroupIDByName :one
+SELECT id FROM groups
+WHERE group_name = $1
+`
+
+func (q *Queries) GetGroupIDByName(ctx context.Context, groupName string) (int32, error) {
+	row := q.db.QueryRowContext(ctx, getGroupIDByName, groupName)
+	var id int32
+	err := row.Scan(&id)
+	return id, err
+}

--- a/ground-control/internal/server/helpers.go
+++ b/ground-control/internal/server/helpers.go
@@ -82,17 +82,16 @@ func addSatelliteToGroups(ctx context.Context, q *database.Queries, groups *[]st
 					}
 				}
 			}
-			group, err := q.GetGroupByName(ctx, groupName)
+			groupID, err := q.GetGroupIDByName(ctx, groupName)
 			if err != nil {
 				return nil, &AppError{
 					Message: fmt.Sprintf("Error: Invalid Group Name: %v", groupName),
 					Code:    http.StatusBadRequest,
 				}
 			}
-			// TODO: we just need the group id here.
 			if err := q.AddSatelliteToGroup(ctx, database.AddSatelliteToGroupParams{
 				SatelliteID: satelliteID,
-				GroupID:     group.ID,
+				GroupID:     groupID,
 			}); err != nil {
 				return nil, err
 			}

--- a/ground-control/sql/queries/groups.sql
+++ b/ground-control/sql/queries/groups.sql
@@ -29,3 +29,7 @@ WHERE group_name = $1;
 
 -- name: CheckGroupExists :one
 SELECT EXISTS(SELECT 1 FROM groups WHERE group_name = $1);
+
+-- name: GetGroupIDByName :one
+SELECT id FROM groups
+WHERE group_name = $1;


### PR DESCRIPTION
## Summary
This PR optimizes database queries in the ground-control component by using a more efficient lookup when only the group ID is needed.

## Closed:
#220 

## Changes Made
- control/internal/database/groups.sql.go
- Added the missing GetGroupIDByName function 
- ground-control/internal/server/helpers.go
- Updated addSatelliteToGroups function to use GetGroupIDByName instead of GetGroupByName
- Removed the TODO comment since we now only fetch the group ID

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized addSatelliteToGroups to fetch only the group ID, reducing database work and avoiding unnecessary data retrieval. Added the missing GetGroupIDByName query and method.

- **Refactors**
  - Added GetGroupIDByName SQL and generated Go method.
  - Updated addSatelliteToGroups to use group ID instead of fetching full group.
  - Removed outdated TODO comment.

<sup>Written for commit f58569bbb46ccac2296696d1b2bb1fde18e3bef8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized group lookup operations for improved efficiency when managing satellite assignments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->