### PR TITLE
ci: install syft in release pipeline for SBOM generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,6 +83,10 @@ jobs:
           install-only: true
           version: v2.9.0
 
+      - name: Install Syft
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
+        uses: anchore/sbom-action/download-syft@v0.22.2
+
       - name: Create Release
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
         env:


### PR DESCRIPTION
- Fixes: #

## Description
quickfix for the release pipeline.


## Additional context

<!-- Add any other context about the PR here. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install Syft in the release GitHub Actions workflow so SBOM generation runs on tagged releases. Adds an install step using anchore/sbom-action/download-syft@v0.22.2 for push tag events to fix the release pipeline.

<sup>Written for commit 2855b2989c01d3f8f6cf1b64da1134a496a6c6b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release pipeline to install an SBOM tool before creating releases on tag pushes.
  * Change occurs between existing tool installation and release creation steps.
  * No impact on application features or behavior; runtime and installation remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->