### PR TITLE
QuickFix Project Name

### DIFF
--- a/taskfiles/e2e.yml
+++ b/taskfiles/e2e.yml
@@ -10,7 +10,7 @@ vars:
   GC_ADMIN_USER: admin
   GC_ADMIN_PASSWORD: AdminPass123
   GC_URL: http://localhost:9080
-  PROJECT_NAME: edge
+  PROJECT_NAME: harbor-satellite
   REGISTRY_NAME: test-registry
   DEST_NAMESPACE: test-group
 


### PR DESCRIPTION
## Summary 
There is problem with the harbor-satellite - project setting in `publish-image.yml`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced Dagger with Task-based builds and CI, added end-to-end test stacks (Harbor and SPIFFE), and enabled multi-arch image build/publish/sign via Docker Buildx and Cosign. Also fixed the wrong registry project name and improved the state fetcher to handle HTTP/HTTPS and insecure registries correctly.

- **New Features**
  - Added Taskfile with build, lint, vuln, e2e, publish, release, and publish-and-sign tasks.
  - New e2e environments: Harbor stack and SPIFFE join-token flow with external SPIRE.
  - GitHub Actions now use Task, golangci-lint v2, govulncheck, GoReleaser, Syft, and Buildx.
  - Composite action now builds, pushes, and signs both images via Task and Cosign.

- **Bug Fixes**
  - Corrected registry project name to harbor-satellite across publish and e2e tasks.
  - URLStateFetcher now respects explicit http/https schemes, supports insecure mode, and avoids transport mutation.
  - Ignore Task artifacts (bin/, .task/) in git.

<sup>Written for commit 6e25b19dea02789b02b7083c69d6f0b989e599bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project configuration variable for end-to-end testing and Harbor integration operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->