### PR TITLE
docs: improve QUICKSTART.md with Task installation note, TTL example, and registry dir note

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -6,7 +6,7 @@ Harbor Satellite extends Harbor container registry to edge computing environment
 
 - A Harbor registry instance with the satellite adapter installed. See [harbor-next](https://github.com/container-registry/harbor-next/tree/satellite).
 - Credentials with permission to create robot accounts in the registry.
-- [Task](https://taskfile.dev/installation/) installed.
+- [Task](https://taskfile.dev/installation/) installed. See the [Task installation guide](https://taskfile.dev/installation/) for Linux, macOS, and Windows instructions.
 - (Optional) [Docker](https://docs.docker.com/get-docker/) and Docker Compose.
 
 ## Choose Your Authentication Method
@@ -19,7 +19,7 @@ Simple one-time token authentication. An admin registers a satellite via the Gro
 
 - No additional infrastructure required
 - Good for local development, CI/CD, and quick testing
-- Token is single-use with a configurable TTL
+- Token is single-use with a configurable TTL (default: 24h, configurable via `TOKEN_TTL` environment variable)
 
 [Get started with Token-based ZTR](deploy/no-spiffe/quickstart.md)
 
@@ -86,6 +86,9 @@ export REGISTRY_DATA_DIR="/custom/path"
 ```
 
 The flag takes precedence over the environment variable, which takes precedence over the default path.
+
+> **Note:** The directory will be created automatically if it does not exist.
+
 ## Need Help?
 
 - Explore the [Harbor Satellite documentation](https://docs.goharbor.io).


### PR DESCRIPTION
## What changed
- Added Task installation guide reference for Linux, macOS, and Windows
- Clarified Token TTL with default value and TOKEN_TTL environment variable example
- Added note that registry data directory is created automatically if it does not exist

## Why
These small additions help new contributors and users get started faster without having to search for missing details.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced quickstart guide with clearer prerequisites, including Task installation reference.
  * Clarified token TTL configuration options and defaults.
  * Added clarification that the registry data directory is created automatically.
  * Improved content in the support section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->