### PR TITLE
Fixing the routing for deleting the satellite from group

### DIFF
--- a/ground-control/internal/server/routes.go
+++ b/ground-control/internal/server/routes.go
@@ -40,9 +40,8 @@ func (s *Server) RegisterRoutes() http.Handler {
 	api.HandleFunc("/groups/sync", s.groupsSyncHandler).Methods("POST")
 	api.HandleFunc("/groups/{group}", s.getGroupHandler).Methods("GET")
 	api.HandleFunc("/groups/{group}/satellites", s.groupSatelliteHandler).Methods("GET")
-	api.HandleFunc("/groups/{group}/satellite/{satellite}", s.removeSatelliteFromGroup).Methods("DELETE")
 	api.HandleFunc("/groups/satellite", s.addSatelliteToGroup).Methods("POST")
-	api.HandleFunc("/groups/satellite", s.removeSatelliteFromGroup).Methods("DELETE")
+	api.HandleFunc("/groups/{group}/satellite/{satellite}", s.removeSatelliteFromGroup).Methods("DELETE")
 	api.HandleFunc("/groups/{group}", s.RequireRole(roleSystemAdmin, s.deleteGroupHandler)).Methods("DELETE")
 
 	// Configs


### PR DESCRIPTION
## Fixes

Issue: #276 

## Description
- The function `removeSatelliteFromGroup` expects the params from the route 
```
func (s *Server) removeSatelliteFromGroup(w http.ResponseWriter, r *http.Request) {
	vars := mux.Vars(r)
	groupName := vars["group"]
	satelliteName := vars["satellite"]
```
- but the route in  `ground-control/internal/server/routes.go` is defined like this -
```
	protected.HandleFunc("/groups/satellite/", s.removeSatelliteFromGroup).Methods("DELETE")
```

- Changed the route to match the function `removeSatelliteFromGroup`. 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the DELETE route for removing a satellite from a group. The API now uses path params for group and satellite, matching removeSatelliteFromGroup and enabling proper deletions.

- **Bug Fixes**
  - Added DELETE route to /groups/{group}/satellite/{satellite}

<sup>Written for commit 1bf5d4f683d1c5d9814344797602e84f07012f1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Modified the endpoint for removing satellites from groups. The route now requires explicit group and satellite identifiers in the URL path, replacing the previous generic structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->