### PR TITLE
Enable Helm chart custom secret for credentials

### DIFF
--- a/deploy/helm/ground-control/templates/deployment.yaml
+++ b/deploy/helm/ground-control/templates/deployment.yaml
@@ -36,6 +36,34 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          env:
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "ground-control.fullname" .) .Values.groundControl.existingSecret }}
+                  key: {{ if .Values.groundControl.existingSecret }}
+                    {{ required "groundControl.existingSecretKey is required when existingSecret is set" .Values.groundControl.existingSecretKey }}
+                  {{- else }}
+                    ADMIN_PASSWORD
+                  {{- end }}
+            - name: HARBOR_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "ground-control.fullname" .) .Values.harbor.existingSecret }}
+                  key: {{ if .Values.harbor.existingSecret }}
+                    {{ required "harbor.existingSecretKey is required when existingSecret is set" .Values.harbor.existingSecretKey }}
+                  {{- else }}
+                    HARBOR_PASSWORD
+                  {{- end }}
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "ground-control.fullname" .) .Values.database.existingSecret }}
+                  key: {{ if .Values.database.existingSecret }}
+                    {{ required "database.existingSecretKey is required when existingSecret is set" .Values.database.existingSecretKey }}
+                  {{- else }}
+                    DB_PASSWORD
+                  {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "ground-control.fullname" . }}

--- a/deploy/helm/ground-control/templates/secret.yaml
+++ b/deploy/helm/ground-control/templates/secret.yaml
@@ -8,7 +8,13 @@ type: Opaque
 stringData:
   HARBOR_URL: {{ .Values.harbor.url | quote }}
   HARBOR_USERNAME: {{ .Values.harbor.username | quote }}
-  HARBOR_PASSWORD: {{ required "harbor.password is required" .Values.harbor.password | quote }}
-  ADMIN_PASSWORD: {{ required "adminPassword is required" .Values.adminPassword | quote }}
+  {{- if not .Values.harbor.existingSecret }}
+  HARBOR_PASSWORD: {{ .Values.harbor.password | quote }}
+  {{- end }}
+  {{- if not .Values.groundControl.existingSecret }}
+  ADMIN_PASSWORD: {{ .Values.groundControl.password | quote }}
+  {{- end }}
   DB_USERNAME: {{ .Values.database.username | quote }}
-  DB_PASSWORD: {{ required "database.password is required" .Values.database.password | quote }}
+  {{- if not .Values.database.existingSecret }}
+  DB_PASSWORD: {{ .Values.database.password | quote }}
+  {{- end }}

--- a/deploy/helm/ground-control/values.yaml
+++ b/deploy/helm/ground-control/values.yaml
@@ -25,9 +25,14 @@ harbor:
   username: "admin"
   # -- Harbor admin password
   password: ""
+  existingSecret: ""
+  existingSecretKey: ""
 
 # -- Ground Control admin password
-adminPassword: ""
+groundControl:
+  password: ""
+  existingSecret: ""
+  existingSecretKey: ""
 
 # -- Database configuration
 database:
@@ -44,6 +49,8 @@ database:
   username: "postgres"
   # -- Database password
   password: ""
+  existingSecret: ""
+  existingSecretKey: ""
 
 # -- Internal PostgreSQL settings (only used when database.internal.enabled is true)
 postgresql:


### PR DESCRIPTION
## Description
This change updates the Kubernetes deployment configuration to allow sensitive credentials (e.g. ADMIN_PASSWORD) to be sourced from an existing Kubernetes Secret instead of being hardcoded in the values of the chart.

The Helm template was updated to support conditional secretKeyRef logic, enabling users to provide their own secret and key via values.yaml. This improves security for production deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for referencing existing Kubernetes Secrets for password management instead of creating new ones.
  * Updated configuration structure to enable flexible secret sourcing for admin, database, and Harbor credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->