### PR TITLE
Feat: Add Version Compatibility Check Between Satellite and GC

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,7 +11,8 @@ builds:
     - CGO_ENABLED=0
   ldflags:
     - -w -s -X github.com/container-registry/harbor-satellite/internal/version.GitCommit={{.FullCommit}}
-    - -X github.com/container-registry/harbor-satellite/internal/version.Version={{.Tag}}
+    - -X github.com/container-registry/harbor-satellite/internal/version.Version={{.Version}}
+    - -X github.com/container-registry/harbor-satellite/pkg/version.Version={{.Version}}
   goos:
     - linux
     - darwin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Build stage
 FROM golang:1.24-alpine AS builder
 
+# Arguments
+ARG VERSION=dev
+
 WORKDIR /app
 
 # Install git for go mod download
@@ -14,7 +17,10 @@ RUN go mod download
 COPY . .
 
 # Build the binary
-RUN CGO_ENABLED=0 GOOS=linux go build -o /satellite ./cmd/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags "-X github.com/container-registry/harbor-satellite/pkg/version.Version=${VERSION:-dev} \
+    -X github.com/container-registry/harbor-satellite/internal/version.Version=${VERSION:-dev}" \
+    -o /satellite ./cmd/main.go
 
 # Runtime stage
 FROM alpine:3.20

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -336,7 +336,7 @@ func run(opts SatelliteOptions, pathConfig *config.PathConfig, shutdownTimeout s
 	})
 
 	s := satellite.NewSatellite(cm, criResults, pathConfig.StateFile)
-	err = s.Run(ctx)
+	err = s.Run(ctx, wg)
 	if err != nil {
 		return fmt.Errorf("unable to start satellite: %w", err)
 	}

--- a/ground-control/.goreleaser.yaml
+++ b/ground-control/.goreleaser.yaml
@@ -21,6 +21,7 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       - -w -s -X github.com/container-registry/harbor-satellite/internal/version.GitCommit={{.FullCommit}}
+      - -X github.com/container-registry/harbor-satellite/ground-control/pkg/version.Version={{.Version}}
     goos:
       - linux
       - darwin

--- a/ground-control/Dockerfile
+++ b/ground-control/Dockerfile
@@ -1,6 +1,9 @@
 # Build stage
 FROM golang:1.24-alpine AS builder
 
+# Arguments
+ARG VERSION=dev
+
 WORKDIR /app
 
 # Install git for go mod download (if using private repos)
@@ -14,7 +17,9 @@ RUN go mod download
 COPY . .
 
 # Build the binary
-RUN CGO_ENABLED=0 GOOS=linux go build -o /ground-control ./main.go
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags "-X github.com/container-registry/harbor-satellite/ground-control/pkg/version.Version=${VERSION:-dev}" \
+    -o /ground-control ./main.go
 
 # Runtime stage
 FROM alpine:3.20

--- a/ground-control/go.mod
+++ b/ground-control/go.mod
@@ -22,6 +22,7 @@ require (
 )
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.16.3 // indirect

--- a/ground-control/go.sum
+++ b/ground-control/go.sum
@@ -3,6 +3,9 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/ground-control/internal/server/cached_images_test.go
+++ b/ground-control/internal/server/cached_images_test.go
@@ -85,6 +85,7 @@ func TestSyncHandler_WithCachedImages(t *testing.T) {
 
 	reqBody := SatelliteStatusParams{
 		Name:               "edge-01",
+		Version:            "0.1.0",
 		ImageCount:         2,
 		RequestCreatedTime: now,
 		CachedImages: []CachedImage{
@@ -129,6 +130,7 @@ func TestSyncHandler_NoCachedImages(t *testing.T) {
 
 	reqBody := SatelliteStatusParams{
 		Name:               "edge-01",
+		Version:            "0.1.0",
 		RequestCreatedTime: now,
 	}
 	body, _ := json.Marshal(reqBody)
@@ -151,6 +153,7 @@ func TestSyncHandler_UnknownSatellite(t *testing.T) {
 
 	reqBody := SatelliteStatusParams{
 		Name:               "unknown",
+		Version:            "0.1.0",
 		RequestCreatedTime: time.Now().UTC(),
 	}
 	body, _ := json.Marshal(reqBody)
@@ -272,6 +275,7 @@ func TestSyncHandler_InvalidHeartbeatInterval(t *testing.T) {
 
 	reqBody := SatelliteStatusParams{
 		Name:                "edge-01",
+		Version:             "0.1.0",
 		StateReportInterval: "bad-format",
 		RequestCreatedTime:  now,
 	}
@@ -306,6 +310,7 @@ func TestSyncHandler_BatchInsertArtifactsFails(t *testing.T) {
 
 	reqBody := SatelliteStatusParams{
 		Name:               "edge-01",
+		Version:            "0.1.0",
 		RequestCreatedTime: now,
 		CachedImages: []CachedImage{
 			{Reference: "localhost:8585/nginx:latest@sha256:abc", SizeBytes: 50000},

--- a/ground-control/internal/server/handlers.go
+++ b/ground-control/internal/server/handlers.go
@@ -3,6 +3,7 @@ package server
 import (
 	"log"
 	"net/http"
+	"github.com/container-registry/harbor-satellite/ground-control/pkg/version"
 )
 
 const (
@@ -17,9 +18,15 @@ func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
 	err := s.db.Ping()
 	if err != nil {
 		log.Printf("error pinging db: %v", err)
-		WriteJSONResponse(w, http.StatusServiceUnavailable, map[string]string{"status": "unhealthy"})
+		WriteJSONResponse(w, http.StatusServiceUnavailable, map[string]string{
+			"status":  "unhealthy",
+			"version": version.Version,
+		})
 		return
 	}
 
-	WriteJSONResponse(w, http.StatusOK, map[string]string{"status": "healthy"})
+	WriteJSONResponse(w, http.StatusOK, map[string]string{
+		"status":  "healthy",
+		"version": version.Version,
+	})
 }

--- a/ground-control/internal/server/helpers.go
+++ b/ground-control/internal/server/helpers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/container-registry/harbor-satellite/ground-control/internal/utils"
 	"github.com/container-registry/harbor-satellite/ground-control/pkg/crypto"
 	"github.com/container-registry/harbor-satellite/ground-control/reg/harbor"
+	"github.com/Masterminds/semver/v3"
 )
 
 func isConfigInUse(ctx context.Context, q *database.Queries, config database.Config) (bool, error) {
@@ -288,6 +289,47 @@ func toNullInt64(n int64) sql.NullInt64 {
 
 func toNullInt32(n int32) sql.NullInt32 {
 	return sql.NullInt32{Int32: n, Valid: true}
+}
+
+func (s *Server) validateSatelliteVersion(satVersion string) error {
+	// Treat "dev" or empty as always valid for development ease
+	if satVersion == "" || satVersion == "dev" || s.gcVersion == "dev" {
+		return nil
+	}
+
+	sv, err := semver.NewVersion(satVersion)
+	if err != nil {
+		return fmt.Errorf("invalid satellite version format %q: %w", satVersion, err)
+	}
+
+	gv, err := semver.NewVersion(s.gcVersion)
+	if err != nil {
+		// If for some reason the build process fails to inject a proper semantic version into the binary
+		// and on returning that error every single satellite will be blocked from connecting.
+		// If GC version is somehow invalid (not "dev" and not semver), skip checks
+		return nil
+	}
+
+	if sv.Major() != gv.Major() {
+		return fmt.Errorf("incompatible satellite version %s: ground-control %s requires same major version", satVersion, s.gcVersion)
+	}
+
+	var minorSkew uint64
+	if sv.Minor() >= gv.Minor() {
+		minorSkew = sv.Minor() - gv.Minor()
+	} else {
+		minorSkew = gv.Minor() - sv.Minor()
+	}
+
+	if s.maxMinorSkew < 0 {
+		return fmt.Errorf("invalid server configuration: MAX_MINOR_SKEW cannot be negative (%d)", s.maxMinorSkew)
+	}
+
+	if minorSkew > uint64(s.maxMinorSkew) {
+		return fmt.Errorf("incompatible satellite version %s: ground-control %s allows same major and minor skew <= %d", satVersion, s.gcVersion, s.maxMinorSkew)
+	}
+
+	return nil
 }
 
 // normalizeHeartbeatInterval validates and normalizes the heartbeat interval to a canonical format.

--- a/ground-control/internal/server/satellite_handlers.go
+++ b/ground-control/internal/server/satellite_handlers.go
@@ -49,6 +49,7 @@ type SatelliteStatusParams struct {
 	RequestCreatedTime  time.Time     `json:"request_created_time"`
 	LastSyncDurationMs  int64         `json:"last_sync_duration_ms"`
 	ImageCount          int           `json:"image_count"`
+	Version             string        `json:"version"`
 	CachedImages        []CachedImage `json:"cached_images,omitempty"`
 }
 
@@ -270,6 +271,25 @@ func (s *Server) ztrHandler(w http.ResponseWriter, r *http.Request) {
 	token := vars["token"]
 
 	q := s.dbQueries
+	satVersion := r.URL.Query().Get("version")
+
+	if satVersion == "" {
+		log.Printf("ZTR: Missing version in registration request for token %s", maskToken(token))
+		HandleAppError(w, &AppError{
+			Message: "Error: Satellite version required for registration",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	if err := s.validateSatelliteVersion(satVersion); err != nil {
+		log.Printf("ZTR: %v", err)
+		HandleAppError(w, &AppError{
+			Message: err.Error(),
+			Code:    http.StatusForbidden,
+		})
+		return
+	}
 
 	// Get full token info including expiry
 	tokenInfo, err := q.GetTokenByValue(r.Context(), token)
@@ -416,6 +436,27 @@ func (s *Server) spiffeZtrHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Printf("SPIFFE ZTR: Processing registration for satellite %s", satelliteName)
+
+	satVersion := r.URL.Query().Get("version")
+	if satVersion == "" {
+		log.Printf("SPIFFE ZTR: Missing version in registration request for satellite %s", satelliteName)
+		HandleAppError(w, &AppError{
+			Message: "Error: Satellite version required for registration",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	if err := s.validateSatelliteVersion(satVersion); err != nil {
+		log.Printf("SPIFFE ZTR: %v", err)
+		HandleAppError(w, &AppError{
+			Message: err.Error(),
+			Code:    http.StatusForbidden,
+		})
+		return
+	}
+
+	log.Printf("SPIFFE ZTR: Processing registration for satellite version %s", satVersion)
 
 	q := s.dbQueries
 
@@ -564,6 +605,24 @@ func (s *Server) syncHandler(w http.ResponseWriter, r *http.Request) {
 	if err := DecodeRequestBody(r, &req); err != nil {
 		log.Println(err)
 		HandleAppError(w, err)
+		return
+	}
+
+	if req.Version == "" {
+		log.Printf("Sync: Missing version in heartbeat for satellite %s", req.Name)
+		HandleAppError(w, &AppError{
+			Message: "Error: Satellite version required for heartbeat",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	if err := s.validateSatelliteVersion(req.Version); err != nil {
+		log.Printf("Sync: %v", err)
+		HandleAppError(w, &AppError{
+			Message: err.Error(),
+			Code:    http.StatusForbidden,
+		})
 		return
 	}
 

--- a/ground-control/internal/server/server.go
+++ b/ground-control/internal/server/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/container-registry/harbor-satellite/ground-control/internal/database"
 	"github.com/container-registry/harbor-satellite/ground-control/internal/middleware"
 	"github.com/container-registry/harbor-satellite/ground-control/internal/spiffe"
+	"github.com/container-registry/harbor-satellite/ground-control/pkg/version"
 )
 
 type Server struct {
@@ -42,6 +43,10 @@ type Server struct {
 
 	// Satellite status
 	staleThreshold time.Duration
+
+	// Version compatibility
+	gcVersion    string
+	maxMinorSkew int
 }
 
 // TLSConfig holds TLS settings for the server.
@@ -168,6 +173,10 @@ func NewServer() *ServerResult {
 
 		// Satellite status
 		staleThreshold: parseDurationEnv("STALE_THRESHOLD", time.Hour),
+
+		// Version compatibility
+		gcVersion:    version.Version,
+		maxMinorSkew: parseIntEnv("MAX_MINOR_SKEW", 2),
 	}
 
 	// Bootstrap system admin user if not exists

--- a/ground-control/internal/server/spire_handlers.go
+++ b/ground-control/internal/server/spire_handlers.go
@@ -19,6 +19,7 @@ type RegisterSatelliteRequest struct {
 	AttestationMethod string   `json:"attestation_method"` // join_token, x509pop, sshpop
 	TTLSeconds        int      `json:"ttl_seconds,omitempty"`
 	ParentAgentID     string   `json:"parent_agent_id,omitempty"`
+	Version           string   `json:"version"`
 }
 
 // RegisterSatelliteWithSPIFFEResponse contains satellite registration details.
@@ -87,6 +88,23 @@ func (s *Server) registerSatelliteWithSPIFFEHandler(w http.ResponseWriter, r *ht
 	if err := DecodeRequestBody(r, &req); err != nil {
 		HandleAppError(w, &AppError{
 			Message: "Invalid request body",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	if req.Version == "" {
+		HandleAppError(w, &AppError{
+			Message: "version is required",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	if err := s.validateSatelliteVersion(req.Version); err != nil {
+		log.Printf("Register: %v", err)
+		HandleAppError(w, &AppError{
+			Message: err.Error(),
 			Code:    http.StatusBadRequest,
 		})
 		return

--- a/ground-control/internal/server/spire_handlers_test.go
+++ b/ground-control/internal/server/spire_handlers_test.go
@@ -24,6 +24,7 @@ func TestRegisterSatelliteRequest_Validation(t *testing.T) {
 				Region:            "us-west",
 				Selectors:         []string{"docker:label:foo"},
 				AttestationMethod: "join_token",
+				Version:           "0.1.0",
 			},
 			expectError: false,
 		},
@@ -33,6 +34,7 @@ func TestRegisterSatelliteRequest_Validation(t *testing.T) {
 				SatelliteName:     "edge-02",
 				Selectors:         []string{"docker:label:bar"},
 				AttestationMethod: "x509pop",
+				Version:           "0.1.0",
 			},
 			expectError: false,
 		},
@@ -43,6 +45,7 @@ func TestRegisterSatelliteRequest_Validation(t *testing.T) {
 				Selectors:         []string{"docker:label:baz"},
 				AttestationMethod: "sshpop",
 				ParentAgentID:     "spiffe://domain/agent/foo",
+				Version:           "0.1.0",
 			},
 			expectError: false,
 		},
@@ -51,6 +54,7 @@ func TestRegisterSatelliteRequest_Validation(t *testing.T) {
 			request: RegisterSatelliteRequest{
 				Selectors:         []string{"docker:label:foo"},
 				AttestationMethod: "join_token",
+				Version:           "0.1.0",
 			},
 			expectError:    true,
 			expectedErrMsg: "satellite_name is required",
@@ -60,6 +64,7 @@ func TestRegisterSatelliteRequest_Validation(t *testing.T) {
 			request: RegisterSatelliteRequest{
 				SatelliteName:     "edge-01",
 				AttestationMethod: "join_token",
+				Version:           "0.1.0",
 			},
 			expectError:    true,
 			expectedErrMsg: "selectors is required",
@@ -70,6 +75,7 @@ func TestRegisterSatelliteRequest_Validation(t *testing.T) {
 				SatelliteName:     "edge-01",
 				Selectors:         []string{"invalid-selector"},
 				AttestationMethod: "join_token",
+				Version:           "0.1.0",
 			},
 			expectError:    true,
 			expectedErrMsg: "must contain ':'",
@@ -80,6 +86,7 @@ func TestRegisterSatelliteRequest_Validation(t *testing.T) {
 				SatelliteName:     "edge-01",
 				Selectors:         []string{"docker:label:foo"},
 				AttestationMethod: "invalid",
+				Version:           "0.1.0",
 			},
 			expectError:    true,
 			expectedErrMsg: "attestation_method must be one of",
@@ -90,6 +97,7 @@ func TestRegisterSatelliteRequest_Validation(t *testing.T) {
 				SatelliteName:     "edge-01",
 				Selectors:         []string{"docker:label:foo"},
 				AttestationMethod: "sshpop",
+				Version:           "0.1.0",
 			},
 			expectError:    true,
 			expectedErrMsg: "parent_agent_id is required for sshpop",
@@ -161,6 +169,7 @@ func TestRegisterSatelliteRequest_DefaultValues(t *testing.T) {
 		SatelliteName:     "edge-01",
 		Selectors:         []string{"docker:label:foo"},
 		AttestationMethod: "join_token",
+		Version:           "0.1.0",
 	}
 
 	body, err := json.Marshal(req)

--- a/ground-control/pkg/version/version.go
+++ b/ground-control/pkg/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+//nolint:gochecknoglobals // populated via -ldflags at build time
+var Version = "dev"

--- a/internal/satellite/health.go
+++ b/internal/satellite/health.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/container-registry/harbor-satellite/internal/logger"
 	"github.com/container-registry/harbor-satellite/internal/server"
 	"github.com/container-registry/harbor-satellite/internal/version"
 )
@@ -20,10 +21,18 @@ func (h *HealthRegistrar) RegisterRoutes(router server.Router) {
 }
 
 func (h *HealthRegistrar) HealthHandler(w http.ResponseWriter, r *http.Request) {
+	log := logger.FromContext(r.Context())
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(HealthResponse{
+	payload := HealthResponse{
 		Status:  "healthy",
 		Version: version.Version,
-	})
+	}
+
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		log.Error().Err(err).Msg("failed to encode health response")
+		// If headers were already sent, this will only log a warning in the server,
+		// but it's better than ignoring the error.
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
 }

--- a/internal/satellite/health.go
+++ b/internal/satellite/health.go
@@ -1,0 +1,29 @@
+package satellite
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/container-registry/harbor-satellite/internal/server"
+	"github.com/container-registry/harbor-satellite/internal/version"
+)
+
+type HealthResponse struct {
+	Status  string `json:"status"`
+	Version string `json:"version"`
+}
+
+type HealthRegistrar struct{}
+
+func (h *HealthRegistrar) RegisterRoutes(router server.Router) {
+	router.HandleFunc("/health", h.HealthHandler)
+}
+
+func (h *HealthRegistrar) HealthHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(HealthResponse{
+		Status:  "healthy",
+		Version: version.Version,
+	})
+}

--- a/internal/satellite/satellite.go
+++ b/internal/satellite/satellite.go
@@ -2,8 +2,6 @@ package satellite
 
 import (
 	"context"
-	"net/http"
-	"time"
 
 	runtime "github.com/container-registry/harbor-satellite/internal/container_runtime"
 	"github.com/container-registry/harbor-satellite/internal/logger"
@@ -11,6 +9,7 @@ import (
 	"github.com/container-registry/harbor-satellite/internal/server"
 	"github.com/container-registry/harbor-satellite/internal/state"
 	"github.com/container-registry/harbor-satellite/pkg/config"
+	"golang.org/x/sync/errgroup"
 )
 
 type Satellite struct {
@@ -30,7 +29,7 @@ func NewSatellite(cm *config.ConfigManager, criResults []runtime.CRIConfigResult
 	}
 }
 
-func (s *Satellite) Run(ctx context.Context) error {
+func (s *Satellite) Run(ctx context.Context, wg *errgroup.Group) error {
 	log := logger.FromContext(ctx)
 	log.Info().Msg("Starting Satellite")
 
@@ -105,21 +104,7 @@ func (s *Satellite) Run(ctx context.Context) error {
 	router := server.NewDefaultRouter("")
 	s.app = server.NewApp(router, ctx, log, &HealthRegistrar{})
 	s.app.SetupRoutes()
-
-	go func() {
-		if err := s.app.Start(); err != nil && err != http.ErrServerClosed {
-			log.Error().Err(err).Msg("Failed to start health server")
-		}
-	}()
-
-	go func() {
-		<-ctx.Done()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := s.app.Shutdown(shutdownCtx); err != nil {
-			log.Error().Err(err).Msg("Error during health server shutdown")
-		}
-	}()
+	s.app.SetupServer(wg)
 
 	return ctx.Err()
 }

--- a/internal/satellite/satellite.go
+++ b/internal/satellite/satellite.go
@@ -2,10 +2,13 @@ package satellite
 
 import (
 	"context"
+	"net/http"
+	"time"
 
 	runtime "github.com/container-registry/harbor-satellite/internal/container_runtime"
 	"github.com/container-registry/harbor-satellite/internal/logger"
 	"github.com/container-registry/harbor-satellite/internal/scheduler"
+	"github.com/container-registry/harbor-satellite/internal/server"
 	"github.com/container-registry/harbor-satellite/internal/state"
 	"github.com/container-registry/harbor-satellite/pkg/config"
 )
@@ -15,6 +18,7 @@ type Satellite struct {
 	criResults    []runtime.CRIConfigResult
 	schedulers    []*scheduler.Scheduler
 	stateFilePath string
+	app           *server.App
 }
 
 func NewSatellite(cm *config.ConfigManager, criResults []runtime.CRIConfigResult, stateFilePath string) *Satellite {
@@ -96,6 +100,26 @@ func (s *Satellite) Run(ctx context.Context) error {
 	}
 	s.schedulers = append(s.schedulers, statusScheduler)
 	statusScheduler.Start(ctx)
+
+	// Start health server
+	router := server.NewDefaultRouter("")
+	s.app = server.NewApp(router, ctx, log, &HealthRegistrar{})
+	s.app.SetupRoutes()
+
+	go func() {
+		if err := s.app.Start(); err != nil && err != http.ErrServerClosed {
+			log.Error().Err(err).Msg("Failed to start health server")
+		}
+	}()
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := s.app.Shutdown(shutdownCtx); err != nil {
+			log.Error().Err(err).Msg("Error during health server shutdown")
+		}
+	}()
 
 	return ctx.Err()
 }

--- a/internal/state/helpers.go
+++ b/internal/state/helpers.go
@@ -1,7 +1,9 @@
 package state
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/container-registry/harbor-satellite/internal/utils"
 	"github.com/container-registry/harbor-satellite/pkg/config"
@@ -20,3 +22,16 @@ func getStateFetcherForInputWithTLS(input, username, password string, useInsecur
 	log.Info().Msg("Input is a valid URL")
 	return NewURLStateFetcherWithTLS(input, username, password, useInsecure, tlsCfg), nil
 }
+
+// parseErrorResponse attempts to decode a JSON error message from the response body.
+// It falls back to the HTTP status string if decoding fails.
+func parseErrorResponse(resp *http.Response) string {
+	var errResp struct {
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err == nil && errResp.Message != "" {
+		return errResp.Message
+	}
+	return resp.Status
+}
+

--- a/internal/state/registration_process.go
+++ b/internal/state/registration_process.go
@@ -6,12 +6,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/container-registry/harbor-satellite/internal/logger"
 	satTLS "github.com/container-registry/harbor-satellite/internal/tls"
+	"github.com/container-registry/harbor-satellite/internal/version"
 	"github.com/container-registry/harbor-satellite/pkg/config"
 	"github.com/rs/zerolog"
 )
@@ -152,7 +154,13 @@ func (z *ZtrProcess) stop() {
 }
 
 func registerSatellite(groundControlURL, path, token string, tlsCfg config.TLSConfig, useUnsecure bool, ctx context.Context) (config.StateConfig, error) {
-	ztrURL := fmt.Sprintf("%s/%s/%s", groundControlURL, path, token)
+	ztrURL := fmt.Sprintf(
+		"%s/%s/%s?version=%s", 
+		strings.TrimRight(groundControlURL, "/"), 
+		path, 
+		url.PathEscape(token), 
+		url.QueryEscape(version.Version),
+	)
 
 	client, err := createHTTPClient(tlsCfg, useUnsecure)
 	if err != nil {
@@ -174,7 +182,7 @@ func registerSatellite(groundControlURL, path, token string, tlsCfg config.TLSCo
 	}()
 
 	if response.StatusCode != http.StatusOK {
-		return config.StateConfig{}, fmt.Errorf("failed to register satellite: %s", response.Status)
+		return config.StateConfig{}, fmt.Errorf("failed to register satellite: %s", parseErrorResponse(response))
 	}
 
 	var authResponse config.StateConfig

--- a/internal/state/report.go
+++ b/internal/state/report.go
@@ -26,6 +26,7 @@ type StatusReportParams struct {
 	RequestCreatedTime  time.Time     `json:"request_created_time"`
 	LastSyncDurationMs  int64         `json:"last_sync_duration_ms"`
 	ImageCount          int           `json:"image_count"`
+	Version             string        `json:"version"`
 	CachedImages        []CachedImage `json:"cached_images,omitempty"`
 }
 

--- a/internal/state/reporting_process.go
+++ b/internal/state/reporting_process.go
@@ -14,6 +14,7 @@ import (
 	"github.com/container-registry/harbor-satellite/internal/logger"
 	"github.com/container-registry/harbor-satellite/internal/spiffe"
 	"github.com/container-registry/harbor-satellite/internal/utils"
+	"github.com/container-registry/harbor-satellite/internal/version"
 	"github.com/container-registry/harbor-satellite/pkg/config"
 )
 
@@ -89,6 +90,7 @@ func (s *StatusReportingProcess) Execute(ctx context.Context) error {
 		Name:                satelliteName,
 		StateReportInterval: heartbeatExpr,
 		RequestCreatedTime:  time.Now().UTC(),
+		Version:             version.Version,
 	}
 
 	// Include pending CRI results until successfully sent
@@ -181,7 +183,7 @@ func (s *StatusReportingProcess) sendStatusReport(ctx context.Context, groundCon
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("status report failed: %s", resp.Status)
+		return fmt.Errorf("status report failed: %s", parseErrorResponse(resp))
 	}
 
 	return nil

--- a/internal/state/spiffe_registration.go
+++ b/internal/state/spiffe_registration.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/container-registry/harbor-satellite/internal/logger"
 	"github.com/container-registry/harbor-satellite/internal/spiffe"
+	"github.com/container-registry/harbor-satellite/internal/version"
 	"github.com/container-registry/harbor-satellite/pkg/config"
 	"github.com/rs/zerolog"
 )
@@ -100,7 +101,7 @@ func (s *SpiffeZtrProcess) Execute(ctx context.Context) error {
 
 func (s *SpiffeZtrProcess) registerWithSPIFFE(ctx context.Context, log *zerolog.Logger) (config.StateConfig, error) {
 	gcURL := s.cm.ResolveGroundControlURL()
-	ztrURL := fmt.Sprintf("%s/%s", gcURL, SPIFFEZeroTouchRegistrationRoute)
+	ztrURL := fmt.Sprintf("%s/%s?version=%s", gcURL, SPIFFEZeroTouchRegistrationRoute, version.Version)
 
 	httpClient, err := s.spiffeClient.CreateHTTPClient()
 	if err != nil {
@@ -124,7 +125,7 @@ func (s *SpiffeZtrProcess) registerWithSPIFFE(ctx context.Context, log *zerolog.
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return config.StateConfig{}, fmt.Errorf("registration failed: %s", resp.Status)
+		return config.StateConfig{}, fmt.Errorf("registration failed: %s", parseErrorResponse(resp))
 	}
 
 	var stateConfig config.StateConfig

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+//nolint:gochecknoglobals // populated via -ldflags at build time
+var Version = "dev"

--- a/taskfiles/build.yml
+++ b/taskfiles/build.yml
@@ -5,6 +5,8 @@ vars:
     sh: go env GOOS
   GOARCH:
     sh: go env GOARCH
+  VERSION:
+    sh: (git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//') || echo "dev"
 
 tasks:
   satellite:
@@ -12,7 +14,7 @@ tasks:
     cmds:
       - echo "Building satellite for {{.GOOS}}/{{.GOARCH}}..."
       - mkdir -p {{.BIN_DIR}}
-      - go build -o {{.BIN_DIR}}/satellite ./cmd/main.go
+      - go build -ldflags "-X github.com/container-registry/harbor-satellite/pkg/version.Version={{.VERSION}} -X github.com/container-registry/harbor-satellite/internal/version.Version={{.VERSION}}" -o {{.BIN_DIR}}/satellite ./cmd/main.go
       - echo "Built bin/satellite"
     sources:
       - "**/*.go"
@@ -28,7 +30,7 @@ tasks:
     cmds:
       - echo "Building ground-control for {{.GOOS}}/{{.GOARCH}}..."
       - mkdir -p {{.BIN_DIR}}
-      - go build -o {{.BIN_DIR}}/ground-control ./main.go
+      - go build -ldflags "-X github.com/container-registry/harbor-satellite/ground-control/pkg/version.Version={{.VERSION}}" -o {{.BIN_DIR}}/ground-control ./main.go
       - echo "Built bin/ground-control"
     sources:
       - "**/*.go"
@@ -49,9 +51,9 @@ tasks:
       - echo "Building satellite and ground-control for {{.GOOS}}/{{.GOARCH}}..."
       - mkdir -p {{.BIN_DIR}}
       - echo "  Compiling satellite..."
-      - go build -o {{.BIN_DIR}}/satellite ./cmd/main.go
+      - go build -ldflags "-X github.com/container-registry/harbor-satellite/pkg/version.Version={{.VERSION}} -X github.com/container-registry/harbor-satellite/internal/version.Version={{.VERSION}}" -o {{.BIN_DIR}}/satellite ./cmd/main.go
       - echo "  Compiling ground-control..."
-      - cd ground-control && go build -o {{.BIN_DIR}}/ground-control ./main.go
+      - cd ground-control && go build -ldflags "-X github.com/container-registry/harbor-satellite/ground-control/pkg/version.Version={{.VERSION}}" -o {{.BIN_DIR}}/ground-control ./main.go
       - echo "Done! Binaries in bin/"
     silent: true
 
@@ -74,14 +76,14 @@ tasks:
             GOARCH: [amd64, arm64, ppc64le, s390x, riscv64]
         cmd: |
           echo "  {{.ITEM.GOOS}}/{{.ITEM.GOARCH}}..."
-          GOOS={{.ITEM.GOOS}} GOARCH={{.ITEM.GOARCH}} go build -o {{.BIN_DIR}}/satellite/satellite-{{.ITEM.GOOS}}-{{.ITEM.GOARCH}} ./cmd/main.go
+          GOOS={{.ITEM.GOOS}} GOARCH={{.ITEM.GOARCH}} go build -ldflags "-X github.com/container-registry/harbor-satellite/pkg/version.Version={{.VERSION}} -X github.com/container-registry/harbor-satellite/internal/version.Version={{.VERSION}}" -o {{.BIN_DIR}}/satellite/satellite-{{.ITEM.GOOS}}-{{.ITEM.GOARCH}} ./cmd/main.go
       - for:
           matrix:
             GOOS: [darwin]
             GOARCH: [amd64, arm64]
         cmd: |
           echo "  {{.ITEM.GOOS}}/{{.ITEM.GOARCH}}..."
-          GOOS={{.ITEM.GOOS}} GOARCH={{.ITEM.GOARCH}} go build -o {{.BIN_DIR}}/satellite/satellite-{{.ITEM.GOOS}}-{{.ITEM.GOARCH}} ./cmd/main.go
+          GOOS={{.ITEM.GOOS}} GOARCH={{.ITEM.GOARCH}} go build -ldflags "-X github.com/container-registry/harbor-satellite/pkg/version.Version={{.VERSION}} -X github.com/container-registry/harbor-satellite/internal/version.Version={{.VERSION}}" -o {{.BIN_DIR}}/satellite/satellite-{{.ITEM.GOOS}}-{{.ITEM.GOARCH}} ./cmd/main.go
     silent: true
 
   all-ground-control:
@@ -96,12 +98,12 @@ tasks:
             GOARCH: [amd64, arm64, ppc64le, s390x, riscv64]
         cmd: |
           echo "  {{.ITEM.GOOS}}/{{.ITEM.GOARCH}}..."
-          GOOS={{.ITEM.GOOS}} GOARCH={{.ITEM.GOARCH}} go build -o {{.BIN_DIR}}/ground-control/ground-control-{{.ITEM.GOOS}}-{{.ITEM.GOARCH}} ./main.go
+          GOOS={{.ITEM.GOOS}} GOARCH={{.ITEM.GOARCH}} go build -ldflags "-X github.com/container-registry/harbor-satellite/ground-control/pkg/version.Version={{.VERSION}}" -o {{.BIN_DIR}}/ground-control/ground-control-{{.ITEM.GOOS}}-{{.ITEM.GOARCH}} ./main.go
       - for:
           matrix:
             GOOS: [darwin]
             GOARCH: [amd64, arm64]
         cmd: |
           echo "  {{.ITEM.GOOS}}/{{.ITEM.GOARCH}}..."
-          GOOS={{.ITEM.GOOS}} GOARCH={{.ITEM.GOARCH}} go build -o {{.BIN_DIR}}/ground-control/ground-control-{{.ITEM.GOOS}}-{{.ITEM.GOARCH}} ./main.go
+          GOOS={{.ITEM.GOOS}} GOARCH={{.ITEM.GOARCH}} go build -ldflags "-X github.com/container-registry/harbor-satellite/ground-control/pkg/version.Version={{.VERSION}}" -o {{.BIN_DIR}}/ground-control/ground-control-{{.ITEM.GOOS}}-{{.ITEM.GOARCH}} ./main.go
     silent: true

--- a/taskfiles/e2e.yml
+++ b/taskfiles/e2e.yml
@@ -54,7 +54,7 @@ tasks:
     desc: Start Harbor and Ground Control stack
     cmds:
       - echo "Building ground-control image..."
-      - docker build -t gc:e2e -f ground-control/Dockerfile ground-control/
+      - docker build -t gc:e2e --build-arg VERSION=e2e -f ground-control/Dockerfile ground-control/
       - echo "Starting Harbor and GC stack..."
       - docker compose -f docker/e2e/docker-compose.yml up -d
       - sleep 5
@@ -65,7 +65,7 @@ tasks:
     desc: Start SPIFFE test stack with external SPIRE
     cmds:
       - echo "Building ground-control image..."
-      - docker build -t gc:e2e -f ground-control/Dockerfile ground-control/
+      - docker build -t gc:e2e --build-arg VERSION=e2e -f ground-control/Dockerfile ground-control/
       - task: generate-spiffe-certs
       - task: start-spire-server
       - task: setup-gc-agent
@@ -417,7 +417,7 @@ tasks:
         echo "Satellite registered with token: $TOKEN"
 
         echo "Building satellite from local code..."
-        docker build -t satellite:e2e -f Dockerfile .
+        docker build -t satellite:e2e --build-arg VERSION=e2e -f Dockerfile .
 
         echo "Starting satellite..."
         docker run -d --name satellite --network harbor-e2e \
@@ -681,7 +681,7 @@ tasks:
         done
 
         echo "Building satellite from local code..."
-        docker build -t satellite:e2e -f Dockerfile .
+        docker build -t satellite:e2e --build-arg VERSION=e2e -f Dockerfile .
 
         echo "Starting satellite in BYO mode..."
         docker run -d --name satellite-byo --network harbor-e2e \
@@ -792,7 +792,7 @@ tasks:
         echo "$TOKEN" > /tmp/e2e_satellite_token
 
         echo "Building satellite from local code..."
-        docker build -t satellite:e2e -f Dockerfile .
+        docker build -t satellite:e2e --build-arg VERSION=e2e -f Dockerfile .
 
         echo "Starting satellite with named volume..."
         docker run -d --name satellite --network harbor-e2e \

--- a/taskfiles/publish.yml
+++ b/taskfiles/publish.yml
@@ -90,9 +90,17 @@ tasks:
             TAGS="$TAGS -t {{.REGISTRY}}/{{.PROJECT_NAME}}/{{.COMPONENT}}:$tag"
           done
 
+          # Get primary semver tag (exclude exact "latest", strip leading "v")
+          VERSION=$(echo "{{.IMAGE_TAGS}}" | tr ',' '\n' | grep -v '^latest$' | head -n 1)
+          if [ -z "$VERSION" ]; then
+            VERSION=$(echo "{{.IMAGE_TAGS}}" | cut -d',' -f1)
+          fi
+          VERSION=$(echo "$VERSION" | sed 's/^v//')
+
           docker buildx build \
             --platform {{.PLATFORMS}} \
             -f $DOCKERFILE \
+            --build-arg VERSION=$VERSION \
             $TAGS \
             --push \
             $CONTEXT
@@ -100,9 +108,17 @@ tasks:
           MANIFEST_NAME="localhost/{{.COMPONENT}}:build"
           podman manifest rm "$MANIFEST_NAME" 2>/dev/null || true
 
+          # Get primary semver tag (exclude exact "latest", strip leading "v")
+          VERSION=$(echo "{{.IMAGE_TAGS}}" | tr ',' '\n' | grep -v '^latest$' | head -n 1)
+          if [ -z "$VERSION" ]; then
+            VERSION=$(echo "{{.IMAGE_TAGS}}" | cut -d',' -f1)
+          fi
+          VERSION=$(echo "$VERSION" | sed 's/^v//')
+
           podman build \
             --platform {{.PLATFORMS}} \
             -f $DOCKERFILE \
+            --build-arg VERSION=$VERSION \
             --manifest "$MANIFEST_NAME" \
             $CONTEXT
 

--- a/taskfiles/publish.yml
+++ b/taskfiles/publish.yml
@@ -91,11 +91,16 @@ tasks:
           done
 
           # Get primary semver tag (exclude exact "latest", strip leading "v")
-          VERSION=$(echo "{{.IMAGE_TAGS}}" | tr ',' '\n' | grep -v '^latest$' | head -n 1)
+          VERSION=$(echo "{{.IMAGE_TAGS}}" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^latest$' | head -n 1)
           if [ -z "$VERSION" ]; then
-            VERSION=$(echo "{{.IMAGE_TAGS}}" | cut -d',' -f1)
+            VERSION=$(echo "{{.IMAGE_TAGS}}" | cut -d',' -f1 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
           fi
           VERSION=$(echo "$VERSION" | sed 's/^v//')
+
+          # Fallback to "dev" if VERSION is not a strict semver (x.y.z[-pre][+build])
+          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$'; then
+            VERSION="dev"
+          fi
 
           docker buildx build \
             --platform {{.PLATFORMS}} \
@@ -109,11 +114,16 @@ tasks:
           podman manifest rm "$MANIFEST_NAME" 2>/dev/null || true
 
           # Get primary semver tag (exclude exact "latest", strip leading "v")
-          VERSION=$(echo "{{.IMAGE_TAGS}}" | tr ',' '\n' | grep -v '^latest$' | head -n 1)
+          VERSION=$(echo "{{.IMAGE_TAGS}}" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^latest$' | head -n 1)
           if [ -z "$VERSION" ]; then
-            VERSION=$(echo "{{.IMAGE_TAGS}}" | cut -d',' -f1)
+            VERSION=$(echo "{{.IMAGE_TAGS}}" | cut -d',' -f1 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
           fi
           VERSION=$(echo "$VERSION" | sed 's/^v//')
+
+          # Fallback to "dev" if VERSION is not a strict semver (x.y.z[-pre][+build])
+          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$'; then
+            VERSION="dev"
+          fi
 
           podman build \
             --platform {{.PLATFORMS}} \


### PR DESCRIPTION
- Fixes: #245

## Description
- Added build time version injection using `ldflags` in goreleaser 
- satellite includes its version in both initial registration (ZTR) and periodic heartbeats
- ground control verifies satellite's version with a configurable compatibility matrix
- added `/health` in satellite and both satellite and ground control expose their version.
- semantic versioning skew can be overriden/configured via `MAX_MINOR_SKEW` env variable

## Additional context
- connection fails gracefully if the versions between satellite and ground control mismatch
### Minor version outside skew
- ground control logs error
```
2026/04/22 18:12:32 ZTR: incompatible satellite version 1.5.0: ground-control 1.2.0 allows same major and minor skew <= 2
```
- satellite logs
```
{"level":"error","process":"register_satellite","error":"failed to register satellite: incompatible satellite version 1.5.0: ground-control 1.2.0 allows same major and minor skew <= 2","caller":"/home/karthik/Projects/oss/harbor-satellite/internal/state/registration_process.go:68","time":"2026-04-22T18:12:17.676516577+05:30","message":"Failed to register satellite"}
{"level":"warn","Process":"register_satellite","error":"failed to register satellite: incompatible satellite version 1.5.0: ground-control 1.2.0 allows same major and minor skew <= 2","caller":"/home/karthik/Projects/oss/harbor-satellite/internal/scheduler/scheduler.go:151","time":"2026-04-22T18:12:17.676555808+05:30","message":"Error occurred while executing process."}
```

### different Major versions
- ground control logs
```
2026/04/22 18:14:12 ZTR: incompatible satellite version 2.0.0: ground-control 1.2.0 requires same major version
```
- satellite 
```
2026/04/22 18:14:12 ZTR: incompatible satellite version 2.0.0: ground-control 1.2.0 requires same major version
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health endpoints now include version information alongside status.

* **Behavior Changes**
  * Registration, sync, and heartbeat endpoints require and validate a reported version; incompatible or missing versions are rejected.
  * Status reports and zero-touch registration include version metadata in requests.
  * Server enforces compatible version ranges with configurable tolerance.

* **Chores**
  * Build and release processes and container builds inject consistent VERSION metadata into artifacts.

* **Tests**
  * Tests updated to include version in request payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->