### PR TITLE
Add SPIRE Entry Deletion to Cleanup Scripts

### DIFF
--- a/deploy/quickstart/spiffe/join-token/external/gc/cleanup.sh
+++ b/deploy/quickstart/spiffe/join-token/external/gc/cleanup.sh
@@ -8,9 +8,15 @@ cd "$SCRIPT_DIR"
 echo "=== Cleaning up Ground Control (Join Token) ==="
 
 echo "> Deleting Ground Control SPIRE entry..."
-docker exec spire-server /opt/spire/bin/spire-server entry delete \
+ENTRY_ID=$(docker exec spire-server /opt/spire/bin/spire-server entry show \
     -spiffeID spiffe://harbor-satellite.local/ground-control \
-    -socketPath /tmp/spire-server/private/api.sock 2>/dev/null || true
+    -socketPath /tmp/spire-server/private/api.sock 2>/dev/null \
+    | grep "Entry ID" | awk '{print $4}') || true
+if [ -n "$ENTRY_ID" ]; then
+    docker exec spire-server /opt/spire/bin/spire-server entry delete \
+        -entryID "$ENTRY_ID" \
+        -socketPath /tmp/spire-server/private/api.sock 2>/dev/null || true
+fi
 
 echo "> docker compose down -v --remove-orphans"
 docker compose down -v --remove-orphans

--- a/deploy/quickstart/spiffe/join-token/external/sat/cleanup.sh
+++ b/deploy/quickstart/spiffe/join-token/external/sat/cleanup.sh
@@ -8,9 +8,15 @@ cd "$SCRIPT_DIR"
 echo "=== Cleaning up Satellite (Join Token) ==="
 
 echo "> Deleting Satellite SPIRE entry..."
-docker exec spire-server /opt/spire/bin/spire-server entry delete \
+ENTRY_ID=$(docker exec spire-server /opt/spire/bin/spire-server entry show \
     -spiffeID spiffe://harbor-satellite.local/satellite/region/us-west/edge-01 \
-    -socketPath /tmp/spire-server/private/api.sock 2>/dev/null || true
+    -socketPath /tmp/spire-server/private/api.sock 2>/dev/null \
+    | grep "Entry ID" | awk '{print $4}') || true
+if [ -n "$ENTRY_ID" ]; then
+    docker exec spire-server /opt/spire/bin/spire-server entry delete \
+        -entryID "$ENTRY_ID" \
+        -socketPath /tmp/spire-server/private/api.sock 2>/dev/null || true
+fi
 
 echo "> docker compose down -v --remove-orphans"
 docker compose down -v --remove-orphans

--- a/deploy/quickstart/spiffe/sshpop/external/gc/cleanup.sh
+++ b/deploy/quickstart/spiffe/sshpop/external/gc/cleanup.sh
@@ -8,9 +8,15 @@ cd "$SCRIPT_DIR"
 echo "=== Cleaning up Ground Control (SSH PoP) ==="
 
 echo "> Deleting Ground Control SPIRE entry..."
-docker exec spire-server /opt/spire/bin/spire-server entry delete \
+ENTRY_ID=$(docker exec spire-server /opt/spire/bin/spire-server entry show \
     -spiffeID spiffe://harbor-satellite.local/ground-control \
-    -socketPath /tmp/spire-server/private/api.sock 2>/dev/null || true
+    -socketPath /tmp/spire-server/private/api.sock 2>/dev/null \
+    | grep "Entry ID" | awk '{print $4}') || true
+if [ -n "$ENTRY_ID" ]; then
+    docker exec spire-server /opt/spire/bin/spire-server entry delete \
+        -entryID "$ENTRY_ID" \
+        -socketPath /tmp/spire-server/private/api.sock 2>/dev/null || true
+fi
 
 echo "> docker compose down -v --remove-orphans"
 docker compose down -v --remove-orphans

--- a/deploy/quickstart/spiffe/sshpop/external/sat/cleanup.sh
+++ b/deploy/quickstart/spiffe/sshpop/external/sat/cleanup.sh
@@ -8,9 +8,15 @@ cd "$SCRIPT_DIR"
 echo "=== Cleaning up Satellite (SSH PoP) ==="
 
 echo "> Deleting Satellite SPIRE entry..."
-docker exec spire-server /opt/spire/bin/spire-server entry delete \
+ENTRY_ID=$(docker exec spire-server /opt/spire/bin/spire-server entry show \
     -spiffeID spiffe://harbor-satellite.local/satellite/region/default/edge-01 \
-    -socketPath /tmp/spire-server/private/api.sock 2>/dev/null || true
+    -socketPath /tmp/spire-server/private/api.sock 2>/dev/null \
+    | grep "Entry ID" | awk '{print $4}') || true
+if [ -n "$ENTRY_ID" ]; then
+    docker exec spire-server /opt/spire/bin/spire-server entry delete \
+        -entryID "$ENTRY_ID" \
+        -socketPath /tmp/spire-server/private/api.sock 2>/dev/null || true
+fi
 
 echo "> docker compose down -v --remove-orphans"
 docker compose down -v --remove-orphans

--- a/deploy/quickstart/spiffe/x509pop/external/gc/cleanup.sh
+++ b/deploy/quickstart/spiffe/x509pop/external/gc/cleanup.sh
@@ -8,9 +8,15 @@ cd "$SCRIPT_DIR"
 echo "=== Cleaning up Ground Control (X.509 PoP) ==="
 
 echo "> Deleting Ground Control SPIRE entry..."
-docker exec spire-server /opt/spire/bin/spire-server entry delete \
+ENTRY_ID=$(docker exec spire-server /opt/spire/bin/spire-server entry show \
     -spiffeID spiffe://harbor-satellite.local/ground-control \
-    -socketPath /tmp/spire-server/private/api.sock 2>/dev/null || true
+    -socketPath /tmp/spire-server/private/api.sock 2>/dev/null \
+    | grep "Entry ID" | awk '{print $4}') || true
+if [ -n "$ENTRY_ID" ]; then
+    docker exec spire-server /opt/spire/bin/spire-server entry delete \
+        -entryID "$ENTRY_ID" \
+        -socketPath /tmp/spire-server/private/api.sock 2>/dev/null || true
+fi
 
 echo "> docker compose down -v --remove-orphans"
 docker compose down -v --remove-orphans

--- a/deploy/quickstart/spiffe/x509pop/external/sat/cleanup.sh
+++ b/deploy/quickstart/spiffe/x509pop/external/sat/cleanup.sh
@@ -8,9 +8,15 @@ cd "$SCRIPT_DIR"
 echo "=== Cleaning up Satellite (X.509 PoP) ==="
 
 echo "> Deleting Satellite SPIRE entry..."
-docker exec spire-server /opt/spire/bin/spire-server entry delete \
+ENTRY_ID=$(docker exec spire-server /opt/spire/bin/spire-server entry show \
     -spiffeID spiffe://harbor-satellite.local/satellite/region/default/edge-01 \
-    -socketPath /tmp/spire-server/private/api.sock 2>/dev/null || true
+    -socketPath /tmp/spire-server/private/api.sock 2>/dev/null \
+    | grep "Entry ID" | awk '{print $4}') || true
+if [ -n "$ENTRY_ID" ]; then
+    docker exec spire-server /opt/spire/bin/spire-server entry delete \
+        -entryID "$ENTRY_ID" \
+        -socketPath /tmp/spire-server/private/api.sock 2>/dev/null || true
+fi
 
 echo "> docker compose down -v --remove-orphans"
 docker compose down -v --remove-orphans


### PR DESCRIPTION
- Fixes: #289 

## Description
Cleanup scripts now delete SPIRE workload entries before tearing down containers. Previously, entries accumulated in the persistent spire-server across setup/cleanup cycles.

- GC scripts delete the ground-control SPIRE entry
- SAT scripts delete the satellite SPIRE entry (with correct SPIFFE ID per attestation method)

## Additional context
none
<!-- Add any other context about the PR here. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleanup scripts now delete SPIRE workload entries before tearing down containers to prevent leftovers on the persistent spire-server. This stops entries from piling up across quickstart setup/cleanup cycles.

- **Bug Fixes**
  - Delete Ground Control and Satellite entries via spire-server entry delete.
  - Applied to join-token, sshpop, and x509pop external cleanup scripts before docker compose down.

<sup>Written for commit 526c87341956125496adad76fd45ef04f9147f9f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced quickstart cleanup across SPIFFE deployment flows to proactively remove SPIRE entries (ground control and satellite) before teardown, remove generated certs and networks, and delete associated Harbor robot accounts when present.
  * Improved logging and non-fatal error handling during cleanup while preserving the existing environment shutdown sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->