### PR TITLE
fix: GC endpoint: `satellites/{satellite}/images` returns 500, resolves #366

### DIFF
--- a/ground-control/internal/database/satellite_status.sql.go
+++ b/ground-control/internal/database/satellite_status.sql.go
@@ -90,10 +90,12 @@ func (q *Queries) GetActiveSatellites(ctx context.Context) ([]GetActiveSatellite
 const getLatestArtifacts = `-- name: GetLatestArtifacts :many
 SELECT a.id, a.reference, a.size_bytes, a.created_at
 FROM artifacts a
-WHERE a.id = ANY(
-    (SELECT artifact_ids FROM satellite_status
-     WHERE satellite_id = $1
-     ORDER BY created_at DESC LIMIT 1)
+WHERE a.id IN (
+    SELECT unnest(artifact_ids) FROM (
+        SELECT artifact_ids FROM satellite_status
+        WHERE satellite_id = $1
+        ORDER BY created_at DESC LIMIT 1
+    ) latest
 )
 ORDER BY a.reference
 `

--- a/ground-control/sql/queries/satellite_status.sql
+++ b/ground-control/sql/queries/satellite_status.sql
@@ -61,9 +61,11 @@ LIMIT $2;
 -- name: GetLatestArtifacts :many
 SELECT a.id, a.reference, a.size_bytes, a.created_at
 FROM artifacts a
-WHERE a.id = ANY(
-    (SELECT artifact_ids FROM satellite_status
-     WHERE satellite_id = $1
-     ORDER BY created_at DESC LIMIT 1)
+WHERE a.id IN (
+    SELECT unnest(artifact_ids) FROM (
+        SELECT artifact_ids FROM satellite_status
+        WHERE satellite_id = $1
+        ORDER BY created_at DESC LIMIT 1
+    ) latest
 )
 ORDER BY a.reference;


### PR DESCRIPTION
- Fixes: #366 

## Description

Changes sql query from:
```sql
SELECT a.id, a.reference, a.size_bytes, a.created_at
FROM artifacts a
WHERE a.id = ANY(
    (SELECT artifact_ids FROM satellite_status
     WHERE satellite_id = $1
     ORDER BY created_at DESC LIMIT 1)
)
ORDER BY a.reference;

```
to 
``sql
SELECT a.id, a.reference, a.size_bytes, a.created_at
FROM artifacts a
WHERE a.id IN (
    SELECT unnest(artifact_ids) FROM (
        SELECT artifact_ids FROM satellite_status
        WHERE satellite_id = $1
        ORDER BY created_at DESC LIMIT 1
    ) latest
)
ORDER BY a.reference;

```

## Additional context

<!-- Add any other context about the PR here. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the database query for retrieving latest satellite artifacts to improve query reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->