### PR TITLE
Add satellite drift detection

### DIFF
--- a/ground-control/internal/database/drift.sql.go
+++ b/ground-control/internal/database/drift.sql.go
@@ -1,0 +1,130 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+type ConfigDigest struct {
+	ConfigID  int32
+	Digest    string
+	UpdatedAt time.Time
+}
+
+type SatelliteDesiredState struct {
+	SatelliteID          int32
+	ExpectedStateDigest  sql.NullString
+	ExpectedConfigDigest sql.NullString
+	LastConvergedAt      sql.NullTime
+	UpdatedAt            time.Time
+}
+
+const upsertConfigDigest = `-- name: UpsertConfigDigest :exec
+INSERT INTO config_digests (config_id, digest, updated_at)
+VALUES ($1, $2, NOW())
+ON CONFLICT (config_id)
+DO UPDATE SET digest = EXCLUDED.digest, updated_at = NOW()
+`
+
+type UpsertConfigDigestParams struct {
+	ConfigID int32
+	Digest   string
+}
+
+func (q *Queries) UpsertConfigDigest(ctx context.Context, arg UpsertConfigDigestParams) error {
+	_, err := q.db.ExecContext(ctx, upsertConfigDigest, arg.ConfigID, arg.Digest)
+	return err
+}
+
+const getConfigDigest = `-- name: GetConfigDigest :one
+SELECT config_id, digest, updated_at FROM config_digests
+WHERE config_id = $1
+`
+
+func (q *Queries) GetConfigDigest(ctx context.Context, configID int32) (ConfigDigest, error) {
+	row := q.db.QueryRowContext(ctx, getConfigDigest, configID)
+	var i ConfigDigest
+	err := row.Scan(&i.ConfigID, &i.Digest, &i.UpdatedAt)
+	return i, err
+}
+
+const upsertSatelliteDesiredState = `-- name: UpsertSatelliteDesiredState :exec
+INSERT INTO satellite_desired_states (
+    satellite_id, expected_state_digest, expected_config_digest, updated_at
+)
+VALUES ($1, $2, $3, NOW())
+ON CONFLICT (satellite_id)
+DO UPDATE SET
+    expected_state_digest = EXCLUDED.expected_state_digest,
+    expected_config_digest = EXCLUDED.expected_config_digest,
+    updated_at = NOW()
+`
+
+type UpsertSatelliteDesiredStateParams struct {
+	SatelliteID          int32
+	ExpectedStateDigest  sql.NullString
+	ExpectedConfigDigest sql.NullString
+}
+
+func (q *Queries) UpsertSatelliteDesiredState(ctx context.Context, arg UpsertSatelliteDesiredStateParams) error {
+	_, err := q.db.ExecContext(
+		ctx,
+		upsertSatelliteDesiredState,
+		arg.SatelliteID,
+		arg.ExpectedStateDigest,
+		arg.ExpectedConfigDigest,
+	)
+	return err
+}
+
+const getSatelliteDesiredState = `-- name: GetSatelliteDesiredState :one
+SELECT satellite_id, expected_state_digest, expected_config_digest, last_converged_at, updated_at
+FROM satellite_desired_states
+WHERE satellite_id = $1
+`
+
+func (q *Queries) GetSatelliteDesiredState(ctx context.Context, satelliteID int32) (SatelliteDesiredState, error) {
+	row := q.db.QueryRowContext(ctx, getSatelliteDesiredState, satelliteID)
+	var i SatelliteDesiredState
+	err := row.Scan(&i.SatelliteID, &i.ExpectedStateDigest, &i.ExpectedConfigDigest, &i.LastConvergedAt, &i.UpdatedAt)
+	return i, err
+}
+
+const updateSatelliteDesiredConfigDigestForConfig = `-- name: UpdateSatelliteDesiredConfigDigestForConfig :exec
+INSERT INTO satellite_desired_states (satellite_id, expected_config_digest, updated_at)
+SELECT sc.satellite_id, $2, NOW()
+FROM satellite_configs sc
+WHERE sc.config_id = $1
+ON CONFLICT (satellite_id)
+DO UPDATE SET
+    expected_config_digest = EXCLUDED.expected_config_digest,
+    updated_at = NOW()
+`
+
+type UpdateSatelliteDesiredConfigDigestForConfigParams struct {
+	ConfigID int32
+	Digest   string
+}
+
+func (q *Queries) UpdateSatelliteDesiredConfigDigestForConfig(ctx context.Context, arg UpdateSatelliteDesiredConfigDigestForConfigParams) error {
+	_, err := q.db.ExecContext(ctx, updateSatelliteDesiredConfigDigestForConfig, arg.ConfigID, arg.Digest)
+	return err
+}
+
+const updateSatelliteLastConvergedAt = `-- name: UpdateSatelliteLastConvergedAt :exec
+UPDATE satellite_desired_states
+SET last_converged_at = $2,
+    updated_at = NOW()
+WHERE satellite_id = $1
+`
+
+type UpdateSatelliteLastConvergedAtParams struct {
+	SatelliteID     int32
+	LastConvergedAt time.Time
+}
+
+func (q *Queries) UpdateSatelliteLastConvergedAt(ctx context.Context, arg UpdateSatelliteLastConvergedAtParams) error {
+	_, err := q.db.ExecContext(ctx, updateSatelliteLastConvergedAt, arg.SatelliteID, arg.LastConvergedAt)
+	return err
+}

--- a/ground-control/internal/server/cached_images_test.go
+++ b/ground-control/internal/server/cached_images_test.go
@@ -82,6 +82,9 @@ func TestSyncHandler_WithCachedImages(t *testing.T) {
 
 	// Mock UpdateSatelliteLastSeen
 	mock.ExpectExec("UPDATE satellites SET last_seen").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("SELECT satellite_id, expected_state_digest, expected_config_digest, last_converged_at, updated_at").
+		WithArgs(int32(1)).
+		WillReturnError(sql.ErrNoRows)
 
 	reqBody := SatelliteStatusParams{
 		Name:               "edge-01",
@@ -126,6 +129,9 @@ func TestSyncHandler_NoCachedImages(t *testing.T) {
 	mock.ExpectQuery("INSERT INTO satellite_status").WillReturnRows(statusRows)
 
 	mock.ExpectExec("UPDATE satellites SET last_seen").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("SELECT satellite_id, expected_state_digest, expected_config_digest, last_converged_at, updated_at").
+		WithArgs(int32(1)).
+		WillReturnError(sql.ErrNoRows)
 
 	reqBody := SatelliteStatusParams{
 		Name:               "edge-01",

--- a/ground-control/internal/server/config_handlers.go
+++ b/ground-control/internal/server/config_handlers.go
@@ -86,7 +86,7 @@ func (s *Server) createConfigHandler(w http.ResponseWriter, r *http.Request) {
 		Config:      configJson,
 	}
 
-	_, err = q.CreateConfig(r.Context(), params)
+	result, err := q.CreateConfig(r.Context(), params)
 	if err != nil {
 		var pqErr *pq.Error
 		if errors.As(err, &pqErr) && pqErr.Code == "23505" {
@@ -103,9 +103,14 @@ func (s *Server) createConfigHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Push config as OCI artifact
-	err = utils.CreateAndPushConfigStateArtifact(r.Context(), configJson, req.ConfigName)
+	configDigest, err := utils.CreateAndPushConfigStateArtifact(r.Context(), configJson, req.ConfigName)
 	if err != nil {
 		log.Println("Error while creating config state artifact: ", err)
+		HandleAppError(w, err)
+		return
+	}
+	if err := upsertConfigDigest(r.Context(), q, result.ID, configDigest); err != nil {
+		log.Println("Error while storing config digest: ", err)
 		HandleAppError(w, err)
 		return
 	}
@@ -229,9 +234,19 @@ func (s *Server) updateConfigHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Push config as OCI artifact
-	err = utils.CreateAndPushConfigStateArtifact(r.Context(), patchedJson, configName)
+	configDigest, err := utils.CreateAndPushConfigStateArtifact(r.Context(), patchedJson, configName)
 	if err != nil {
 		log.Println("Error while creating config state artifact: ", err)
+		HandleAppError(w, err)
+		return
+	}
+	if err := upsertConfigDigest(r.Context(), q, result.ID, configDigest); err != nil {
+		log.Println("Error while storing config digest: ", err)
+		HandleAppError(w, err)
+		return
+	}
+	if err := updateAssignedConfigDigest(r.Context(), q, result.ID, configDigest); err != nil {
+		log.Println("Error while updating assigned satellite config digests: ", err)
 		HandleAppError(w, err)
 		return
 	}
@@ -329,7 +344,7 @@ func (s *Server) setSatelliteConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-    // TODO: Store the groupStates in memory to survive hot reloads
+	// TODO: Store the groupStates in memory to survive hot reloads
 	var groupStates []string
 	for _, group := range groupList {
 		grp, err := q.GetGroupByID(r.Context(), group.GroupID)
@@ -345,9 +360,20 @@ func (s *Server) setSatelliteConfig(w http.ResponseWriter, r *http.Request) {
 		groupStates = append(groupStates, utils.AssembleGroupState(grp.GroupName))
 	}
 
-	err = utils.CreateOrUpdateSatStateArtifact(r.Context(), sat.Name, groupStates, req.ConfigName)
+	stateDigest, err := utils.CreateOrUpdateSatStateArtifact(r.Context(), sat.Name, groupStates, req.ConfigName)
 	if err != nil {
 		log.Printf("Could not update satellite state artifact: %v", err)
+		HandleAppError(w, err)
+		return
+	}
+	configObject, err := q.GetConfigByName(r.Context(), req.ConfigName)
+	if err != nil {
+		log.Printf("Could not get satellite config: %v", err)
+		HandleAppError(w, err)
+		return
+	}
+	if err := updateSatelliteDesiredState(r.Context(), q, sat.ID, configObject.ID, stateDigest); err != nil {
+		log.Printf("Could not update satellite desired state: %v", err)
 		HandleAppError(w, err)
 		return
 	}

--- a/ground-control/internal/server/group_handlers.go
+++ b/ground-control/internal/server/group_handlers.go
@@ -282,13 +282,18 @@ func (s *Server) deleteGroupHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Update state artifact
-		err = utils.CreateOrUpdateSatStateArtifact(r.Context(), sat.Name, groupStates, configObject.ConfigName)
+		stateDigest, err := utils.CreateOrUpdateSatStateArtifact(r.Context(), sat.Name, groupStates, configObject.ConfigName)
 		if err != nil {
 			log.Println(err)
 			err := &AppError{
 				Message: "Error: Failed to update satellite state",
 				Code:    http.StatusInternalServerError,
 			}
+			HandleAppError(w, err)
+			return
+		}
+		if err := updateSatelliteDesiredState(r.Context(), q, sat.ID, configObject.ID, stateDigest); err != nil {
+			log.Printf("Error: Failed to update satellite desired state: %v", err)
 			HandleAppError(w, err)
 			return
 		}

--- a/ground-control/internal/server/helpers.go
+++ b/ground-control/internal/server/helpers.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -276,6 +277,62 @@ func fetchSatelliteConfig(ctx context.Context, dbQueries *database.Queries, sate
 		}
 	}
 	return configObject, nil
+}
+
+func upsertConfigDigest(ctx context.Context, q *database.Queries, configID int32, digest string) error {
+	if digest == "" {
+		return nil
+	}
+	return q.UpsertConfigDigest(ctx, database.UpsertConfigDigestParams{
+		ConfigID: configID,
+		Digest:   digest,
+	})
+}
+
+func updateAssignedConfigDigest(ctx context.Context, q *database.Queries, configID int32, digest string) error {
+	if digest == "" {
+		return nil
+	}
+	return q.UpdateSatelliteDesiredConfigDigestForConfig(ctx, database.UpdateSatelliteDesiredConfigDigestForConfigParams{
+		ConfigID: configID,
+		Digest:   digest,
+	})
+}
+
+func updateSatelliteDesiredState(ctx context.Context, q *database.Queries, satelliteID int32, configID int32, stateDigest string) error {
+	configDigest, err := q.GetConfigDigest(ctx, configID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+
+	params := database.UpsertSatelliteDesiredStateParams{
+		SatelliteID:          satelliteID,
+		ExpectedStateDigest:  toNullString(stateDigest),
+		ExpectedConfigDigest: sql.NullString{},
+	}
+	if err == nil {
+		params.ExpectedConfigDigest = toNullString(configDigest.Digest)
+	}
+	return q.UpsertSatelliteDesiredState(ctx, params)
+}
+
+func updateSatelliteConvergence(ctx context.Context, q *database.Queries, satelliteID int32, stateDigest string, configDigest string, convergedAt time.Time) error {
+	desired, err := q.GetSatelliteDesiredState(ctx, satelliteID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if digestsMatch(desired.ExpectedStateDigest, toNullString(stateDigest)) &&
+		digestsMatch(desired.ExpectedConfigDigest, toNullString(configDigest)) {
+		return q.UpdateSatelliteLastConvergedAt(ctx, database.UpdateSatelliteLastConvergedAtParams{
+			SatelliteID:     satelliteID,
+			LastConvergedAt: convergedAt,
+		})
+	}
+	return nil
 }
 
 func toNullString(s string) sql.NullString {

--- a/ground-control/internal/server/satellite_handlers.go
+++ b/ground-control/internal/server/satellite_handlers.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -50,6 +51,35 @@ type SatelliteStatusParams struct {
 	LastSyncDurationMs  int64         `json:"last_sync_duration_ms"`
 	ImageCount          int           `json:"image_count"`
 	CachedImages        []CachedImage `json:"cached_images,omitempty"`
+}
+
+type SatelliteStatusResponse struct {
+	ID                 int32          `json:"id"`
+	SatelliteID        int32          `json:"satellite_id"`
+	Activity           string         `json:"activity"`
+	LatestStateDigest  string         `json:"latest_state_digest,omitempty"`
+	LatestConfigDigest string         `json:"latest_config_digest,omitempty"`
+	CPUPercent         string         `json:"cpu_percent,omitempty"`
+	MemoryUsedBytes    int64          `json:"memory_used_bytes,omitempty"`
+	StorageUsedBytes   int64          `json:"storage_used_bytes,omitempty"`
+	LastSyncDurationMs int64          `json:"last_sync_duration_ms,omitempty"`
+	ImageCount         int32          `json:"image_count,omitempty"`
+	ReportedAt         time.Time      `json:"reported_at"`
+	CreatedAt          time.Time      `json:"created_at"`
+	ArtifactIDs        []int32        `json:"artifact_ids,omitempty"`
+	Drift              SatelliteDrift `json:"drift"`
+}
+
+type SatelliteDrift struct {
+	DesiredStateKnown    bool       `json:"desired_state_known"`
+	InSync               bool       `json:"in_sync"`
+	ConfigInSync         bool       `json:"config_in_sync"`
+	StateInSync          bool       `json:"state_in_sync"`
+	ExpectedConfigDigest string     `json:"expected_config_digest,omitempty"`
+	ReportedConfigDigest string     `json:"reported_config_digest,omitempty"`
+	ExpectedStateDigest  string     `json:"expected_state_digest,omitempty"`
+	ReportedStateDigest  string     `json:"reported_state_digest,omitempty"`
+	LastConvergedAt      *time.Time `json:"last_converged_at,omitempty"`
 }
 
 func (s *Server) registerSatelliteHandler(w http.ResponseWriter, r *http.Request) {
@@ -220,9 +250,14 @@ func (s *Server) registerSatelliteHandler(w http.ResponseWriter, r *http.Request
 	}
 
 	// Create the satellite's state artifact
-	err = utils.CreateOrUpdateSatStateArtifact(r.Context(), req.Name, groupStates, req.ConfigName)
+	stateDigest, err := utils.CreateOrUpdateSatStateArtifact(r.Context(), req.Name, groupStates, req.ConfigName)
 	if err != nil {
 		log.Println(err)
+		HandleAppError(w, err)
+		return
+	}
+	if err := updateSatelliteDesiredState(r.Context(), q, satellite.ID, config.ID, stateDigest); err != nil {
+		log.Println("Error updating satellite desired state:", err)
 		HandleAppError(w, err)
 		return
 	}
@@ -353,9 +388,14 @@ func (s *Server) ztrHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// For sanity, create (update) the state artifact during the registration process as well.
-	err = utils.CreateOrUpdateSatStateArtifact(r.Context(), satellite.Name, states, configObject.ConfigName)
+	stateDigest, err := utils.CreateOrUpdateSatStateArtifact(r.Context(), satellite.Name, states, configObject.ConfigName)
 	if err != nil {
 		log.Println(err)
+		HandleAppError(w, err)
+		return
+	}
+	if err := updateSatelliteDesiredState(r.Context(), q, satellite.ID, configObject.ID, stateDigest); err != nil {
+		log.Println("Error updating satellite desired state:", err)
 		HandleAppError(w, err)
 		return
 	}
@@ -513,9 +553,14 @@ func (s *Server) spiffeZtrHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		err = utils.CreateOrUpdateSatStateArtifact(r.Context(), satellite.Name, states, configObject.ConfigName)
+		stateDigest, err := utils.CreateOrUpdateSatStateArtifact(r.Context(), satellite.Name, states, configObject.ConfigName)
 		if err != nil {
 			log.Printf("SPIFFE ZTR: Failed to create state artifact: %v", err)
+			HandleAppError(w, err)
+			return
+		}
+		if err := updateSatelliteDesiredState(r.Context(), q, satellite.ID, configObject.ID, stateDigest); err != nil {
+			log.Printf("SPIFFE ZTR: Failed to update satellite desired state: %v", err)
 			HandleAppError(w, err)
 			return
 		}
@@ -654,7 +699,80 @@ func (s *Server) syncHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := updateSatelliteConvergence(r.Context(), s.dbQueries, sat.ID, req.LatestStateDigest, req.LatestConfigDigest, req.RequestCreatedTime); err != nil {
+		log.Printf("Failed to update convergence timestamp: %v", err)
+		HandleAppError(w, &AppError{Message: "failed to update convergence timestamp", Code: http.StatusInternalServerError})
+		return
+	}
+
 	w.WriteHeader(http.StatusOK)
+}
+
+func newSatelliteStatusResponse(status database.SatelliteStatus, desired database.SatelliteDesiredState, desiredKnown bool) SatelliteStatusResponse {
+	response := SatelliteStatusResponse{
+		ID:                 status.ID,
+		SatelliteID:        status.SatelliteID,
+		Activity:           status.Activity,
+		LatestStateDigest:  nullStringValue(status.LatestStateDigest),
+		LatestConfigDigest: nullStringValue(status.LatestConfigDigest),
+		CPUPercent:         nullStringValue(status.CpuPercent),
+		MemoryUsedBytes:    nullInt64Value(status.MemoryUsedBytes),
+		StorageUsedBytes:   nullInt64Value(status.StorageUsedBytes),
+		LastSyncDurationMs: nullInt64Value(status.LastSyncDurationMs),
+		ImageCount:         nullInt32Value(status.ImageCount),
+		ReportedAt:         status.ReportedAt,
+		CreatedAt:          status.CreatedAt,
+		ArtifactIDs:        status.ArtifactIds,
+	}
+	response.Drift = buildSatelliteDrift(status, desired, desiredKnown)
+	return response
+}
+
+func buildSatelliteDrift(status database.SatelliteStatus, desired database.SatelliteDesiredState, desiredKnown bool) SatelliteDrift {
+	drift := SatelliteDrift{
+		DesiredStateKnown:    desiredKnown,
+		ExpectedConfigDigest: nullStringValue(desired.ExpectedConfigDigest),
+		ReportedConfigDigest: nullStringValue(status.LatestConfigDigest),
+		ExpectedStateDigest:  nullStringValue(desired.ExpectedStateDigest),
+		ReportedStateDigest:  nullStringValue(status.LatestStateDigest),
+	}
+	if !desiredKnown {
+		return drift
+	}
+
+	drift.ConfigInSync = digestsMatch(desired.ExpectedConfigDigest, status.LatestConfigDigest)
+	drift.StateInSync = digestsMatch(desired.ExpectedStateDigest, status.LatestStateDigest)
+	drift.InSync = drift.ConfigInSync && drift.StateInSync
+	if desired.LastConvergedAt.Valid {
+		convergedAt := desired.LastConvergedAt.Time
+		drift.LastConvergedAt = &convergedAt
+	}
+	return drift
+}
+
+func digestsMatch(expected, reported sql.NullString) bool {
+	return expected.Valid && reported.Valid && expected.String == reported.String
+}
+
+func nullStringValue(value sql.NullString) string {
+	if !value.Valid {
+		return ""
+	}
+	return value.String
+}
+
+func nullInt64Value(value sql.NullInt64) int64 {
+	if !value.Valid {
+		return 0
+	}
+	return value.Int64
+}
+
+func nullInt32Value(value sql.NullInt32) int32 {
+	if !value.Valid {
+		return 0
+	}
+	return value.Int32
 }
 
 func (s *Server) getSatelliteStatusHandler(w http.ResponseWriter, r *http.Request) {
@@ -673,7 +791,16 @@ func (s *Server) getSatelliteStatusHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	WriteJSONResponse(w, http.StatusOK, status)
+	desired, err := s.dbQueries.GetSatelliteDesiredState(r.Context(), sat.ID)
+	desiredKnown := true
+	if errors.Is(err, sql.ErrNoRows) {
+		desiredKnown = false
+	} else if err != nil {
+		HandleAppError(w, &AppError{Message: "failed to get desired state", Code: http.StatusInternalServerError})
+		return
+	}
+
+	WriteJSONResponse(w, http.StatusOK, newSatelliteStatusResponse(status, desired, desiredKnown))
 }
 
 func (s *Server) getActiveSatellitesHandler(w http.ResponseWriter, r *http.Request) {
@@ -843,9 +970,21 @@ func ensureSatelliteConfig(r *http.Request, q *database.Queries, satellite datab
 			return fmt.Errorf("create default config: %w", err)
 		}
 
-		if pushErr := utils.CreateAndPushConfigStateArtifact(r.Context(), defaultConfigJSON, "default"); pushErr != nil {
+		configDigest, pushErr := utils.CreateAndPushConfigStateArtifact(r.Context(), defaultConfigJSON, "default")
+		if pushErr != nil {
 			log.Printf("SPIFFE ZTR: Warning - failed to create config-state artifact: %v", pushErr)
+		} else if err := upsertConfigDigest(r.Context(), q, defaultConfig.ID, configDigest); err != nil {
+			return fmt.Errorf("store default config digest: %w", err)
 		}
+	} else if _, err := q.GetConfigDigest(r.Context(), defaultConfig.ID); errors.Is(err, sql.ErrNoRows) {
+		configDigest, pushErr := utils.CreateAndPushConfigStateArtifact(r.Context(), defaultConfig.Config, defaultConfig.ConfigName)
+		if pushErr != nil {
+			log.Printf("SPIFFE ZTR: Warning - failed to create config-state artifact: %v", pushErr)
+		} else if err := upsertConfigDigest(r.Context(), q, defaultConfig.ID, configDigest); err != nil {
+			return fmt.Errorf("store default config digest: %w", err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("get default config digest: %w", err)
 	}
 
 	configLinkParams := database.SetSatelliteConfigParams{
@@ -1198,9 +1337,14 @@ func (s *Server) addSatelliteToGroup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Update the state artifact to also track the new group state artifact
-	err = utils.CreateOrUpdateSatStateArtifact(r.Context(), sat.Name, groupStates, configObject.ConfigName)
+	stateDigest, err := utils.CreateOrUpdateSatStateArtifact(r.Context(), sat.Name, groupStates, configObject.ConfigName)
 	if err != nil {
 		log.Printf("Error: Failed to update satellite state artifact: %v", err)
+		HandleAppError(w, err)
+		return
+	}
+	if err := updateSatelliteDesiredState(r.Context(), q, sat.ID, configObject.ID, stateDigest); err != nil {
+		log.Printf("Error: Failed to update satellite desired state: %v", err)
 		HandleAppError(w, err)
 		return
 	}
@@ -1351,9 +1495,14 @@ func (s *Server) removeSatelliteFromGroup(w http.ResponseWriter, r *http.Request
 	}
 
 	// Update the state artifact to also track the new group state artifact
-	err = utils.CreateOrUpdateSatStateArtifact(r.Context(), sat.Name, groupStates, configObject.ConfigName)
+	stateDigest, err := utils.CreateOrUpdateSatStateArtifact(r.Context(), sat.Name, groupStates, configObject.ConfigName)
 	if err != nil {
 		log.Println(err)
+		HandleAppError(w, err)
+		return
+	}
+	if err := updateSatelliteDesiredState(r.Context(), q, sat.ID, configObject.ID, stateDigest); err != nil {
+		log.Printf("Error: Failed to update satellite desired state: %v", err)
 		HandleAppError(w, err)
 		return
 	}

--- a/ground-control/internal/server/satellite_listing_test.go
+++ b/ground-control/internal/server/satellite_listing_test.go
@@ -164,6 +164,18 @@ func TestGetSatelliteStatusHandler(t *testing.T) {
 		mock.ExpectQuery("SELECT .+ FROM satellite_status").
 			WithArgs(int32(1)).
 			WillReturnRows(statusRows)
+		desiredRows := sqlmock.NewRows([]string{
+			"satellite_id", "expected_state_digest", "expected_config_digest", "last_converged_at", "updated_at",
+		}).AddRow(
+			1,
+			sql.NullString{String: "sha256:abc", Valid: true},
+			sql.NullString{String: "sha256:def", Valid: true},
+			sql.NullTime{Time: now.Add(-time.Minute), Valid: true},
+			now,
+		)
+		mock.ExpectQuery("SELECT satellite_id, expected_state_digest, expected_config_digest, last_converged_at, updated_at").
+			WithArgs(int32(1)).
+			WillReturnRows(desiredRows)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/satellites/edge-01/status", nil)
 		req = mux.SetURLVars(req, map[string]string{"satellite": "edge-01"})
@@ -173,6 +185,10 @@ func TestGetSatelliteStatusHandler(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, rr.Code)
 		require.Contains(t, rr.Body.String(), "syncing")
+		require.Contains(t, rr.Body.String(), `"desired_state_known":true`)
+		require.Contains(t, rr.Body.String(), `"state_in_sync":true`)
+		require.Contains(t, rr.Body.String(), `"config_in_sync":false`)
+		require.Contains(t, rr.Body.String(), `"last_converged_at"`)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 

--- a/ground-control/internal/utils/helper.go
+++ b/ground-control/internal/utils/helper.go
@@ -152,7 +152,7 @@ func CreateStateArtifact(ctx context.Context, stateArtifact *m.StateArtifact) er
 }
 
 // Create and Push State Artifact for Config
-func CreateAndPushConfigStateArtifact(ctx context.Context, configData []byte, configName string) error {
+func CreateAndPushConfigStateArtifact(ctx context.Context, configData []byte, configName string) (string, error) {
 	// func CreateAndPushConfigStateArtifact(ctx context.Context, configObject *m.ConfigObject) error {
 	// Marshal the state artifact to JSON format
 	// configData, err := json.Marshal(configObject.Config)
@@ -163,11 +163,16 @@ func CreateAndPushConfigStateArtifact(ctx context.Context, configData []byte, co
 	// Create the image with the state artifact JSON
 	img, err := crane.Image(map[string][]byte{"artifacts.json": configData})
 	if err != nil {
-		return fmt.Errorf("failed to create image: %v", err)
+		return "", fmt.Errorf("failed to create image: %v", err)
+	}
+
+	digest, err := img.Digest()
+	if err != nil {
+		return "", fmt.Errorf("failed to calculate image digest: %v", err)
 	}
 
 	if err := envSanityCheck(); err != nil {
-		return err
+		return "", err
 	}
 
 	auth := authn.FromConfig(authn.AuthConfig{
@@ -185,10 +190,14 @@ func CreateAndPushConfigStateArtifact(ctx context.Context, configData []byte, co
 
 	// Push the image to the repository
 	if err := crane.Push(img, destinationRepo, options...); err != nil {
-		return fmt.Errorf("failed to push image: %v", err)
+		return "", fmt.Errorf("failed to push image: %v", err)
 	}
 
-	return tagImage(destinationRepo, options)
+	if err := tagImage(destinationRepo, options); err != nil {
+		return "", err
+	}
+
+	return digest.String(), nil
 }
 
 func AssembleSatelliteState(satelliteName string) string {
@@ -199,28 +208,33 @@ func AssembleConfigState(configName string) string {
 	return fmt.Sprintf("%s/satellite/config-state/%s/state:latest", os.Getenv("HARBOR_URL"), configName)
 }
 
-func CreateOrUpdateSatStateArtifact(ctx context.Context, satelliteName string, states []string, config string) error {
+func CreateOrUpdateSatStateArtifact(ctx context.Context, satelliteName string, states []string, config string) (string, error) {
 	if satelliteName == "" {
-		return fmt.Errorf("the satellite name must be atleast one character long")
+		return "", fmt.Errorf("the satellite name must be atleast one character long")
 	}
 
 	if len(states) == 0 {
-		return nil
+		return "", nil
 	}
 
 	if err := envSanityCheck(); err != nil {
-		return err
+		return "", err
 	}
 
 	satelliteState := &m.SatelliteStateArtifact{States: states, Config: AssembleConfigState(config)}
 	data, err := json.Marshal(satelliteState)
 	if err != nil {
-		return fmt.Errorf("failed to marshal satellite state artifact to JSON: %v", err)
+		return "", fmt.Errorf("failed to marshal satellite state artifact to JSON: %v", err)
 	}
 
 	img, err := crane.Image(map[string][]byte{"artifacts.json": data})
 	if err != nil {
-		return fmt.Errorf("failed to create image: %v", err)
+		return "", fmt.Errorf("failed to create image: %v", err)
+	}
+
+	digest, err := img.Digest()
+	if err != nil {
+		return "", fmt.Errorf("failed to calculate image digest: %v", err)
 	}
 
 	auth := authn.FromConfig(authn.AuthConfig{Username: username, Password: password})
@@ -233,10 +247,14 @@ func CreateOrUpdateSatStateArtifact(ctx context.Context, satelliteName string, s
 	destinationRepo = stripProtocol(destinationRepo)
 
 	if err := pushImage(img, destinationRepo, options); err != nil {
-		return err
+		return "", err
 	}
 
-	return tagImage(destinationRepo, options)
+	if err := tagImage(destinationRepo, options); err != nil {
+		return "", err
+	}
+
+	return digest.String(), nil
 }
 
 func DeleteArtifact(deleteURL string) error {

--- a/ground-control/sql/queries/drift.sql
+++ b/ground-control/sql/queries/drift.sql
@@ -1,0 +1,41 @@
+-- name: UpsertConfigDigest :exec
+INSERT INTO config_digests (config_id, digest, updated_at)
+VALUES ($1, $2, NOW())
+ON CONFLICT (config_id)
+DO UPDATE SET digest = EXCLUDED.digest, updated_at = NOW();
+
+-- name: GetConfigDigest :one
+SELECT config_id, digest, updated_at FROM config_digests
+WHERE config_id = $1;
+
+-- name: UpsertSatelliteDesiredState :exec
+INSERT INTO satellite_desired_states (
+    satellite_id, expected_state_digest, expected_config_digest, updated_at
+)
+VALUES ($1, $2, $3, NOW())
+ON CONFLICT (satellite_id)
+DO UPDATE SET
+    expected_state_digest = EXCLUDED.expected_state_digest,
+    expected_config_digest = EXCLUDED.expected_config_digest,
+    updated_at = NOW();
+
+-- name: GetSatelliteDesiredState :one
+SELECT satellite_id, expected_state_digest, expected_config_digest, last_converged_at, updated_at
+FROM satellite_desired_states
+WHERE satellite_id = $1;
+
+-- name: UpdateSatelliteDesiredConfigDigestForConfig :exec
+INSERT INTO satellite_desired_states (satellite_id, expected_config_digest, updated_at)
+SELECT sc.satellite_id, $2, NOW()
+FROM satellite_configs sc
+WHERE sc.config_id = $1
+ON CONFLICT (satellite_id)
+DO UPDATE SET
+    expected_config_digest = EXCLUDED.expected_config_digest,
+    updated_at = NOW();
+
+-- name: UpdateSatelliteLastConvergedAt :exec
+UPDATE satellite_desired_states
+SET last_converged_at = $2,
+    updated_at = NOW()
+WHERE satellite_id = $1;

--- a/ground-control/sql/schema/016_drift_detection.sql
+++ b/ground-control/sql/schema/016_drift_detection.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+
+CREATE TABLE config_digests (
+    config_id INT PRIMARY KEY REFERENCES configs(id) ON DELETE CASCADE,
+    digest VARCHAR(255) NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE satellite_desired_states (
+    satellite_id INT PRIMARY KEY REFERENCES satellites(id) ON DELETE CASCADE,
+    expected_state_digest VARCHAR(255),
+    expected_config_digest VARCHAR(255),
+    last_converged_at TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- +goose Down
+DROP TABLE satellite_desired_states;
+DROP TABLE config_digests;


### PR DESCRIPTION
## Summary

Adds drift detection to the satellite status response so Ground Control clients can see whether a satellite has converged to its expected config and state.

This stores the digest of pushed config artifacts and the expected digest for each satellite state artifact. The status endpoint now returns a `drift` block that compares those expected digests with the latest digests reported by the satellite heartbeat.

Fixes #376

## What changed

- Added tables for config artifact digests and per-satellite desired state digests.
- Stored config digests when config artifacts are pushed.
- Stored expected satellite state digests when satellite state artifacts are created or updated.
- Added drift fields to satellite status responses:
  - `desired_state_known`
  - `in_sync`
  - `config_in_sync`
  - `state_in_sync`
  - expected and reported config/state digests
  - `last_converged_at`
- Updated the status handler test to cover the new drift response.

## Testing

```sh
GOCACHE=/tmp/harbor-satellite-go-build GOMODCACHE=/tmp/harbor-satellite-go-mod go test ./...
```

Run from `ground-control`.

```sh
GOCACHE=/tmp/harbor-satellite-go-build GOMODCACHE=/tmp/harbor-satellite-go-mod-root go test ./...
```

Run from the repo root.

I could not run `task lint` locally because `task` is not installed in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added drift detection to continuously monitor and identify when satellites diverge from their desired configuration and state
  * Enhanced satellite status API with synchronization indicators showing alignment between actual and desired configuration and state
  * Implemented configuration digest tracking to maintain and manage configuration versions across all deployed satellites
  * Improved state management during satellite registration and configuration updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->