### PR TITLE
Fix Lint Issue

### DIFF
--- a/internal/registry/zot_storage_test.go
+++ b/internal/registry/zot_storage_test.go
@@ -55,7 +55,11 @@ func startZotRegistry(t *testing.T, storageDir string) string {
 		if err != nil {
 			return false
 		}
-		resp.Body.Close()
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				t.Logf("error closing response body: %v", err)
+			}
+		}()
 		return resp.StatusCode == http.StatusOK
 	}, 5*time.Second, 50*time.Millisecond, "/v2/ not ready")
 


### PR DESCRIPTION
- Fixes: #

## Description
- Fix Lint issue

## Additional context

<!-- Add any other context about the PR here. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix lint warning by deferring resp.Body.Close and logging any close errors in startZotRegistry. Improves resource cleanup and test reliability.

<sup>Written for commit 99a33a9f50b8683b85b46f7c052bdffdb2571a3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

