### PR TITLE
feat: make config directory configurable via flags and env

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -1,5 +1,10 @@
 package config
 
+import (
+  "os"
+  "path/filepath"
+)
+
 // Job names that the user is expected to provide in the config.json file
 const ReplicateStateJobName string = "replicate_state"
 const ZTRConfigJobName string = "register_satellite"
@@ -9,8 +14,18 @@ const ZTRConfigJobName string = "register_satellite"
 // in the config.json file.
 
 // Default config.json path for the satellite, used if the user does not provide any config path
-const DefaultConfigPath string = "config.json"
-const DefaultPrevConfigPath string = "prev_config.json"
+const DefaultConfigFilename string = "config.json"
+const DefaultPrevConfigFilename string = "prev_config.json"
+
+var DefaultConfigDir string = defaultConfigDir()
+
+func defaultConfigDir() string {
+  home, err := os.UserHomeDir()
+  if err != nil || home == "" {
+    return filepath.Join(".", ".config", "satellite")
+  }
+  return filepath.Join(home, ".config", "satellite")
+}
 
 // Below are the default values of the job schedules that would be used if the user does not provide any schedule or
 // if there is any error while parsing the cron expression


### PR DESCRIPTION
## Description

This PR allows users to configure where Satellite stores its config and state files using a `--config-dir` flag or the `CONFIG_DIR` environment variable.
If neither is provided, Satellite defaults to `~/.config/satellite` and ensures the directory exists before use.

**Related Issue:** #226 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Satellite config directory configurable via a new --config-dir flag and CONFIG_DIR env. Defaults to ~/.config/satellite, ensures the directory exists, and uses it for config reads and file watching.

- **New Features**
  - --config-dir flag and CONFIG_DIR env set where config and state files are stored.
  - Defaults to ~/.config/satellite; creates the directory if missing.
  - Passes the resolved paths to InitConfigManager and the file watcher.

- **Migration**
  - If you used config.json in the working directory, move it to ~/.config/satellite/ or set --config-dir/CONFIG_DIR to your preferred path.

<sup>Written for commit 4c16cef8ceebd6a4f0c44a4c75273b6349e8927d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--config-dir` command-line flag to specify custom configuration directory location.
  * Added `CONFIG_DIR` environment variable support for configuration directory specification.
  * Configuration paths are now dynamically resolved, allowing flexible placement of configuration files across different system locations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->