### PR TITLE
fix: remove invalid todo comment

### DIFF
--- a/ground-control/internal/server/helpers.go
+++ b/ground-control/internal/server/helpers.go
@@ -89,7 +89,6 @@ func addSatelliteToGroups(ctx context.Context, q *database.Queries, groups *[]st
 					Code:    http.StatusBadRequest,
 				}
 			}
-			// TODO: we just need the group id here.
 			if err := q.AddSatelliteToGroup(ctx, database.AddSatelliteToGroupParams{
 				SatelliteID: satelliteID,
 				GroupID:     group.ID,


### PR DESCRIPTION
### Closed
#221 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed an incorrect TODO comment in ground-control/internal/server/helpers.go to keep the code clear. No functional changes.

<sup>Written for commit 617617c346941b4425f6f27f209ed631bc47d7ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

