### PR TITLE
fix: protect /satellites/sync with satellite token auth

### DIFF
--- a/ground-control/internal/server/routes.go
+++ b/ground-control/internal/server/routes.go
@@ -14,11 +14,13 @@ func (s *Server) RegisterRoutes() http.Handler {
 	r.HandleFunc("/health", s.healthHandler).Methods("GET")
 	r.HandleFunc("/login", s.loginHandler).Methods("POST")
 	r.HandleFunc("/satellites/ztr/{token}", s.ztrHandler).Methods("GET") // Satellite token auth
-	r.HandleFunc("/satellites/sync", s.syncHandler).Methods("POST")      // Satellite heartbeat (uses ZTR token)
 
 	// Protected routes (require authentication)
 	protected := r.PathPrefix("").Subrouter()
 	protected.Use(s.AuthMiddleware)
+
+	// Satellite sync (authenticated with satellite token only)
+	protected.HandleFunc("/satellites/sync", s.RequireRole("satellite", s.syncHandler)).Methods("POST")
 
 	// Auth
 	protected.HandleFunc("/logout", s.logoutHandler).Methods("POST")


### PR DESCRIPTION
**Summary:**
Moved `/satellites/sync` from public to protected routes. Added satellite token support in `AuthMiddleware` and ensured satellite status reports include `Authorization: Bearer <token>` header.

Fixes #218 

**Testing:**

* Ran local verification script to confirm route + auth wiring changes.
<img width="732" height="1594" alt="image" src="https://github.com/user-attachments/assets/3ae21e9d-7f61-4955-a8ba-3bd542596dbe" />
<img width="930" height="1468" alt="image" src="https://github.com/user-attachments/assets/e716a3e8-03aa-4617-bef7-db92740ee63c" />
<img width="1014" height="455" alt="image" src="https://github.com/user-attachments/assets/c803db61-90e9-4a8a-8585-2f087b1b2517" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * /satellites/sync now requires authenticated satellite role.
  * Status report requests include authentication and return clearer "unauthorized" errors when rejected.

* **Improvements**
  * Authentication middleware now accepts satellite tokens as a fallback when user session tokens are not present, improving satellite access handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->