### PR TITLE
feat: add pagination and filtering to satellite list API

### DIFF
--- a/ground-control/internal/database/satellite_list.go
+++ b/ground-control/internal/database/satellite_list.go
@@ -53,7 +53,7 @@ LIMIT $%d OFFSET $%d`, whereSQL, sortColumn, order, limitArg, offsetArg)
 	}
 	defer rows.Close()
 
-	var items []Satellite
+	items := make([]Satellite, 0)
 	for rows.Next() {
 		var i Satellite
 		if err := rows.Scan(
@@ -83,8 +83,8 @@ func satelliteListWhere(arg ListSatellitesFilteredParams) (string, []any) {
 	var args []any
 
 	if arg.NamePrefix != "" {
-		args = append(args, arg.NamePrefix)
-		clauses = append(clauses, fmt.Sprintf("lower(name) LIKE lower($%d) || '%%'", len(args)))
+		args = append(args, escapePostgresLikePattern(arg.NamePrefix))
+		clauses = append(clauses, fmt.Sprintf("lower(name) LIKE lower($%d) || '%%' ESCAPE '\\'", len(args)))
 	}
 
 	if len(clauses) == 0 {
@@ -92,4 +92,11 @@ func satelliteListWhere(arg ListSatellitesFilteredParams) (string, []any) {
 	}
 
 	return " WHERE " + strings.Join(clauses, " AND "), args
+}
+
+func escapePostgresLikePattern(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, `%`, `\%`)
+	value = strings.ReplaceAll(value, `_`, `\_`)
+	return value
 }

--- a/ground-control/internal/database/satellite_list.go
+++ b/ground-control/internal/database/satellite_list.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -51,7 +52,6 @@ LIMIT $%d OFFSET $%d`, whereSQL, sortColumn, order, limitArg, offsetArg)
 	if err != nil {
 		return nil, 0, err
 	}
-	defer rows.Close()
 
 	items := make([]Satellite, 0)
 	for rows.Next() {
@@ -64,7 +64,7 @@ LIMIT $%d OFFSET $%d`, whereSQL, sortColumn, order, limitArg, offsetArg)
 			&i.LastSeen,
 			&i.HeartbeatInterval,
 		); err != nil {
-			return nil, 0, err
+			return nil, 0, errors.Join(err, rows.Close())
 		}
 		items = append(items, i)
 	}

--- a/ground-control/internal/database/satellite_list.go
+++ b/ground-control/internal/database/satellite_list.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"strings"
@@ -16,22 +17,6 @@ type ListSatellitesFilteredParams struct {
 }
 
 func (q *Queries) ListSatellitesFiltered(ctx context.Context, arg ListSatellitesFilteredParams) ([]Satellite, int32, error) {
-	sortColumn := map[string]string{
-		"id":         "id",
-		"name":       "name",
-		"created_at": "created_at",
-		"updated_at": "updated_at",
-		"last_seen":  "last_seen",
-	}[arg.Sort]
-	if sortColumn == "" {
-		sortColumn = "name"
-	}
-
-	order := strings.ToUpper(arg.Order)
-	if order != "DESC" {
-		order = "ASC"
-	}
-
 	whereSQL, args := satelliteListWhere(arg)
 	countQuery := "SELECT COUNT(*) FROM satellites" + whereSQL
 
@@ -46,13 +31,43 @@ func (q *Queries) ListSatellitesFiltered(ctx context.Context, arg ListSatellites
 	listQuery := fmt.Sprintf(`SELECT id, name, created_at, updated_at, last_seen, heartbeat_interval
 FROM satellites%s
 ORDER BY %s %s, id ASC
-LIMIT $%d OFFSET $%d`, whereSQL, sortColumn, order, limitArg, offsetArg)
+LIMIT $%d OFFSET $%d`, whereSQL, satelliteListSortColumn(arg.Sort), satelliteListOrder(arg.Order), limitArg, offsetArg)
 
 	rows, err := q.db.QueryContext(ctx, listQuery, queryArgs...)
 	if err != nil {
 		return nil, 0, err
 	}
 
+	items, err := scanSatelliteRows(rows)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return items, total, nil
+}
+
+func satelliteListSortColumn(sort string) string {
+	sortColumn := map[string]string{
+		"id":         "id",
+		"name":       "name",
+		"created_at": "created_at",
+		"updated_at": "updated_at",
+		"last_seen":  "last_seen",
+	}[sort]
+	if sortColumn == "" {
+		return "name"
+	}
+	return sortColumn
+}
+
+func satelliteListOrder(order string) string {
+	if strings.ToUpper(order) == "DESC" {
+		return "DESC"
+	}
+	return "ASC"
+}
+
+func scanSatelliteRows(rows *sql.Rows) ([]Satellite, error) {
 	items := make([]Satellite, 0)
 	for rows.Next() {
 		var i Satellite
@@ -64,18 +79,18 @@ LIMIT $%d OFFSET $%d`, whereSQL, sortColumn, order, limitArg, offsetArg)
 			&i.LastSeen,
 			&i.HeartbeatInterval,
 		); err != nil {
-			return nil, 0, errors.Join(err, rows.Close())
+			return nil, errors.Join(err, rows.Close())
 		}
 		items = append(items, i)
 	}
 	if err := rows.Close(); err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	if err := rows.Err(); err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
-	return items, total, nil
+	return items, nil
 }
 
 func satelliteListWhere(arg ListSatellitesFilteredParams) (string, []any) {

--- a/ground-control/internal/database/satellite_list.go
+++ b/ground-control/internal/database/satellite_list.go
@@ -1,0 +1,95 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type ListSatellitesFilteredParams struct {
+	Limit      int32
+	Offset     int32
+	Sort       string
+	Order      string
+	NamePrefix string
+}
+
+func (q *Queries) ListSatellitesFiltered(ctx context.Context, arg ListSatellitesFilteredParams) ([]Satellite, int32, error) {
+	sortColumn := map[string]string{
+		"id":         "id",
+		"name":       "name",
+		"created_at": "created_at",
+		"updated_at": "updated_at",
+		"last_seen":  "last_seen",
+	}[arg.Sort]
+	if sortColumn == "" {
+		sortColumn = "name"
+	}
+
+	order := strings.ToUpper(arg.Order)
+	if order != "DESC" {
+		order = "ASC"
+	}
+
+	whereSQL, args := satelliteListWhere(arg)
+	countQuery := "SELECT COUNT(*) FROM satellites" + whereSQL
+
+	var total int32
+	if err := q.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	limitArg := len(args) + 1
+	offsetArg := len(args) + 2
+	queryArgs := append(args, arg.Limit, arg.Offset)
+	listQuery := fmt.Sprintf(`SELECT id, name, created_at, updated_at, last_seen, heartbeat_interval
+FROM satellites%s
+ORDER BY %s %s, id ASC
+LIMIT $%d OFFSET $%d`, whereSQL, sortColumn, order, limitArg, offsetArg)
+
+	rows, err := q.db.QueryContext(ctx, listQuery, queryArgs...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var items []Satellite
+	for rows.Next() {
+		var i Satellite
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.LastSeen,
+			&i.HeartbeatInterval,
+		); err != nil {
+			return nil, 0, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, 0, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+
+	return items, total, nil
+}
+
+func satelliteListWhere(arg ListSatellitesFilteredParams) (string, []any) {
+	var clauses []string
+	var args []any
+
+	if arg.NamePrefix != "" {
+		args = append(args, arg.NamePrefix)
+		clauses = append(clauses, fmt.Sprintf("lower(name) LIKE lower($%d) || '%%'", len(args)))
+	}
+
+	if len(clauses) == 0 {
+		return "", args
+	}
+
+	return " WHERE " + strings.Join(clauses, " AND "), args
+}

--- a/ground-control/internal/database/satellites.sql.go
+++ b/ground-control/internal/database/satellites.sql.go
@@ -148,7 +148,8 @@ func (q *Queries) GetSatellitesByGroupName(ctx context.Context, groupName string
 }
 
 const listSatellites = `-- name: ListSatellites :many
-SELECT id, name, created_at, updated_at, last_seen, heartbeat_interval FROM satellites
+SELECT id, name, created_at, updated_at, last_seen, heartbeat_interval
+FROM PUBLIC.satellites
 ORDER BY name ASC, id ASC
 `
 

--- a/ground-control/internal/database/satellites.sql.go
+++ b/ground-control/internal/database/satellites.sql.go
@@ -149,6 +149,7 @@ func (q *Queries) GetSatellitesByGroupName(ctx context.Context, groupName string
 
 const listSatellites = `-- name: ListSatellites :many
 SELECT id, name, created_at, updated_at, last_seen, heartbeat_interval FROM satellites
+ORDER BY name ASC, id ASC
 `
 
 func (q *Queries) ListSatellites(ctx context.Context) ([]Satellite, error) {

--- a/ground-control/internal/server/satellite_handlers.go
+++ b/ground-control/internal/server/satellite_handlers.go
@@ -557,47 +557,35 @@ func (s *Server) spiffeZtrHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listSatelliteHandler(w http.ResponseWriter, r *http.Request) {
-	query := r.URL.Query()
-	if len(query) > 0 {
-		params, err := parseSatelliteListQuery(r)
-		if err != nil {
-			HandleAppError(w, err)
+	if len(r.URL.Query()) > 0 {
+		params, appErr := parseSatelliteListQuery(r)
+		if appErr != nil {
+			HandleAppError(w, appErr)
 			return
 		}
-
 		satellites, total, err := s.dbQueries.ListSatellitesFiltered(r.Context(), params)
 		if err != nil {
 			log.Printf("Error: Failed to List Satellites: %v", err)
-			HandleAppError(w, &AppError{
-				Message: "Error: Failed to List Satellites",
-				Code:    http.StatusInternalServerError,
-			})
+			HandleAppError(w, &AppError{Message: "Error: Failed to List Satellites", Code: http.StatusInternalServerError})
 			return
 		}
-
 		WriteJSONResponse(w, http.StatusOK, SatelliteListResponse{
 			Satellites: satellites,
-			Pagination: SatelliteListPageInfo{
-				Limit:  params.Limit,
-				Offset: params.Offset,
-				Total:  total,
-			},
+			Pagination: SatelliteListPageInfo{Limit: params.Limit, Offset: params.Offset, Total: total},
 		})
 		return
 	}
 
-	result, err := s.dbQueries.ListSatellites(r.Context())
+	satellites, err := s.dbQueries.ListSatellites(r.Context())
 	if err != nil {
 		log.Printf("Error: Failed to List Satellites: %v", err)
-		err := &AppError{
-			Message: "Error: Failed to List Satellites",
-			Code:    http.StatusInternalServerError,
-		}
-		HandleAppError(w, err)
+		HandleAppError(w, &AppError{Message: "Error: Failed to List Satellites", Code: http.StatusInternalServerError})
 		return
 	}
-
-	WriteJSONResponse(w, http.StatusOK, result)
+	WriteJSONResponse(w, http.StatusOK, SatelliteListResponse{
+		Satellites: satellites,
+		Pagination: SatelliteListPageInfo{Total: int32(len(satellites))},
+	})
 }
 
 func parseSatelliteListQuery(r *http.Request) (database.ListSatellitesFilteredParams, *AppError) {
@@ -613,52 +601,24 @@ func parseSatelliteListQuery(r *http.Request) (database.ListSatellitesFilteredPa
 		}
 	}
 
-	limit := int32(100)
-	if rawLimit := strings.TrimSpace(query.Get("limit")); rawLimit != "" {
-		parsed, err := strconv.ParseInt(rawLimit, 10, 32)
-		if err != nil || parsed < 1 || parsed > 500 {
-			return database.ListSatellitesFilteredParams{}, &AppError{
-				Message: "limit must be between 1 and 500",
-				Code:    http.StatusBadRequest,
-			}
-		}
-		limit = int32(parsed)
+	limit, appErr := parseLimitParam(strings.TrimSpace(query.Get("limit")))
+	if appErr != nil {
+		return database.ListSatellitesFilteredParams{}, appErr
 	}
 
-	offset := int32(0)
-	if rawOffset := strings.TrimSpace(query.Get("offset")); rawOffset != "" {
-		parsed, err := strconv.ParseInt(rawOffset, 10, 32)
-		if err != nil || parsed < 0 {
-			return database.ListSatellitesFilteredParams{}, &AppError{
-				Message: "offset must be greater than or equal to 0",
-				Code:    http.StatusBadRequest,
-			}
-		}
-		offset = int32(parsed)
+	offset, appErr := parseOffsetParam(strings.TrimSpace(query.Get("offset")))
+	if appErr != nil {
+		return database.ListSatellitesFilteredParams{}, appErr
 	}
 
-	sort := strings.TrimSpace(query.Get("sort"))
-	if sort == "" {
-		sort = "name"
-	}
-	switch sort {
-	case "id", "name", "created_at", "updated_at", "last_seen":
-	default:
-		return database.ListSatellitesFilteredParams{}, &AppError{
-			Message: "sort must be one of id, name, created_at, updated_at, last_seen",
-			Code:    http.StatusBadRequest,
-		}
+	sort, appErr := parseSortParam(strings.TrimSpace(query.Get("sort")))
+	if appErr != nil {
+		return database.ListSatellitesFilteredParams{}, appErr
 	}
 
-	order := strings.ToLower(strings.TrimSpace(query.Get("order")))
-	if order == "" {
-		order = "asc"
-	}
-	if order != "asc" && order != "desc" {
-		return database.ListSatellitesFilteredParams{}, &AppError{
-			Message: "order must be asc or desc",
-			Code:    http.StatusBadRequest,
-		}
+	order, appErr := parseOrderParam(strings.TrimSpace(query.Get("order")))
+	if appErr != nil {
+		return database.ListSatellitesFilteredParams{}, appErr
 	}
 
 	return database.ListSatellitesFilteredParams{
@@ -668,6 +628,51 @@ func parseSatelliteListQuery(r *http.Request) (database.ListSatellitesFilteredPa
 		Order:      order,
 		NamePrefix: strings.TrimSpace(query.Get("name_prefix")),
 	}, nil
+}
+
+func parseLimitParam(raw string) (int32, *AppError) {
+	if raw == "" {
+		return 100, nil
+	}
+	parsed, err := strconv.ParseInt(raw, 10, 32)
+	if err != nil || parsed < 1 || parsed > 500 {
+		return 0, &AppError{Message: "limit must be between 1 and 500", Code: http.StatusBadRequest}
+	}
+	return int32(parsed), nil
+}
+
+func parseOffsetParam(raw string) (int32, *AppError) {
+	if raw == "" {
+		return 0, nil
+	}
+	parsed, err := strconv.ParseInt(raw, 10, 32)
+	if err != nil || parsed < 0 {
+		return 0, &AppError{Message: "offset must be greater than or equal to 0", Code: http.StatusBadRequest}
+	}
+	return int32(parsed), nil
+}
+
+func parseSortParam(raw string) (string, *AppError) {
+	if raw == "" {
+		return "name", nil
+	}
+	switch raw {
+	case "id", "name", "created_at", "updated_at", "last_seen":
+		return raw, nil
+	default:
+		return "", &AppError{Message: "sort must be one of id, name, created_at, updated_at, last_seen", Code: http.StatusBadRequest}
+	}
+}
+
+func parseOrderParam(raw string) (string, *AppError) {
+	if raw == "" {
+		return "asc", nil
+	}
+	order := strings.ToLower(raw)
+	if order != "asc" && order != "desc" {
+		return "", &AppError{Message: "order must be asc or desc", Code: http.StatusBadRequest}
+	}
+	return order, nil
 }
 
 func (s *Server) syncHandler(w http.ResponseWriter, r *http.Request) {

--- a/ground-control/internal/server/satellite_handlers.go
+++ b/ground-control/internal/server/satellite_handlers.go
@@ -602,6 +602,16 @@ func (s *Server) listSatelliteHandler(w http.ResponseWriter, r *http.Request) {
 
 func parseSatelliteListQuery(r *http.Request) (database.ListSatellitesFilteredParams, *AppError) {
 	query := r.URL.Query()
+	for key := range query {
+		switch key {
+		case "limit", "offset", "sort", "order", "name_prefix":
+		default:
+			return database.ListSatellitesFilteredParams{}, &AppError{
+				Message: "unsupported query parameter: " + key,
+				Code:    http.StatusBadRequest,
+			}
+		}
+	}
 
 	limit := int32(100)
 	if rawLimit := strings.TrimSpace(query.Get("limit")); rawLimit != "" {

--- a/ground-control/internal/server/satellite_handlers.go
+++ b/ground-control/internal/server/satellite_handlers.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/container-registry/harbor-satellite/ground-control/internal/database"
@@ -50,6 +51,17 @@ type SatelliteStatusParams struct {
 	LastSyncDurationMs  int64         `json:"last_sync_duration_ms"`
 	ImageCount          int           `json:"image_count"`
 	CachedImages        []CachedImage `json:"cached_images,omitempty"`
+}
+
+type SatelliteListResponse struct {
+	Satellites []database.Satellite  `json:"satellites"`
+	Pagination SatelliteListPageInfo `json:"pagination"`
+}
+
+type SatelliteListPageInfo struct {
+	Limit  int32 `json:"limit"`
+	Offset int32 `json:"offset"`
+	Total  int32 `json:"total"`
 }
 
 func (s *Server) registerSatelliteHandler(w http.ResponseWriter, r *http.Request) {
@@ -545,6 +557,35 @@ func (s *Server) spiffeZtrHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listSatelliteHandler(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	if len(query) > 0 {
+		params, err := parseSatelliteListQuery(r)
+		if err != nil {
+			HandleAppError(w, err)
+			return
+		}
+
+		satellites, total, err := s.dbQueries.ListSatellitesFiltered(r.Context(), params)
+		if err != nil {
+			log.Printf("Error: Failed to List Satellites: %v", err)
+			HandleAppError(w, &AppError{
+				Message: "Error: Failed to List Satellites",
+				Code:    http.StatusInternalServerError,
+			})
+			return
+		}
+
+		WriteJSONResponse(w, http.StatusOK, SatelliteListResponse{
+			Satellites: satellites,
+			Pagination: SatelliteListPageInfo{
+				Limit:  params.Limit,
+				Offset: params.Offset,
+				Total:  total,
+			},
+		})
+		return
+	}
+
 	result, err := s.dbQueries.ListSatellites(r.Context())
 	if err != nil {
 		log.Printf("Error: Failed to List Satellites: %v", err)
@@ -557,6 +598,66 @@ func (s *Server) listSatelliteHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	WriteJSONResponse(w, http.StatusOK, result)
+}
+
+func parseSatelliteListQuery(r *http.Request) (database.ListSatellitesFilteredParams, *AppError) {
+	query := r.URL.Query()
+
+	limit := int32(100)
+	if rawLimit := strings.TrimSpace(query.Get("limit")); rawLimit != "" {
+		parsed, err := strconv.ParseInt(rawLimit, 10, 32)
+		if err != nil || parsed < 1 || parsed > 500 {
+			return database.ListSatellitesFilteredParams{}, &AppError{
+				Message: "limit must be between 1 and 500",
+				Code:    http.StatusBadRequest,
+			}
+		}
+		limit = int32(parsed)
+	}
+
+	offset := int32(0)
+	if rawOffset := strings.TrimSpace(query.Get("offset")); rawOffset != "" {
+		parsed, err := strconv.ParseInt(rawOffset, 10, 32)
+		if err != nil || parsed < 0 {
+			return database.ListSatellitesFilteredParams{}, &AppError{
+				Message: "offset must be greater than or equal to 0",
+				Code:    http.StatusBadRequest,
+			}
+		}
+		offset = int32(parsed)
+	}
+
+	sort := strings.TrimSpace(query.Get("sort"))
+	if sort == "" {
+		sort = "name"
+	}
+	switch sort {
+	case "id", "name", "created_at", "updated_at", "last_seen":
+	default:
+		return database.ListSatellitesFilteredParams{}, &AppError{
+			Message: "sort must be one of id, name, created_at, updated_at, last_seen",
+			Code:    http.StatusBadRequest,
+		}
+	}
+
+	order := strings.ToLower(strings.TrimSpace(query.Get("order")))
+	if order == "" {
+		order = "asc"
+	}
+	if order != "asc" && order != "desc" {
+		return database.ListSatellitesFilteredParams{}, &AppError{
+			Message: "order must be asc or desc",
+			Code:    http.StatusBadRequest,
+		}
+	}
+
+	return database.ListSatellitesFilteredParams{
+		Limit:      limit,
+		Offset:     offset,
+		Sort:       sort,
+		Order:      order,
+		NamePrefix: strings.TrimSpace(query.Get("name_prefix")),
+	}, nil
 }
 
 func (s *Server) syncHandler(w http.ResponseWriter, r *http.Request) {

--- a/ground-control/internal/server/satellite_listing_test.go
+++ b/ground-control/internal/server/satellite_listing_test.go
@@ -24,7 +24,7 @@ func TestListSatelliteHandler(t *testing.T) {
 		rows := sqlmock.NewRows([]string{"id", "name", "created_at", "updated_at", "last_seen", "heartbeat_interval"}).
 			AddRow(1, "edge-01", now, now, sql.NullTime{Time: now, Valid: true}, sql.NullString{String: "30s", Valid: true}).
 			AddRow(2, "edge-02", now, now, sql.NullTime{}, sql.NullString{})
-		mock.ExpectQuery("SELECT .+ FROM satellites").WillReturnRows(rows)
+		mock.ExpectQuery(`(?s)SELECT .+FROM PUBLIC\.satellites`).WillReturnRows(rows)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/satellites", nil)
 		rr := httptest.NewRecorder()
@@ -44,7 +44,7 @@ func TestListSatelliteHandler(t *testing.T) {
 		server, mock := newMockServer(t)
 
 		rows := sqlmock.NewRows([]string{"id", "name", "created_at", "updated_at", "last_seen", "heartbeat_interval"})
-		mock.ExpectQuery("SELECT .+ FROM satellites").WillReturnRows(rows)
+		mock.ExpectQuery(`(?s)SELECT .+FROM PUBLIC\.satellites`).WillReturnRows(rows)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/satellites", nil)
 		rr := httptest.NewRecorder()
@@ -61,7 +61,7 @@ func TestListSatelliteHandler(t *testing.T) {
 	t.Run("db error returns 500", func(t *testing.T) {
 		server, mock := newMockServer(t)
 
-		mock.ExpectQuery("SELECT .+ FROM satellites").WillReturnError(fmt.Errorf("db error"))
+		mock.ExpectQuery(`(?s)SELECT .+FROM PUBLIC\.satellites`).WillReturnError(fmt.Errorf("db error"))
 
 		req := httptest.NewRequest(http.MethodGet, "/api/satellites", nil)
 		rr := httptest.NewRecorder()

--- a/ground-control/internal/server/satellite_listing_test.go
+++ b/ground-control/internal/server/satellite_listing_test.go
@@ -88,7 +88,7 @@ LIMIT $2 OFFSET $3`)).
 			WithArgs(`edge\_\%`, int32(1), int32(1)).
 			WillReturnRows(rows)
 
-		req := httptest.NewRequest(http.MethodGet, "/api/satellites?limit=1&offset=1&name_prefix=edge_%&sort=name&order=asc", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites?limit=1&offset=1&name_prefix=edge_%25&sort=name&order=asc", nil)
 		rr := httptest.NewRecorder()
 		server.listSatelliteHandler(rr, req)
 

--- a/ground-control/internal/server/satellite_listing_test.go
+++ b/ground-control/internal/server/satellite_listing_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 	"time"
 
@@ -65,17 +66,20 @@ func TestListSatelliteHandler(t *testing.T) {
 		server, mock := newMockServer(t)
 		now := time.Now().UTC().Truncate(time.Second)
 
-		mock.ExpectQuery(`SELECT COUNT\(\*\) FROM satellites WHERE lower\(name\) LIKE lower\(\$1\) \|\| '%'`).
-			WithArgs("edge").
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*) FROM satellites WHERE lower(name) LIKE lower($1) || '%' ESCAPE '\'`)).
+			WithArgs(`edge\_\%`).
 			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
 
 		rows := sqlmock.NewRows([]string{"id", "name", "created_at", "updated_at", "last_seen", "heartbeat_interval"}).
 			AddRow(2, "edge-02", now, now, sql.NullTime{}, sql.NullString{})
-		mock.ExpectQuery("SELECT .+ FROM satellites").
-			WithArgs("edge", int32(1), int32(1)).
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, name, created_at, updated_at, last_seen, heartbeat_interval
+FROM satellites WHERE lower(name) LIKE lower($1) || '%' ESCAPE '\'
+ORDER BY name ASC, id ASC
+LIMIT $2 OFFSET $3`)).
+			WithArgs(`edge\_\%`, int32(1), int32(1)).
 			WillReturnRows(rows)
 
-		req := httptest.NewRequest(http.MethodGet, "/api/satellites?limit=1&offset=1&name_prefix=edge&sort=name&order=asc", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites?limit=1&offset=1&name_prefix=edge_%&sort=name&order=asc", nil)
 		rr := httptest.NewRecorder()
 		server.listSatelliteHandler(rr, req)
 
@@ -84,6 +88,43 @@ func TestListSatelliteHandler(t *testing.T) {
 		require.Contains(t, rr.Body.String(), `"limit":1`)
 		require.Contains(t, rr.Body.String(), `"offset":1`)
 		require.Contains(t, rr.Body.String(), `"total":2`)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("returns empty array for filtered paginated satellites with no matches", func(t *testing.T) {
+		server, mock := newMockServer(t)
+
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*) FROM satellites WHERE lower(name) LIKE lower($1) || '%' ESCAPE '\'`)).
+			WithArgs("unknown").
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+		rows := sqlmock.NewRows([]string{"id", "name", "created_at", "updated_at", "last_seen", "heartbeat_interval"})
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, name, created_at, updated_at, last_seen, heartbeat_interval
+FROM satellites WHERE lower(name) LIKE lower($1) || '%' ESCAPE '\'
+ORDER BY name ASC, id ASC
+LIMIT $2 OFFSET $3`)).
+			WithArgs("unknown", int32(100), int32(0)).
+			WillReturnRows(rows)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites?name_prefix=unknown", nil)
+		rr := httptest.NewRecorder()
+		server.listSatelliteHandler(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		require.Contains(t, rr.Body.String(), `"satellites":[]`)
+		require.Contains(t, rr.Body.String(), `"total":0`)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("rejects unsupported query parameter", func(t *testing.T) {
+		server, mock := newMockServer(t)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites?foo=bar", nil)
+		rr := httptest.NewRecorder()
+		server.listSatelliteHandler(rr, req)
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+		require.Contains(t, rr.Body.String(), "unsupported query parameter: foo")
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 

--- a/ground-control/internal/server/satellite_listing_test.go
+++ b/ground-control/internal/server/satellite_listing_test.go
@@ -60,6 +60,56 @@ func TestListSatelliteHandler(t *testing.T) {
 		require.Equal(t, http.StatusInternalServerError, rr.Code)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
+
+	t.Run("returns filtered paginated satellites", func(t *testing.T) {
+		server, mock := newMockServer(t)
+		now := time.Now().UTC().Truncate(time.Second)
+
+		mock.ExpectQuery(`SELECT COUNT\(\*\) FROM satellites WHERE lower\(name\) LIKE lower\(\$1\) \|\| '%'`).
+			WithArgs("edge").
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+
+		rows := sqlmock.NewRows([]string{"id", "name", "created_at", "updated_at", "last_seen", "heartbeat_interval"}).
+			AddRow(2, "edge-02", now, now, sql.NullTime{}, sql.NullString{})
+		mock.ExpectQuery("SELECT .+ FROM satellites").
+			WithArgs("edge", int32(1), int32(1)).
+			WillReturnRows(rows)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites?limit=1&offset=1&name_prefix=edge&sort=name&order=asc", nil)
+		rr := httptest.NewRecorder()
+		server.listSatelliteHandler(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		require.Contains(t, rr.Body.String(), "edge-02")
+		require.Contains(t, rr.Body.String(), `"limit":1`)
+		require.Contains(t, rr.Body.String(), `"offset":1`)
+		require.Contains(t, rr.Body.String(), `"total":2`)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("rejects invalid limit", func(t *testing.T) {
+		server, mock := newMockServer(t)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites?limit=0", nil)
+		rr := httptest.NewRecorder()
+		server.listSatelliteHandler(rr, req)
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+		require.Contains(t, rr.Body.String(), "limit must be between 1 and 500")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("rejects invalid sort", func(t *testing.T) {
+		server, mock := newMockServer(t)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites?sort=token", nil)
+		rr := httptest.NewRecorder()
+		server.listSatelliteHandler(rr, req)
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+		require.Contains(t, rr.Body.String(), "sort must be one of")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
 }
 
 func TestGetActiveSatellitesHandler(t *testing.T) {

--- a/ground-control/internal/server/satellite_listing_test.go
+++ b/ground-control/internal/server/satellite_listing_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -30,8 +31,12 @@ func TestListSatelliteHandler(t *testing.T) {
 		server.listSatelliteHandler(rr, req)
 
 		require.Equal(t, http.StatusOK, rr.Code)
-		require.Contains(t, rr.Body.String(), "edge-01")
-		require.Contains(t, rr.Body.String(), "edge-02")
+		var resp SatelliteListResponse
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+		require.Len(t, resp.Satellites, 2)
+		require.Equal(t, "edge-01", resp.Satellites[0].Name)
+		require.Equal(t, "edge-02", resp.Satellites[1].Name)
+		require.Equal(t, int32(2), resp.Pagination.Total)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
@@ -46,6 +51,10 @@ func TestListSatelliteHandler(t *testing.T) {
 		server.listSatelliteHandler(rr, req)
 
 		require.Equal(t, http.StatusOK, rr.Code)
+		var resp SatelliteListResponse
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+		require.Empty(t, resp.Satellites)
+		require.Equal(t, int32(0), resp.Pagination.Total)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
@@ -84,10 +93,13 @@ LIMIT $2 OFFSET $3`)).
 		server.listSatelliteHandler(rr, req)
 
 		require.Equal(t, http.StatusOK, rr.Code)
-		require.Contains(t, rr.Body.String(), "edge-02")
-		require.Contains(t, rr.Body.String(), `"limit":1`)
-		require.Contains(t, rr.Body.String(), `"offset":1`)
-		require.Contains(t, rr.Body.String(), `"total":2`)
+		var resp SatelliteListResponse
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+		require.Len(t, resp.Satellites, 1)
+		require.Equal(t, "edge-02", resp.Satellites[0].Name)
+		require.Equal(t, int32(1), resp.Pagination.Limit)
+		require.Equal(t, int32(1), resp.Pagination.Offset)
+		require.Equal(t, int32(2), resp.Pagination.Total)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
@@ -111,8 +123,10 @@ LIMIT $2 OFFSET $3`)).
 		server.listSatelliteHandler(rr, req)
 
 		require.Equal(t, http.StatusOK, rr.Code)
-		require.Contains(t, rr.Body.String(), `"satellites":[]`)
-		require.Contains(t, rr.Body.String(), `"total":0`)
+		var resp SatelliteListResponse
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+		require.Empty(t, resp.Satellites)
+		require.Equal(t, int32(0), resp.Pagination.Total)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 

--- a/ground-control/sql/queries/satellites.sql
+++ b/ground-control/sql/queries/satellites.sql
@@ -4,7 +4,8 @@ VALUES ($1, NOW(), NOW())
 RETURNING *;
 
 -- name: ListSatellites :many
-SELECT * FROM satellites
+SELECT id, name, created_at, updated_at, last_seen, heartbeat_interval
+FROM PUBLIC.satellites
 ORDER BY name ASC, id ASC;
 
 -- name: GetSatellitesByGroupName :many

--- a/ground-control/sql/queries/satellites.sql
+++ b/ground-control/sql/queries/satellites.sql
@@ -4,7 +4,8 @@ VALUES ($1, NOW(), NOW())
 RETURNING *;
 
 -- name: ListSatellites :many
-SELECT * FROM satellites;
+SELECT * FROM satellites
+ORDER BY name ASC, id ASC;
 
 -- name: GetSatellitesByGroupName :many
 SELECT s.id, s.name, s.created_at, s.updated_at


### PR DESCRIPTION
Fixes #382

## Description
- Add query controls to GET /api/satellites for limit, offset, name_prefix, sort, and order
- Return pagination metadata when query parameters are used while keeping the existing array response without query parameters
- Add deterministic ordering for the default satellite listing
- Cover pagination, filtering, and validation in handler tests

## Testing
- Not run; Go is not installed in this environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Satellite list supports case-insensitive name-prefix filtering (with proper escaping), sorting (allowlisted), and pagination (limit, offset); responses include pagination metadata (limit, offset, total).
  * Results are now deterministically sorted by name then id.

* **Tests**
  * Expanded tests covering filtered listing, pagination, deterministic ordering, and request validation (invalid query params return 400).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->