### PR TITLE
feat: add labels and selectors for satellites

### DIFF
--- a/ground-control/internal/database/satellite_labels.go
+++ b/ground-control/internal/database/satellite_labels.go
@@ -3,7 +3,10 @@ package database
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
+
+	"github.com/lib/pq"
 )
 
 // GetLabelsBySatelliteID returns all labels for a satellite as a key→value map.
@@ -51,6 +54,32 @@ func (q *Queries) DeleteLabel(ctx context.Context, satelliteID int32, key string
 	return err
 }
 
+// GetLabelsByIDs returns labels for multiple satellites as a map of satelliteID → key → value.
+func (q *Queries) GetLabelsByIDs(ctx context.Context, ids []int32) (map[int32]map[string]string, error) {
+	if len(ids) == 0 {
+		return map[int32]map[string]string{}, nil
+	}
+	query := `SELECT satellite_id, key, value FROM satellite_labels WHERE satellite_id = ANY($1) ORDER BY satellite_id, key`
+	rows, err := q.db.QueryContext(ctx, query, pq.Array(ids))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := make(map[int32]map[string]string)
+	for rows.Next() {
+		var satID int32
+		var k, v string
+		if err := rows.Scan(&satID, &k, &v); err != nil {
+			return nil, err
+		}
+		if result[satID] == nil {
+			result[satID] = make(map[string]string)
+		}
+		result[satID][k] = v
+	}
+	return result, rows.Err()
+}
+
 // labelSelectorClause builds a WHERE sub-clause and args for AND-semantics label selectors.
 // A nil value means "key must exist"; a non-nil value means "key=value" equality.
 // Returns ("", nil) when selectors is empty.
@@ -58,10 +87,16 @@ func labelSelectorClause(selectors map[string]*string, startIdx int) (string, []
 	if len(selectors) == 0 {
 		return "", nil
 	}
+	keys := make([]string, 0, len(selectors))
+	for k := range selectors {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
 	var orConds []string
 	var args []any
 	idx := startIdx
-	for k, v := range selectors {
+	for _, k := range keys {
+		v := selectors[k]
 		if v == nil {
 			args = append(args, k)
 			orConds = append(orConds, fmt.Sprintf("(key = $%d)", idx))

--- a/ground-control/internal/database/satellite_labels.go
+++ b/ground-control/internal/database/satellite_labels.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -16,14 +17,16 @@ func (q *Queries) GetLabelsBySatelliteID(ctx context.Context, satelliteID int32)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 	labels := make(map[string]string)
 	for rows.Next() {
 		var k, v string
 		if err := rows.Scan(&k, &v); err != nil {
-			return nil, err
+			return nil, errors.Join(err, rows.Close())
 		}
 		labels[k] = v
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
 	}
 	return labels, rows.Err()
 }
@@ -64,18 +67,20 @@ func (q *Queries) GetLabelsByIDs(ctx context.Context, ids []int32) (map[int32]ma
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 	result := make(map[int32]map[string]string)
 	for rows.Next() {
 		var satID int32
 		var k, v string
 		if err := rows.Scan(&satID, &k, &v); err != nil {
-			return nil, err
+			return nil, errors.Join(err, rows.Close())
 		}
 		if result[satID] == nil {
 			result[satID] = make(map[string]string)
 		}
 		result[satID][k] = v
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
 	}
 	return result, rows.Err()
 }

--- a/ground-control/internal/database/satellite_labels.go
+++ b/ground-control/internal/database/satellite_labels.go
@@ -1,0 +1,93 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// GetLabelsBySatelliteID returns all labels for a satellite as an ordered key→value map.
+func (q *Queries) GetLabelsBySatelliteID(ctx context.Context, satelliteID int32) (map[string]string, error) {
+	const query = `SELECT key, value FROM satellite_labels WHERE satellite_id = $1 ORDER BY key`
+	rows, err := q.db.QueryContext(ctx, query, satelliteID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	labels := make(map[string]string)
+	for rows.Next() {
+		var k, v string
+		if err := rows.Scan(&k, &v); err != nil {
+			return nil, err
+		}
+		labels[k] = v
+	}
+	return labels, rows.Err()
+}
+
+// SetLabels replaces the full label set for a satellite atomically.
+func (q *Queries) SetLabels(ctx context.Context, satelliteID int32, labels map[string]string) error {
+	tx, err := q.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+	if _, err := tx.ExecContext(ctx, `DELETE FROM satellite_labels WHERE satellite_id = $1`, satelliteID); err != nil {
+		return err
+	}
+	for k, v := range labels {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO satellite_labels (satellite_id, key, value) VALUES ($1, $2, $3)`,
+			satelliteID, k, v); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// PatchLabels merges changes into the label set: nil value removes the key, non-nil upserts it.
+func (q *Queries) PatchLabels(ctx context.Context, satelliteID int32, patch map[string]*string) error {
+	tx, err := q.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+	for k, v := range patch {
+		if v == nil {
+			if _, err := tx.ExecContext(ctx,
+				`DELETE FROM satellite_labels WHERE satellite_id = $1 AND key = $2`,
+				satelliteID, k); err != nil {
+				return err
+			}
+			continue
+		}
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO satellite_labels (satellite_id, key, value) VALUES ($1, $2, $3)
+			 ON CONFLICT (satellite_id, key) DO UPDATE SET value = EXCLUDED.value`,
+			satelliteID, k, *v); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// labelSelectorClause builds a WHERE sub-clause and args for AND-semantics label selectors.
+// Returns ("", nil) when selectors is empty.
+func labelSelectorClause(selectors map[string]string, startIdx int) (string, []any) {
+	if len(selectors) == 0 {
+		return "", nil
+	}
+	var orConds []string
+	var args []any
+	idx := startIdx
+	for k, v := range selectors {
+		args = append(args, k, v)
+		orConds = append(orConds, fmt.Sprintf("(key = $%d AND value = $%d)", idx, idx+1))
+		idx += 2
+	}
+	args = append(args, int32(len(selectors)))
+	clause := fmt.Sprintf(
+		"id IN (SELECT satellite_id FROM satellite_labels WHERE %s GROUP BY satellite_id HAVING COUNT(*) = $%d)",
+		strings.Join(orConds, " OR "), idx)
+	return clause, args
+}

--- a/ground-control/internal/database/satellite_labels.go
+++ b/ground-control/internal/database/satellite_labels.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// GetLabelsBySatelliteID returns all labels for a satellite as an ordered key→value map.
+// GetLabelsBySatelliteID returns all labels for a satellite as a key→value map.
 func (q *Queries) GetLabelsBySatelliteID(ctx context.Context, satelliteID int32) (map[string]string, error) {
 	const query = `SELECT key, value FROM satellite_labels WHERE satellite_id = $1 ORDER BY key`
 	rows, err := q.db.QueryContext(ctx, query, satelliteID)
@@ -25,55 +25,36 @@ func (q *Queries) GetLabelsBySatelliteID(ctx context.Context, satelliteID int32)
 	return labels, rows.Err()
 }
 
-// SetLabels replaces the full label set for a satellite atomically.
-func (q *Queries) SetLabels(ctx context.Context, satelliteID int32, labels map[string]string) error {
-	tx, err := q.db.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback() //nolint:errcheck
-	if _, err := tx.ExecContext(ctx, `DELETE FROM satellite_labels WHERE satellite_id = $1`, satelliteID); err != nil {
-		return err
-	}
-	for k, v := range labels {
-		if _, err := tx.ExecContext(ctx,
-			`INSERT INTO satellite_labels (satellite_id, key, value) VALUES ($1, $2, $3)`,
-			satelliteID, k, v); err != nil {
-			return err
-		}
-	}
-	return tx.Commit()
+// DeleteLabelsBySatelliteID removes all labels for a satellite.
+// Call within a transaction via WithTx for atomicity.
+func (q *Queries) DeleteLabelsBySatelliteID(ctx context.Context, satelliteID int32) error {
+	_, err := q.db.ExecContext(ctx, `DELETE FROM satellite_labels WHERE satellite_id = $1`, satelliteID)
+	return err
 }
 
-// PatchLabels merges changes into the label set: nil value removes the key, non-nil upserts it.
-func (q *Queries) PatchLabels(ctx context.Context, satelliteID int32, patch map[string]*string) error {
-	tx, err := q.db.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback() //nolint:errcheck
-	for k, v := range patch {
-		if v == nil {
-			if _, err := tx.ExecContext(ctx,
-				`DELETE FROM satellite_labels WHERE satellite_id = $1 AND key = $2`,
-				satelliteID, k); err != nil {
-				return err
-			}
-			continue
-		}
-		if _, err := tx.ExecContext(ctx,
-			`INSERT INTO satellite_labels (satellite_id, key, value) VALUES ($1, $2, $3)
-			 ON CONFLICT (satellite_id, key) DO UPDATE SET value = EXCLUDED.value`,
-			satelliteID, k, *v); err != nil {
-			return err
-		}
-	}
-	return tx.Commit()
+// UpsertLabel inserts or updates a single label.
+// Call within a transaction via WithTx for atomicity.
+func (q *Queries) UpsertLabel(ctx context.Context, satelliteID int32, key, value string) error {
+	_, err := q.db.ExecContext(ctx,
+		`INSERT INTO satellite_labels (satellite_id, key, value) VALUES ($1, $2, $3)
+		 ON CONFLICT (satellite_id, key) DO UPDATE SET value = EXCLUDED.value`,
+		satelliteID, key, value)
+	return err
+}
+
+// DeleteLabel removes a single label by key.
+// Call within a transaction via WithTx for atomicity.
+func (q *Queries) DeleteLabel(ctx context.Context, satelliteID int32, key string) error {
+	_, err := q.db.ExecContext(ctx,
+		`DELETE FROM satellite_labels WHERE satellite_id = $1 AND key = $2`,
+		satelliteID, key)
+	return err
 }
 
 // labelSelectorClause builds a WHERE sub-clause and args for AND-semantics label selectors.
+// A nil value means "key must exist"; a non-nil value means "key=value" equality.
 // Returns ("", nil) when selectors is empty.
-func labelSelectorClause(selectors map[string]string, startIdx int) (string, []any) {
+func labelSelectorClause(selectors map[string]*string, startIdx int) (string, []any) {
 	if len(selectors) == 0 {
 		return "", nil
 	}
@@ -81,9 +62,15 @@ func labelSelectorClause(selectors map[string]string, startIdx int) (string, []a
 	var args []any
 	idx := startIdx
 	for k, v := range selectors {
-		args = append(args, k, v)
-		orConds = append(orConds, fmt.Sprintf("(key = $%d AND value = $%d)", idx, idx+1))
-		idx += 2
+		if v == nil {
+			args = append(args, k)
+			orConds = append(orConds, fmt.Sprintf("(key = $%d)", idx))
+			idx++
+		} else {
+			args = append(args, k, *v)
+			orConds = append(orConds, fmt.Sprintf("(key = $%d AND value = $%d)", idx, idx+1))
+			idx += 2
+		}
 	}
 	args = append(args, int32(len(selectors)))
 	clause := fmt.Sprintf(

--- a/ground-control/internal/database/satellite_list.go
+++ b/ground-control/internal/database/satellite_list.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -56,7 +57,6 @@ LIMIT $%d OFFSET $%d`, whereSQL, sortColumn, order, limitArg, offsetArg)
 	if err != nil {
 		return nil, 0, err
 	}
-	defer rows.Close()
 
 	items := make([]Satellite, 0)
 	for rows.Next() {
@@ -69,7 +69,7 @@ LIMIT $%d OFFSET $%d`, whereSQL, sortColumn, order, limitArg, offsetArg)
 			&i.LastSeen,
 			&i.HeartbeatInterval,
 		); err != nil {
-			return nil, 0, err
+			return nil, 0, errors.Join(err, rows.Close())
 		}
 		items = append(items, i)
 	}

--- a/ground-control/internal/database/satellite_list.go
+++ b/ground-control/internal/database/satellite_list.go
@@ -53,7 +53,7 @@ LIMIT $%d OFFSET $%d`, whereSQL, sortColumn, order, limitArg, offsetArg)
 	}
 	defer rows.Close()
 
-	var items []Satellite
+	items := make([]Satellite, 0)
 	for rows.Next() {
 		var i Satellite
 		if err := rows.Scan(
@@ -83,8 +83,8 @@ func satelliteListWhere(arg ListSatellitesFilteredParams) (string, []any) {
 	var args []any
 
 	if arg.NamePrefix != "" {
-		args = append(args, arg.NamePrefix)
-		clauses = append(clauses, fmt.Sprintf("lower(name) LIKE lower($%d) || '%%'", len(args)))
+		args = append(args, escapePostgresLikePattern(arg.NamePrefix))
+		clauses = append(clauses, fmt.Sprintf("lower(name) LIKE lower($%d) || '%%' ESCAPE '\\'", len(args)))
 	}
 
 	if len(clauses) == 0 {
@@ -92,4 +92,11 @@ func satelliteListWhere(arg ListSatellitesFilteredParams) (string, []any) {
 	}
 
 	return " WHERE " + strings.Join(clauses, " AND "), args
+}
+
+func escapePostgresLikePattern(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, `%`, `\%`)
+	value = strings.ReplaceAll(value, `_`, `\_`)
+	return value
 }

--- a/ground-control/internal/database/satellite_list.go
+++ b/ground-control/internal/database/satellite_list.go
@@ -1,0 +1,95 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type ListSatellitesFilteredParams struct {
+	Limit      int32
+	Offset     int32
+	Sort       string
+	Order      string
+	NamePrefix string
+}
+
+func (q *Queries) ListSatellitesFiltered(ctx context.Context, arg ListSatellitesFilteredParams) ([]Satellite, int32, error) {
+	sortColumn := map[string]string{
+		"id":         "id",
+		"name":       "name",
+		"created_at": "created_at",
+		"updated_at": "updated_at",
+		"last_seen":  "last_seen",
+	}[arg.Sort]
+	if sortColumn == "" {
+		sortColumn = "name"
+	}
+
+	order := strings.ToUpper(arg.Order)
+	if order != "DESC" {
+		order = "ASC"
+	}
+
+	whereSQL, args := satelliteListWhere(arg)
+	countQuery := "SELECT COUNT(*) FROM satellites" + whereSQL
+
+	var total int32
+	if err := q.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	limitArg := len(args) + 1
+	offsetArg := len(args) + 2
+	queryArgs := append(args, arg.Limit, arg.Offset)
+	listQuery := fmt.Sprintf(`SELECT id, name, created_at, updated_at, last_seen, heartbeat_interval
+FROM satellites%s
+ORDER BY %s %s, id ASC
+LIMIT $%d OFFSET $%d`, whereSQL, sortColumn, order, limitArg, offsetArg)
+
+	rows, err := q.db.QueryContext(ctx, listQuery, queryArgs...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var items []Satellite
+	for rows.Next() {
+		var i Satellite
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.LastSeen,
+			&i.HeartbeatInterval,
+		); err != nil {
+			return nil, 0, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, 0, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+
+	return items, total, nil
+}
+
+func satelliteListWhere(arg ListSatellitesFilteredParams) (string, []any) {
+	var clauses []string
+	var args []any
+
+	if arg.NamePrefix != "" {
+		args = append(args, arg.NamePrefix)
+		clauses = append(clauses, fmt.Sprintf("lower(name) LIKE lower($%d) || '%%'", len(args)))
+	}
+
+	if len(clauses) == 0 {
+		return "", args
+	}
+
+	return " WHERE " + strings.Join(clauses, " AND "), args
+}

--- a/ground-control/internal/database/satellite_list.go
+++ b/ground-control/internal/database/satellite_list.go
@@ -12,7 +12,7 @@ type ListSatellitesFilteredParams struct {
 	Sort           string
 	Order          string
 	NamePrefix     string
-	LabelSelectors map[string]string
+	LabelSelectors map[string]*string
 }
 
 func normalizeSortOrder(sort, order string) (string, string) {

--- a/ground-control/internal/database/satellite_list.go
+++ b/ground-control/internal/database/satellite_list.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"strings"
@@ -16,27 +17,7 @@ type ListSatellitesFilteredParams struct {
 	LabelSelectors map[string]*string
 }
 
-func normalizeSortOrder(sort, order string) (string, string) {
-	sortColumn := map[string]string{
-		"id":         "id",
-		"name":       "name",
-		"created_at": "created_at",
-		"updated_at": "updated_at",
-		"last_seen":  "last_seen",
-	}[sort]
-	if sortColumn == "" {
-		sortColumn = "name"
-	}
-	orderUpper := strings.ToUpper(order)
-	if orderUpper != "DESC" {
-		orderUpper = "ASC"
-	}
-	return sortColumn, orderUpper
-}
-
 func (q *Queries) ListSatellitesFiltered(ctx context.Context, arg ListSatellitesFilteredParams) ([]Satellite, int32, error) {
-	sortColumn, order := normalizeSortOrder(arg.Sort, arg.Order)
-
 	whereSQL, args := satelliteListWhere(arg)
 	countQuery := "SELECT COUNT(*) FROM satellites" + whereSQL
 
@@ -51,13 +32,43 @@ func (q *Queries) ListSatellitesFiltered(ctx context.Context, arg ListSatellites
 	listQuery := fmt.Sprintf(`SELECT id, name, created_at, updated_at, last_seen, heartbeat_interval
 FROM satellites%s
 ORDER BY %s %s, id ASC
-LIMIT $%d OFFSET $%d`, whereSQL, sortColumn, order, limitArg, offsetArg)
+LIMIT $%d OFFSET $%d`, whereSQL, satelliteListSortColumn(arg.Sort), satelliteListOrder(arg.Order), limitArg, offsetArg)
 
 	rows, err := q.db.QueryContext(ctx, listQuery, queryArgs...)
 	if err != nil {
 		return nil, 0, err
 	}
 
+	items, err := scanSatelliteRows(rows)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return items, total, nil
+}
+
+func satelliteListSortColumn(sort string) string {
+	sortColumn := map[string]string{
+		"id":         "id",
+		"name":       "name",
+		"created_at": "created_at",
+		"updated_at": "updated_at",
+		"last_seen":  "last_seen",
+	}[sort]
+	if sortColumn == "" {
+		return "name"
+	}
+	return sortColumn
+}
+
+func satelliteListOrder(order string) string {
+	if strings.ToUpper(order) == "DESC" {
+		return "DESC"
+	}
+	return "ASC"
+}
+
+func scanSatelliteRows(rows *sql.Rows) ([]Satellite, error) {
 	items := make([]Satellite, 0)
 	for rows.Next() {
 		var i Satellite
@@ -69,18 +80,18 @@ LIMIT $%d OFFSET $%d`, whereSQL, sortColumn, order, limitArg, offsetArg)
 			&i.LastSeen,
 			&i.HeartbeatInterval,
 		); err != nil {
-			return nil, 0, errors.Join(err, rows.Close())
+			return nil, errors.Join(err, rows.Close())
 		}
 		items = append(items, i)
 	}
 	if err := rows.Close(); err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	if err := rows.Err(); err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
-	return items, total, nil
+	return items, nil
 }
 
 func satelliteListWhere(arg ListSatellitesFilteredParams) (string, []any) {

--- a/ground-control/internal/database/satellite_list.go
+++ b/ground-control/internal/database/satellite_list.go
@@ -7,29 +7,34 @@ import (
 )
 
 type ListSatellitesFilteredParams struct {
-	Limit      int32
-	Offset     int32
-	Sort       string
-	Order      string
-	NamePrefix string
+	Limit          int32
+	Offset         int32
+	Sort           string
+	Order          string
+	NamePrefix     string
+	LabelSelectors map[string]string
 }
 
-func (q *Queries) ListSatellitesFiltered(ctx context.Context, arg ListSatellitesFilteredParams) ([]Satellite, int32, error) {
+func normalizeSortOrder(sort, order string) (string, string) {
 	sortColumn := map[string]string{
 		"id":         "id",
 		"name":       "name",
 		"created_at": "created_at",
 		"updated_at": "updated_at",
 		"last_seen":  "last_seen",
-	}[arg.Sort]
+	}[sort]
 	if sortColumn == "" {
 		sortColumn = "name"
 	}
-
-	order := strings.ToUpper(arg.Order)
-	if order != "DESC" {
-		order = "ASC"
+	orderUpper := strings.ToUpper(order)
+	if orderUpper != "DESC" {
+		orderUpper = "ASC"
 	}
+	return sortColumn, orderUpper
+}
+
+func (q *Queries) ListSatellitesFiltered(ctx context.Context, arg ListSatellitesFilteredParams) ([]Satellite, int32, error) {
+	sortColumn, order := normalizeSortOrder(arg.Sort, arg.Order)
 
 	whereSQL, args := satelliteListWhere(arg)
 	countQuery := "SELECT COUNT(*) FROM satellites" + whereSQL
@@ -85,6 +90,12 @@ func satelliteListWhere(arg ListSatellitesFilteredParams) (string, []any) {
 	if arg.NamePrefix != "" {
 		args = append(args, escapePostgresLikePattern(arg.NamePrefix))
 		clauses = append(clauses, fmt.Sprintf("lower(name) LIKE lower($%d) || '%%' ESCAPE '\\'", len(args)))
+	}
+
+	if len(arg.LabelSelectors) > 0 {
+		clause, extra := labelSelectorClause(arg.LabelSelectors, len(args)+1)
+		args = append(args, extra...)
+		clauses = append(clauses, clause)
 	}
 
 	if len(clauses) == 0 {

--- a/ground-control/internal/database/satellites.sql.go
+++ b/ground-control/internal/database/satellites.sql.go
@@ -148,7 +148,8 @@ func (q *Queries) GetSatellitesByGroupName(ctx context.Context, groupName string
 }
 
 const listSatellites = `-- name: ListSatellites :many
-SELECT id, name, created_at, updated_at, last_seen, heartbeat_interval FROM satellites
+SELECT id, name, created_at, updated_at, last_seen, heartbeat_interval
+FROM PUBLIC.satellites
 ORDER BY name ASC, id ASC
 `
 

--- a/ground-control/internal/database/satellites.sql.go
+++ b/ground-control/internal/database/satellites.sql.go
@@ -149,6 +149,7 @@ func (q *Queries) GetSatellitesByGroupName(ctx context.Context, groupName string
 
 const listSatellites = `-- name: ListSatellites :many
 SELECT id, name, created_at, updated_at, last_seen, heartbeat_interval FROM satellites
+ORDER BY name ASC, id ASC
 `
 
 func (q *Queries) ListSatellites(ctx context.Context) ([]Satellite, error) {

--- a/ground-control/internal/server/label_handlers.go
+++ b/ground-control/internal/server/label_handlers.go
@@ -1,0 +1,140 @@
+package server
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"regexp"
+
+	"github.com/container-registry/harbor-satellite/ground-control/internal/database"
+	"github.com/gorilla/mux"
+)
+
+var labelKeyRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._\-/]*$`)
+
+type patchLabelsRequest map[string]*string
+
+func (s *Server) getLabelsHandler(w http.ResponseWriter, r *http.Request) {
+	sat, ok := s.resolveSatellite(w, r)
+	if !ok {
+		return
+	}
+	labels, err := s.dbQueries.GetLabelsBySatelliteID(r.Context(), sat.ID)
+	if err != nil {
+		log.Printf("Error: Failed to get labels for satellite %s: %v", sat.Name, err)
+		HandleAppError(w, &AppError{Message: "failed to get labels", Code: http.StatusInternalServerError})
+		return
+	}
+	WriteJSONResponse(w, http.StatusOK, labels)
+}
+
+func (s *Server) setLabelsHandler(w http.ResponseWriter, r *http.Request) {
+	sat, ok := s.resolveSatellite(w, r)
+	if !ok {
+		return
+	}
+	var labels map[string]string
+	if err := DecodeRequestBody(r, &labels); err != nil {
+		HandleAppError(w, err)
+		return
+	}
+	if appErr := validateLabels(labels); appErr != nil {
+		HandleAppError(w, appErr)
+		return
+	}
+	if err := s.dbQueries.SetLabels(r.Context(), sat.ID, labels); err != nil {
+		log.Printf("Error: Failed to set labels for satellite %s: %v", sat.Name, err)
+		HandleAppError(w, &AppError{Message: "failed to set labels", Code: http.StatusInternalServerError})
+		return
+	}
+	WriteJSONResponse(w, http.StatusOK, labels)
+}
+
+func (s *Server) patchLabelsHandler(w http.ResponseWriter, r *http.Request) {
+	sat, ok := s.resolveSatellite(w, r)
+	if !ok {
+		return
+	}
+	var patch patchLabelsRequest
+	if err := DecodeRequestBody(r, &patch); err != nil {
+		HandleAppError(w, err)
+		return
+	}
+	if appErr := validatePatch(patch); appErr != nil {
+		HandleAppError(w, appErr)
+		return
+	}
+	if err := s.dbQueries.PatchLabels(r.Context(), sat.ID, map[string]*string(patch)); err != nil {
+		log.Printf("Error: Failed to patch labels for satellite %s: %v", sat.Name, err)
+		HandleAppError(w, &AppError{Message: "failed to patch labels", Code: http.StatusInternalServerError})
+		return
+	}
+	labels, err := s.dbQueries.GetLabelsBySatelliteID(r.Context(), sat.ID)
+	if err != nil {
+		log.Printf("Error: Failed to get labels after patch for satellite %s: %v", sat.Name, err)
+		HandleAppError(w, &AppError{Message: "failed to get labels", Code: http.StatusInternalServerError})
+		return
+	}
+	WriteJSONResponse(w, http.StatusOK, labels)
+}
+
+// resolveSatellite looks up a satellite by the {satellite} mux var.
+func (s *Server) resolveSatellite(w http.ResponseWriter, r *http.Request) (database.Satellite, bool) {
+	name := mux.Vars(r)["satellite"]
+	sat, err := s.dbQueries.GetSatelliteByName(r.Context(), name)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			HandleAppError(w, &AppError{Message: "satellite not found", Code: http.StatusNotFound})
+		} else {
+			log.Printf("Error: Failed to get satellite %s: %v", name, err)
+			HandleAppError(w, &AppError{Message: "failed to get satellite", Code: http.StatusInternalServerError})
+		}
+		return database.Satellite{}, false
+	}
+	return sat, true
+}
+
+func validateLabels(labels map[string]string) *AppError {
+	for k, v := range labels {
+		if err := validateLabelKey(k); err != nil {
+			return &AppError{Message: err.Error(), Code: http.StatusBadRequest}
+		}
+		if err := validateLabelValue(v); err != nil {
+			return &AppError{Message: err.Error(), Code: http.StatusBadRequest}
+		}
+	}
+	return nil
+}
+
+func validatePatch(patch patchLabelsRequest) *AppError {
+	for k, v := range patch {
+		if err := validateLabelKey(k); err != nil {
+			return &AppError{Message: err.Error(), Code: http.StatusBadRequest}
+		}
+		if v != nil {
+			if err := validateLabelValue(*v); err != nil {
+				return &AppError{Message: err.Error(), Code: http.StatusBadRequest}
+			}
+		}
+	}
+	return nil
+}
+
+func validateLabelKey(k string) error {
+	if k == "" || len(k) > 316 {
+		return fmt.Errorf("label key %q: must be 1–316 characters", k)
+	}
+	if !labelKeyRe.MatchString(k) {
+		return fmt.Errorf("label key %q: only alphanumeric, '.', '_', '-', '/' allowed", k)
+	}
+	return nil
+}
+
+func validateLabelValue(v string) error {
+	if len(v) > 63 {
+		return fmt.Errorf("label value exceeds 63 characters")
+	}
+	return nil
+}

--- a/ground-control/internal/server/label_handlers.go
+++ b/ground-control/internal/server/label_handlers.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -11,8 +12,6 @@ import (
 	"github.com/container-registry/harbor-satellite/ground-control/internal/database"
 	"github.com/gorilla/mux"
 )
-
-var labelKeyRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._\-/]*$`)
 
 type patchLabelsRequest map[string]*string
 
@@ -44,7 +43,7 @@ func (s *Server) setLabelsHandler(w http.ResponseWriter, r *http.Request) {
 		HandleAppError(w, appErr)
 		return
 	}
-	if err := s.dbQueries.SetLabels(r.Context(), sat.ID, labels); err != nil {
+	if err := s.replaceLabels(r.Context(), sat.ID, labels); err != nil {
 		log.Printf("Error: Failed to set labels for satellite %s: %v", sat.Name, err)
 		HandleAppError(w, &AppError{Message: "failed to set labels", Code: http.StatusInternalServerError})
 		return
@@ -66,7 +65,7 @@ func (s *Server) patchLabelsHandler(w http.ResponseWriter, r *http.Request) {
 		HandleAppError(w, appErr)
 		return
 	}
-	if err := s.dbQueries.PatchLabels(r.Context(), sat.ID, map[string]*string(patch)); err != nil {
+	if err := s.applyLabelPatch(r.Context(), sat.ID, map[string]*string(patch)); err != nil {
 		log.Printf("Error: Failed to patch labels for satellite %s: %v", sat.Name, err)
 		HandleAppError(w, &AppError{Message: "failed to patch labels", Code: http.StatusInternalServerError})
 		return
@@ -78,6 +77,47 @@ func (s *Server) patchLabelsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	WriteJSONResponse(w, http.StatusOK, labels)
+}
+
+// replaceLabels atomically replaces all labels for a satellite.
+func (s *Server) replaceLabels(ctx context.Context, satelliteID int32, labels map[string]string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+	txQ := s.dbQueries.WithTx(tx)
+	if err := txQ.DeleteLabelsBySatelliteID(ctx, satelliteID); err != nil {
+		return err
+	}
+	for k, v := range labels {
+		if err := txQ.UpsertLabel(ctx, satelliteID, k, v); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// applyLabelPatch atomically applies a patch: nil value removes a key, non-nil upserts.
+func (s *Server) applyLabelPatch(ctx context.Context, satelliteID int32, patch map[string]*string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+	txQ := s.dbQueries.WithTx(tx)
+	for k, v := range patch {
+		if v == nil {
+			if err := txQ.DeleteLabel(ctx, satelliteID, k); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := txQ.UpsertLabel(ctx, satelliteID, k, *v); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
 }
 
 // resolveSatellite looks up a satellite by the {satellite} mux var.
@@ -126,7 +166,8 @@ func validateLabelKey(k string) error {
 	if k == "" || len(k) > 316 {
 		return fmt.Errorf("label key %q: must be 1–316 characters", k)
 	}
-	if !labelKeyRe.MatchString(k) {
+	matched, _ := regexp.MatchString(`^[a-zA-Z0-9][a-zA-Z0-9._\-/]*$`, k)
+	if !matched {
 		return fmt.Errorf("label key %q: only alphanumeric, '.', '_', '-', '/' allowed", k)
 	}
 	return nil

--- a/ground-control/internal/server/label_handlers.go
+++ b/ground-control/internal/server/label_handlers.go
@@ -85,7 +85,13 @@ func (s *Server) replaceLabels(ctx context.Context, satelliteID int32, labels ma
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback() //nolint:errcheck
+	if err := s.runReplaceLabels(ctx, tx, satelliteID, labels); err != nil {
+		return errors.Join(err, tx.Rollback())
+	}
+	return tx.Commit()
+}
+
+func (s *Server) runReplaceLabels(ctx context.Context, tx *sql.Tx, satelliteID int32, labels map[string]string) error {
 	txQ := s.dbQueries.WithTx(tx)
 	if err := txQ.DeleteLabelsBySatelliteID(ctx, satelliteID); err != nil {
 		return err
@@ -95,7 +101,7 @@ func (s *Server) replaceLabels(ctx context.Context, satelliteID int32, labels ma
 			return err
 		}
 	}
-	return tx.Commit()
+	return nil
 }
 
 // applyLabelPatch atomically applies a patch: nil value removes a key, non-nil upserts.
@@ -104,7 +110,13 @@ func (s *Server) applyLabelPatch(ctx context.Context, satelliteID int32, patch m
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback() //nolint:errcheck
+	if err := s.runPatchLabels(ctx, tx, satelliteID, patch); err != nil {
+		return errors.Join(err, tx.Rollback())
+	}
+	return tx.Commit()
+}
+
+func (s *Server) runPatchLabels(ctx context.Context, tx *sql.Tx, satelliteID int32, patch map[string]*string) error {
 	txQ := s.dbQueries.WithTx(tx)
 	for k, v := range patch {
 		if v == nil {
@@ -117,7 +129,7 @@ func (s *Server) applyLabelPatch(ctx context.Context, satelliteID int32, patch m
 			return err
 		}
 	}
-	return tx.Commit()
+	return nil
 }
 
 // resolveSatellite looks up a satellite by the {satellite} mux var.

--- a/ground-control/internal/server/label_handlers.go
+++ b/ground-control/internal/server/label_handlers.go
@@ -176,12 +176,16 @@ func validatePatch(patch patchLabelsRequest) *AppError {
 
 func validateLabelKey(k string) error {
 	if k == "" || len(k) > 316 {
-		return fmt.Errorf("label key %q: must be 1–316 characters", k)
+		return fmt.Errorf("label key %q: must be 1-316 characters", k)
 	}
-	matched, _ := regexp.MatchString(`^[a-zA-Z0-9][a-zA-Z0-9._\-/]*$`, k)
+	matched, err := regexp.MatchString(`^[a-zA-Z0-9][a-zA-Z0-9._/\-]*$`, k)
+	if err != nil {
+		return fmt.Errorf("validate label key: %w", err)
+	}
 	if !matched {
 		return fmt.Errorf("label key %q: only alphanumeric, '.', '_', '-', '/' allowed", k)
 	}
+
 	return nil
 }
 

--- a/ground-control/internal/server/label_handlers_test.go
+++ b/ground-control/internal/server/label_handlers_test.go
@@ -182,11 +182,23 @@ func TestPatchLabelsHandler(t *testing.T) {
 }
 
 func TestParseLabelSelectors(t *testing.T) {
-	t.Run("parses valid selectors", func(t *testing.T) {
+	t.Run("parses equality selectors", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/satellites?label=env%3Dproduction&label=region%3Dus-east", nil)
 		got, appErr := parseLabelSelectors(req.URL.Query())
 		require.Nil(t, appErr)
-		require.Equal(t, map[string]string{"env": "production", "region": "us-east"}, got)
+		require.Len(t, got, 2)
+		require.NotNil(t, got["env"])
+		require.Equal(t, "production", *got["env"])
+		require.NotNil(t, got["region"])
+		require.Equal(t, "us-east", *got["region"])
+	})
+
+	t.Run("parses bare-key existence selector", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites?label=env", nil)
+		got, appErr := parseLabelSelectors(req.URL.Query())
+		require.Nil(t, appErr)
+		require.Len(t, got, 1)
+		require.Nil(t, got["env"]) // nil means "key must exist"
 	})
 
 	t.Run("returns nil when no label params", func(t *testing.T) {
@@ -196,12 +208,12 @@ func TestParseLabelSelectors(t *testing.T) {
 		require.Nil(t, got)
 	})
 
-	t.Run("rejects malformed selector missing equals", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/api/satellites?label=envonly", nil)
+	t.Run("rejects empty key in equality selector", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites?label=%3Dvalue", nil)
 		_, appErr := parseLabelSelectors(req.URL.Query())
 		require.NotNil(t, appErr)
 		require.Equal(t, http.StatusBadRequest, appErr.Code)
-		require.Contains(t, appErr.Message, "key=value")
+		require.Contains(t, appErr.Message, "key must not be empty")
 	})
 }
 

--- a/ground-control/internal/server/label_handlers_test.go
+++ b/ground-control/internal/server/label_handlers_test.go
@@ -1,0 +1,218 @@
+package server
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetLabelsHandler(t *testing.T) {
+	t.Run("returns labels for existing satellite", func(t *testing.T) {
+		server, mock := newMockServer(t)
+		now := time.Now().UTC().Truncate(time.Second)
+
+		satRows := sqlmock.NewRows([]string{"id", "name", "created_at", "updated_at", "last_seen", "heartbeat_interval"}).
+			AddRow(1, "edge-01", now, now, sql.NullTime{}, sql.NullString{})
+		mock.ExpectQuery("SELECT .+ FROM satellites WHERE name").
+			WithArgs("edge-01").
+			WillReturnRows(satRows)
+
+		labelRows := sqlmock.NewRows([]string{"key", "value"}).
+			AddRow("env", "production").
+			AddRow("region", "us-east")
+		mock.ExpectQuery("SELECT key, value FROM satellite_labels").
+			WithArgs(int32(1)).
+			WillReturnRows(labelRows)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites/edge-01/labels", nil)
+		req = mux.SetURLVars(req, map[string]string{"satellite": "edge-01"})
+		rr := httptest.NewRecorder()
+		server.getLabelsHandler(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		var got map[string]string
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+		require.Equal(t, "production", got["env"])
+		require.Equal(t, "us-east", got["region"])
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("returns 404 for unknown satellite", func(t *testing.T) {
+		server, mock := newMockServer(t)
+
+		mock.ExpectQuery("SELECT .+ FROM satellites WHERE name").
+			WithArgs("ghost").
+			WillReturnError(sql.ErrNoRows)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites/ghost/labels", nil)
+		req = mux.SetURLVars(req, map[string]string{"satellite": "ghost"})
+		rr := httptest.NewRecorder()
+		server.getLabelsHandler(rr, req)
+
+		require.Equal(t, http.StatusNotFound, rr.Code)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestSetLabelsHandler(t *testing.T) {
+	t.Run("replaces all labels", func(t *testing.T) {
+		server, mock := newMockServer(t)
+		now := time.Now().UTC().Truncate(time.Second)
+
+		satRows := sqlmock.NewRows([]string{"id", "name", "created_at", "updated_at", "last_seen", "heartbeat_interval"}).
+			AddRow(1, "edge-01", now, now, sql.NullTime{}, sql.NullString{})
+		mock.ExpectQuery("SELECT .+ FROM satellites WHERE name").
+			WithArgs("edge-01").
+			WillReturnRows(satRows)
+
+		mock.ExpectBegin()
+		mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM satellite_labels WHERE satellite_id = $1`)).
+			WithArgs(int32(1)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO satellite_labels (satellite_id, key, value) VALUES ($1, $2, $3)`)).
+			WithArgs(int32(1), "env", "staging").
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectCommit()
+
+		body, _ := json.Marshal(map[string]string{"env": "staging"})
+		req := httptest.NewRequest(http.MethodPut, "/api/satellites/edge-01/labels", bytes.NewReader(body))
+		req = mux.SetURLVars(req, map[string]string{"satellite": "edge-01"})
+		rr := httptest.NewRecorder()
+		server.setLabelsHandler(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		var got map[string]string
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+		require.Equal(t, "staging", got["env"])
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("rejects invalid label key", func(t *testing.T) {
+		server, mock := newMockServer(t)
+		now := time.Now().UTC().Truncate(time.Second)
+
+		satRows := sqlmock.NewRows([]string{"id", "name", "created_at", "updated_at", "last_seen", "heartbeat_interval"}).
+			AddRow(1, "edge-01", now, now, sql.NullTime{}, sql.NullString{})
+		mock.ExpectQuery("SELECT .+ FROM satellites WHERE name").
+			WithArgs("edge-01").
+			WillReturnRows(satRows)
+
+		body, _ := json.Marshal(map[string]string{"bad key!": "val"})
+		req := httptest.NewRequest(http.MethodPut, "/api/satellites/edge-01/labels", bytes.NewReader(body))
+		req = mux.SetURLVars(req, map[string]string{"satellite": "edge-01"})
+		rr := httptest.NewRecorder()
+		server.setLabelsHandler(rr, req)
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+		require.Contains(t, rr.Body.String(), "label key")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("rejects value exceeding 63 characters", func(t *testing.T) {
+		server, mock := newMockServer(t)
+		now := time.Now().UTC().Truncate(time.Second)
+
+		satRows := sqlmock.NewRows([]string{"id", "name", "created_at", "updated_at", "last_seen", "heartbeat_interval"}).
+			AddRow(1, "edge-01", now, now, sql.NullTime{}, sql.NullString{})
+		mock.ExpectQuery("SELECT .+ FROM satellites WHERE name").
+			WithArgs("edge-01").
+			WillReturnRows(satRows)
+
+		longVal := make([]byte, 64)
+		for i := range longVal {
+			longVal[i] = 'a'
+		}
+		body, _ := json.Marshal(map[string]string{"env": string(longVal)})
+		req := httptest.NewRequest(http.MethodPut, "/api/satellites/edge-01/labels", bytes.NewReader(body))
+		req = mux.SetURLVars(req, map[string]string{"satellite": "edge-01"})
+		rr := httptest.NewRecorder()
+		server.setLabelsHandler(rr, req)
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+		require.Contains(t, rr.Body.String(), "63")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestPatchLabelsHandler(t *testing.T) {
+	t.Run("adds and removes labels", func(t *testing.T) {
+		server, mock := newMockServer(t)
+		now := time.Now().UTC().Truncate(time.Second)
+
+		satRows := sqlmock.NewRows([]string{"id", "name", "created_at", "updated_at", "last_seen", "heartbeat_interval"}).
+			AddRow(1, "edge-01", now, now, sql.NullTime{}, sql.NullString{})
+		mock.ExpectQuery("SELECT .+ FROM satellites WHERE name").
+			WithArgs("edge-01").
+			WillReturnRows(satRows)
+
+		mock.ExpectBegin()
+		mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM satellite_labels WHERE satellite_id = $1 AND key = $2`)).
+			WithArgs(int32(1), "old-key").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectCommit()
+
+		labelRows := sqlmock.NewRows([]string{"key", "value"}).
+			AddRow("env", "production")
+		mock.ExpectQuery("SELECT key, value FROM satellite_labels").
+			WithArgs(int32(1)).
+			WillReturnRows(labelRows)
+
+		val := (*string)(nil)
+		body, _ := json.Marshal(map[string]*string{"old-key": val})
+		req := httptest.NewRequest(http.MethodPatch, "/api/satellites/edge-01/labels", bytes.NewReader(body))
+		req = mux.SetURLVars(req, map[string]string{"satellite": "edge-01"})
+		rr := httptest.NewRecorder()
+		server.patchLabelsHandler(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		var got map[string]string
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+		require.Equal(t, "production", got["env"])
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestParseLabelSelectors(t *testing.T) {
+	t.Run("parses valid selectors", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites?label=env%3Dproduction&label=region%3Dus-east", nil)
+		got, appErr := parseLabelSelectors(req.URL.Query())
+		require.Nil(t, appErr)
+		require.Equal(t, map[string]string{"env": "production", "region": "us-east"}, got)
+	})
+
+	t.Run("returns nil when no label params", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites", nil)
+		got, appErr := parseLabelSelectors(req.URL.Query())
+		require.Nil(t, appErr)
+		require.Nil(t, got)
+	})
+
+	t.Run("rejects malformed selector missing equals", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites?label=envonly", nil)
+		_, appErr := parseLabelSelectors(req.URL.Query())
+		require.NotNil(t, appErr)
+		require.Equal(t, http.StatusBadRequest, appErr.Code)
+		require.Contains(t, appErr.Message, "key=value")
+	})
+}
+
+func TestValidateLabelKey(t *testing.T) {
+	valid := []string{"env", "app.io/name", "region-1", "a", "prefix/suffix"}
+	for _, k := range valid {
+		require.NoError(t, validateLabelKey(k), "expected valid: %s", k)
+	}
+
+	invalid := []string{"", "bad key", "key!", "has space"}
+	for _, k := range invalid {
+		require.Error(t, validateLabelKey(k), "expected invalid: %s", k)
+	}
+}

--- a/ground-control/internal/server/routes.go
+++ b/ground-control/internal/server/routes.go
@@ -61,6 +61,9 @@ func (s *Server) RegisterRoutes() http.Handler {
 	api.HandleFunc("/satellites/{satellite}", s.DeleteSatelliteByName).Methods("DELETE")
 	api.HandleFunc("/satellites/{satellite}/status", s.getSatelliteStatusHandler).Methods("GET")
 	api.HandleFunc("/satellites/{satellite}/images", s.getCachedImagesHandler).Methods("GET")
+	api.HandleFunc("/satellites/{satellite}/labels", s.getLabelsHandler).Methods("GET")
+	api.HandleFunc("/satellites/{satellite}/labels", s.setLabelsHandler).Methods("PUT")
+	api.HandleFunc("/satellites/{satellite}/labels", s.patchLabelsHandler).Methods("PATCH")
 
 	// SPIRE management (admin only)
 	api.HandleFunc("/spire/status", s.RequireRole(roleSystemAdmin, s.spireStatusHandler)).Methods("GET")

--- a/ground-control/internal/server/satellite_handlers.go
+++ b/ground-control/internal/server/satellite_handlers.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log"
@@ -54,8 +55,13 @@ type SatelliteStatusParams struct {
 	CachedImages        []CachedImage `json:"cached_images,omitempty"`
 }
 
+type SatelliteListItem struct {
+	database.Satellite
+	Labels map[string]string `json:"labels"`
+}
+
 type SatelliteListResponse struct {
-	Satellites []database.Satellite  `json:"satellites"`
+	Satellites []SatelliteListItem   `json:"satellites"`
 	Pagination SatelliteListPageInfo `json:"pagination"`
 }
 
@@ -570,8 +576,14 @@ func (s *Server) listSatelliteHandler(w http.ResponseWriter, r *http.Request) {
 			HandleAppError(w, &AppError{Message: "Error: Failed to List Satellites", Code: http.StatusInternalServerError})
 			return
 		}
+		items, err := s.enrichWithLabels(r.Context(), satellites)
+		if err != nil {
+			log.Printf("Error: Failed to enrich satellites with labels: %v", err)
+			HandleAppError(w, &AppError{Message: "Error: Failed to List Satellites", Code: http.StatusInternalServerError})
+			return
+		}
 		WriteJSONResponse(w, http.StatusOK, SatelliteListResponse{
-			Satellites: satellites,
+			Satellites: items,
 			Pagination: SatelliteListPageInfo{Limit: params.Limit, Offset: params.Offset, Total: total},
 		})
 		return
@@ -583,10 +595,39 @@ func (s *Server) listSatelliteHandler(w http.ResponseWriter, r *http.Request) {
 		HandleAppError(w, &AppError{Message: "Error: Failed to List Satellites", Code: http.StatusInternalServerError})
 		return
 	}
+	items, err := s.enrichWithLabels(r.Context(), result)
+	if err != nil {
+		log.Printf("Error: Failed to enrich satellites with labels: %v", err)
+		HandleAppError(w, &AppError{Message: "Error: Failed to List Satellites", Code: http.StatusInternalServerError})
+		return
+	}
 	WriteJSONResponse(w, http.StatusOK, SatelliteListResponse{
-		Satellites: result,
+		Satellites: items,
 		Pagination: SatelliteListPageInfo{Total: int32(len(result))},
 	})
+}
+
+func (s *Server) enrichWithLabels(ctx context.Context, sats []database.Satellite) ([]SatelliteListItem, error) {
+	if len(sats) == 0 {
+		return []SatelliteListItem{}, nil
+	}
+	ids := make([]int32, len(sats))
+	for i, sat := range sats {
+		ids[i] = sat.ID
+	}
+	labelMap, err := s.dbQueries.GetLabelsByIDs(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	items := make([]SatelliteListItem, len(sats))
+	for i, sat := range sats {
+		labels := labelMap[sat.ID]
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		items[i] = SatelliteListItem{Satellite: sat, Labels: labels}
+	}
+	return items, nil
 }
 
 func parseLimitParam(query url.Values) (int32, *AppError) {

--- a/ground-control/internal/server/satellite_handlers.go
+++ b/ground-control/internal/server/satellite_handlers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -600,11 +601,59 @@ func (s *Server) listSatelliteHandler(w http.ResponseWriter, r *http.Request) {
 	WriteJSONResponse(w, http.StatusOK, result)
 }
 
+func parseLimitParam(query url.Values) (int32, *AppError) {
+	raw := strings.TrimSpace(query.Get("limit"))
+	if raw == "" {
+		return 100, nil
+	}
+	parsed, err := strconv.ParseInt(raw, 10, 32)
+	if err != nil || parsed < 1 || parsed > 500 {
+		return 0, &AppError{Message: "limit must be between 1 and 500", Code: http.StatusBadRequest}
+	}
+	return int32(parsed), nil
+}
+
+func parseOffsetParam(query url.Values) (int32, *AppError) {
+	raw := strings.TrimSpace(query.Get("offset"))
+	if raw == "" {
+		return 0, nil
+	}
+	parsed, err := strconv.ParseInt(raw, 10, 32)
+	if err != nil || parsed < 0 {
+		return 0, &AppError{Message: "offset must be greater than or equal to 0", Code: http.StatusBadRequest}
+	}
+	return int32(parsed), nil
+}
+
+func parseSortParam(query url.Values) (string, *AppError) {
+	sort := strings.TrimSpace(query.Get("sort"))
+	if sort == "" {
+		return "name", nil
+	}
+	switch sort {
+	case "id", "name", "created_at", "updated_at", "last_seen":
+		return sort, nil
+	default:
+		return "", &AppError{Message: "sort must be one of id, name, created_at, updated_at, last_seen", Code: http.StatusBadRequest}
+	}
+}
+
+func parseOrderParam(query url.Values) (string, *AppError) {
+	order := strings.ToLower(strings.TrimSpace(query.Get("order")))
+	if order == "" {
+		return "asc", nil
+	}
+	if order != "asc" && order != "desc" {
+		return "", &AppError{Message: "order must be asc or desc", Code: http.StatusBadRequest}
+	}
+	return order, nil
+}
+
 func parseSatelliteListQuery(r *http.Request) (database.ListSatellitesFilteredParams, *AppError) {
 	query := r.URL.Query()
 	for key := range query {
 		switch key {
-		case "limit", "offset", "sort", "order", "name_prefix":
+		case "limit", "offset", "sort", "order", "name_prefix", "label":
 		default:
 			return database.ListSatellitesFilteredParams{}, &AppError{
 				Message: "unsupported query parameter: " + key,
@@ -613,61 +662,54 @@ func parseSatelliteListQuery(r *http.Request) (database.ListSatellitesFilteredPa
 		}
 	}
 
-	limit := int32(100)
-	if rawLimit := strings.TrimSpace(query.Get("limit")); rawLimit != "" {
-		parsed, err := strconv.ParseInt(rawLimit, 10, 32)
-		if err != nil || parsed < 1 || parsed > 500 {
-			return database.ListSatellitesFilteredParams{}, &AppError{
-				Message: "limit must be between 1 and 500",
-				Code:    http.StatusBadRequest,
-			}
-		}
-		limit = int32(parsed)
+	limit, appErr := parseLimitParam(query)
+	if appErr != nil {
+		return database.ListSatellitesFilteredParams{}, appErr
 	}
-
-	offset := int32(0)
-	if rawOffset := strings.TrimSpace(query.Get("offset")); rawOffset != "" {
-		parsed, err := strconv.ParseInt(rawOffset, 10, 32)
-		if err != nil || parsed < 0 {
-			return database.ListSatellitesFilteredParams{}, &AppError{
-				Message: "offset must be greater than or equal to 0",
-				Code:    http.StatusBadRequest,
-			}
-		}
-		offset = int32(parsed)
+	offset, appErr := parseOffsetParam(query)
+	if appErr != nil {
+		return database.ListSatellitesFilteredParams{}, appErr
 	}
-
-	sort := strings.TrimSpace(query.Get("sort"))
-	if sort == "" {
-		sort = "name"
+	sort, appErr := parseSortParam(query)
+	if appErr != nil {
+		return database.ListSatellitesFilteredParams{}, appErr
 	}
-	switch sort {
-	case "id", "name", "created_at", "updated_at", "last_seen":
-	default:
-		return database.ListSatellitesFilteredParams{}, &AppError{
-			Message: "sort must be one of id, name, created_at, updated_at, last_seen",
-			Code:    http.StatusBadRequest,
-		}
+	order, appErr := parseOrderParam(query)
+	if appErr != nil {
+		return database.ListSatellitesFilteredParams{}, appErr
 	}
-
-	order := strings.ToLower(strings.TrimSpace(query.Get("order")))
-	if order == "" {
-		order = "asc"
-	}
-	if order != "asc" && order != "desc" {
-		return database.ListSatellitesFilteredParams{}, &AppError{
-			Message: "order must be asc or desc",
-			Code:    http.StatusBadRequest,
-		}
+	labelSelectors, appErr := parseLabelSelectors(query)
+	if appErr != nil {
+		return database.ListSatellitesFilteredParams{}, appErr
 	}
 
 	return database.ListSatellitesFilteredParams{
-		Limit:      limit,
-		Offset:     offset,
-		Sort:       sort,
-		Order:      order,
-		NamePrefix: strings.TrimSpace(query.Get("name_prefix")),
+		Limit:          limit,
+		Offset:         offset,
+		Sort:           sort,
+		Order:          order,
+		NamePrefix:     strings.TrimSpace(query.Get("name_prefix")),
+		LabelSelectors: labelSelectors,
 	}, nil
+}
+
+func parseLabelSelectors(query url.Values) (map[string]string, *AppError) {
+	rawLabels := query["label"]
+	if len(rawLabels) == 0 {
+		return nil, nil
+	}
+	selectors := make(map[string]string, len(rawLabels))
+	for _, raw := range rawLabels {
+		k, v, ok := strings.Cut(raw, "=")
+		if !ok || k == "" {
+			return nil, &AppError{
+				Message: fmt.Sprintf("invalid label selector %q: expected key=value", raw),
+				Code:    http.StatusBadRequest,
+			}
+		}
+		selectors[k] = v
+	}
+	return selectors, nil
 }
 
 func (s *Server) syncHandler(w http.ResponseWriter, r *http.Request) {

--- a/ground-control/internal/server/satellite_handlers.go
+++ b/ground-control/internal/server/satellite_handlers.go
@@ -602,6 +602,16 @@ func (s *Server) listSatelliteHandler(w http.ResponseWriter, r *http.Request) {
 
 func parseSatelliteListQuery(r *http.Request) (database.ListSatellitesFilteredParams, *AppError) {
 	query := r.URL.Query()
+	for key := range query {
+		switch key {
+		case "limit", "offset", "sort", "order", "name_prefix":
+		default:
+			return database.ListSatellitesFilteredParams{}, &AppError{
+				Message: "unsupported query parameter: " + key,
+				Code:    http.StatusBadRequest,
+			}
+		}
+	}
 
 	limit := int32(100)
 	if rawLimit := strings.TrimSpace(query.Get("limit")); rawLimit != "" {

--- a/ground-control/internal/server/satellite_handlers.go
+++ b/ground-control/internal/server/satellite_handlers.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/container-registry/harbor-satellite/ground-control/internal/database"
@@ -50,6 +51,17 @@ type SatelliteStatusParams struct {
 	LastSyncDurationMs  int64         `json:"last_sync_duration_ms"`
 	ImageCount          int           `json:"image_count"`
 	CachedImages        []CachedImage `json:"cached_images,omitempty"`
+}
+
+type SatelliteListResponse struct {
+	Satellites []database.Satellite  `json:"satellites"`
+	Pagination SatelliteListPageInfo `json:"pagination"`
+}
+
+type SatelliteListPageInfo struct {
+	Limit  int32 `json:"limit"`
+	Offset int32 `json:"offset"`
+	Total  int32 `json:"total"`
 }
 
 func (s *Server) registerSatelliteHandler(w http.ResponseWriter, r *http.Request) {
@@ -545,6 +557,35 @@ func (s *Server) spiffeZtrHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listSatelliteHandler(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	if len(query) > 0 {
+		params, err := parseSatelliteListQuery(r)
+		if err != nil {
+			HandleAppError(w, err)
+			return
+		}
+
+		satellites, total, err := s.dbQueries.ListSatellitesFiltered(r.Context(), params)
+		if err != nil {
+			log.Printf("Error: Failed to List Satellites: %v", err)
+			HandleAppError(w, &AppError{
+				Message: "Error: Failed to List Satellites",
+				Code:    http.StatusInternalServerError,
+			})
+			return
+		}
+
+		WriteJSONResponse(w, http.StatusOK, SatelliteListResponse{
+			Satellites: satellites,
+			Pagination: SatelliteListPageInfo{
+				Limit:  params.Limit,
+				Offset: params.Offset,
+				Total:  total,
+			},
+		})
+		return
+	}
+
 	result, err := s.dbQueries.ListSatellites(r.Context())
 	if err != nil {
 		log.Printf("Error: Failed to List Satellites: %v", err)
@@ -557,6 +598,66 @@ func (s *Server) listSatelliteHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	WriteJSONResponse(w, http.StatusOK, result)
+}
+
+func parseSatelliteListQuery(r *http.Request) (database.ListSatellitesFilteredParams, *AppError) {
+	query := r.URL.Query()
+
+	limit := int32(100)
+	if rawLimit := strings.TrimSpace(query.Get("limit")); rawLimit != "" {
+		parsed, err := strconv.ParseInt(rawLimit, 10, 32)
+		if err != nil || parsed < 1 || parsed > 500 {
+			return database.ListSatellitesFilteredParams{}, &AppError{
+				Message: "limit must be between 1 and 500",
+				Code:    http.StatusBadRequest,
+			}
+		}
+		limit = int32(parsed)
+	}
+
+	offset := int32(0)
+	if rawOffset := strings.TrimSpace(query.Get("offset")); rawOffset != "" {
+		parsed, err := strconv.ParseInt(rawOffset, 10, 32)
+		if err != nil || parsed < 0 {
+			return database.ListSatellitesFilteredParams{}, &AppError{
+				Message: "offset must be greater than or equal to 0",
+				Code:    http.StatusBadRequest,
+			}
+		}
+		offset = int32(parsed)
+	}
+
+	sort := strings.TrimSpace(query.Get("sort"))
+	if sort == "" {
+		sort = "name"
+	}
+	switch sort {
+	case "id", "name", "created_at", "updated_at", "last_seen":
+	default:
+		return database.ListSatellitesFilteredParams{}, &AppError{
+			Message: "sort must be one of id, name, created_at, updated_at, last_seen",
+			Code:    http.StatusBadRequest,
+		}
+	}
+
+	order := strings.ToLower(strings.TrimSpace(query.Get("order")))
+	if order == "" {
+		order = "asc"
+	}
+	if order != "asc" && order != "desc" {
+		return database.ListSatellitesFilteredParams{}, &AppError{
+			Message: "order must be asc or desc",
+			Code:    http.StatusBadRequest,
+		}
+	}
+
+	return database.ListSatellitesFilteredParams{
+		Limit:      limit,
+		Offset:     offset,
+		Sort:       sort,
+		Order:      order,
+		NamePrefix: strings.TrimSpace(query.Get("name_prefix")),
+	}, nil
 }
 
 func (s *Server) syncHandler(w http.ResponseWriter, r *http.Request) {

--- a/ground-control/internal/server/satellite_handlers.go
+++ b/ground-control/internal/server/satellite_handlers.go
@@ -558,31 +558,21 @@ func (s *Server) spiffeZtrHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listSatelliteHandler(w http.ResponseWriter, r *http.Request) {
-	query := r.URL.Query()
-	if len(query) > 0 {
-		params, err := parseSatelliteListQuery(r)
-		if err != nil {
-			HandleAppError(w, err)
+	if len(r.URL.Query()) > 0 {
+		params, appErr := parseSatelliteListQuery(r)
+		if appErr != nil {
+			HandleAppError(w, appErr)
 			return
 		}
-
 		satellites, total, err := s.dbQueries.ListSatellitesFiltered(r.Context(), params)
 		if err != nil {
 			log.Printf("Error: Failed to List Satellites: %v", err)
-			HandleAppError(w, &AppError{
-				Message: "Error: Failed to List Satellites",
-				Code:    http.StatusInternalServerError,
-			})
+			HandleAppError(w, &AppError{Message: "Error: Failed to List Satellites", Code: http.StatusInternalServerError})
 			return
 		}
-
 		WriteJSONResponse(w, http.StatusOK, SatelliteListResponse{
 			Satellites: satellites,
-			Pagination: SatelliteListPageInfo{
-				Limit:  params.Limit,
-				Offset: params.Offset,
-				Total:  total,
-			},
+			Pagination: SatelliteListPageInfo{Limit: params.Limit, Offset: params.Offset, Total: total},
 		})
 		return
 	}
@@ -590,15 +580,13 @@ func (s *Server) listSatelliteHandler(w http.ResponseWriter, r *http.Request) {
 	result, err := s.dbQueries.ListSatellites(r.Context())
 	if err != nil {
 		log.Printf("Error: Failed to List Satellites: %v", err)
-		err := &AppError{
-			Message: "Error: Failed to List Satellites",
-			Code:    http.StatusInternalServerError,
-		}
-		HandleAppError(w, err)
+		HandleAppError(w, &AppError{Message: "Error: Failed to List Satellites", Code: http.StatusInternalServerError})
 		return
 	}
-
-	WriteJSONResponse(w, http.StatusOK, result)
+	WriteJSONResponse(w, http.StatusOK, SatelliteListResponse{
+		Satellites: result,
+		Pagination: SatelliteListPageInfo{Total: int32(len(result))},
+	})
 }
 
 func parseLimitParam(query url.Values) (int32, *AppError) {
@@ -689,25 +677,36 @@ func parseSatelliteListQuery(r *http.Request) (database.ListSatellitesFilteredPa
 		Sort:           sort,
 		Order:          order,
 		NamePrefix:     strings.TrimSpace(query.Get("name_prefix")),
-		LabelSelectors: labelSelectors,
+		LabelSelectors: labelSelectors, // map[string]*string; nil value = existence check
 	}, nil
 }
 
-func parseLabelSelectors(query url.Values) (map[string]string, *AppError) {
+func parseLabelSelectors(query url.Values) (map[string]*string, *AppError) {
 	rawLabels := query["label"]
 	if len(rawLabels) == 0 {
 		return nil, nil
 	}
-	selectors := make(map[string]string, len(rawLabels))
+	selectors := make(map[string]*string, len(rawLabels))
 	for _, raw := range rawLabels {
-		k, v, ok := strings.Cut(raw, "=")
-		if !ok || k == "" {
-			return nil, &AppError{
-				Message: fmt.Sprintf("invalid label selector %q: expected key=value", raw),
-				Code:    http.StatusBadRequest,
+		if k, v, ok := strings.Cut(raw, "="); ok {
+			if k == "" {
+				return nil, &AppError{
+					Message: fmt.Sprintf("invalid label selector %q: key must not be empty", raw),
+					Code:    http.StatusBadRequest,
+				}
 			}
+			val := v
+			selectors[k] = &val
+		} else {
+			// bare key: existence selector (label=env means "env key must exist")
+			if raw == "" {
+				return nil, &AppError{
+					Message: "invalid label selector: key must not be empty",
+					Code:    http.StatusBadRequest,
+				}
+			}
+			selectors[raw] = nil
 		}
-		selectors[k] = v
 	}
 	return selectors, nil
 }

--- a/ground-control/internal/server/satellite_listing_test.go
+++ b/ground-control/internal/server/satellite_listing_test.go
@@ -24,7 +24,7 @@ func TestListSatelliteHandler(t *testing.T) {
 		rows := sqlmock.NewRows([]string{"id", "name", "created_at", "updated_at", "last_seen", "heartbeat_interval"}).
 			AddRow(1, "edge-01", now, now, sql.NullTime{Time: now, Valid: true}, sql.NullString{String: "30s", Valid: true}).
 			AddRow(2, "edge-02", now, now, sql.NullTime{}, sql.NullString{})
-		mock.ExpectQuery("SELECT .+ FROM satellites").WillReturnRows(rows)
+		mock.ExpectQuery(`(?s)SELECT .+FROM PUBLIC\.satellites`).WillReturnRows(rows)
 		mock.ExpectQuery("SELECT .+ FROM satellite_labels WHERE satellite_id = ANY").
 			WillReturnRows(sqlmock.NewRows([]string{"satellite_id", "key", "value"}))
 
@@ -46,7 +46,7 @@ func TestListSatelliteHandler(t *testing.T) {
 		server, mock := newMockServer(t)
 
 		rows := sqlmock.NewRows([]string{"id", "name", "created_at", "updated_at", "last_seen", "heartbeat_interval"})
-		mock.ExpectQuery("SELECT .+ FROM satellites").WillReturnRows(rows)
+		mock.ExpectQuery(`(?s)SELECT .+FROM PUBLIC\.satellites`).WillReturnRows(rows)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/satellites", nil)
 		rr := httptest.NewRecorder()
@@ -59,7 +59,7 @@ func TestListSatelliteHandler(t *testing.T) {
 	t.Run("db error returns 500", func(t *testing.T) {
 		server, mock := newMockServer(t)
 
-		mock.ExpectQuery("SELECT .+ FROM satellites").WillReturnError(fmt.Errorf("db error"))
+		mock.ExpectQuery(`(?s)SELECT .+FROM PUBLIC\.satellites`).WillReturnError(fmt.Errorf("db error"))
 
 		req := httptest.NewRequest(http.MethodGet, "/api/satellites", nil)
 		rr := httptest.NewRecorder()

--- a/ground-control/internal/server/satellite_listing_test.go
+++ b/ground-control/internal/server/satellite_listing_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 	"time"
 
@@ -65,17 +66,20 @@ func TestListSatelliteHandler(t *testing.T) {
 		server, mock := newMockServer(t)
 		now := time.Now().UTC().Truncate(time.Second)
 
-		mock.ExpectQuery(`SELECT COUNT\(\*\) FROM satellites WHERE lower\(name\) LIKE lower\(\$1\) \|\| '%'`).
-			WithArgs("edge").
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*) FROM satellites WHERE lower(name) LIKE lower($1) || '%' ESCAPE '\'`)).
+			WithArgs(`edge\_\%`).
 			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
 
 		rows := sqlmock.NewRows([]string{"id", "name", "created_at", "updated_at", "last_seen", "heartbeat_interval"}).
 			AddRow(2, "edge-02", now, now, sql.NullTime{}, sql.NullString{})
-		mock.ExpectQuery("SELECT .+ FROM satellites").
-			WithArgs("edge", int32(1), int32(1)).
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, name, created_at, updated_at, last_seen, heartbeat_interval
+FROM satellites WHERE lower(name) LIKE lower($1) || '%' ESCAPE '\'
+ORDER BY name ASC, id ASC
+LIMIT $2 OFFSET $3`)).
+			WithArgs(`edge\_\%`, int32(1), int32(1)).
 			WillReturnRows(rows)
 
-		req := httptest.NewRequest(http.MethodGet, "/api/satellites?limit=1&offset=1&name_prefix=edge&sort=name&order=asc", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites?limit=1&offset=1&name_prefix=edge_%&sort=name&order=asc", nil)
 		rr := httptest.NewRecorder()
 		server.listSatelliteHandler(rr, req)
 
@@ -84,6 +88,43 @@ func TestListSatelliteHandler(t *testing.T) {
 		require.Contains(t, rr.Body.String(), `"limit":1`)
 		require.Contains(t, rr.Body.String(), `"offset":1`)
 		require.Contains(t, rr.Body.String(), `"total":2`)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("returns empty array for filtered paginated satellites with no matches", func(t *testing.T) {
+		server, mock := newMockServer(t)
+
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*) FROM satellites WHERE lower(name) LIKE lower($1) || '%' ESCAPE '\'`)).
+			WithArgs("unknown").
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+		rows := sqlmock.NewRows([]string{"id", "name", "created_at", "updated_at", "last_seen", "heartbeat_interval"})
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, name, created_at, updated_at, last_seen, heartbeat_interval
+FROM satellites WHERE lower(name) LIKE lower($1) || '%' ESCAPE '\'
+ORDER BY name ASC, id ASC
+LIMIT $2 OFFSET $3`)).
+			WithArgs("unknown", int32(100), int32(0)).
+			WillReturnRows(rows)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites?name_prefix=unknown", nil)
+		rr := httptest.NewRecorder()
+		server.listSatelliteHandler(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		require.Contains(t, rr.Body.String(), `"satellites":[]`)
+		require.Contains(t, rr.Body.String(), `"total":0`)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("rejects unsupported query parameter", func(t *testing.T) {
+		server, mock := newMockServer(t)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites?foo=bar", nil)
+		rr := httptest.NewRecorder()
+		server.listSatelliteHandler(rr, req)
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+		require.Contains(t, rr.Body.String(), "unsupported query parameter: foo")
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 

--- a/ground-control/internal/server/satellite_listing_test.go
+++ b/ground-control/internal/server/satellite_listing_test.go
@@ -60,6 +60,56 @@ func TestListSatelliteHandler(t *testing.T) {
 		require.Equal(t, http.StatusInternalServerError, rr.Code)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
+
+	t.Run("returns filtered paginated satellites", func(t *testing.T) {
+		server, mock := newMockServer(t)
+		now := time.Now().UTC().Truncate(time.Second)
+
+		mock.ExpectQuery(`SELECT COUNT\(\*\) FROM satellites WHERE lower\(name\) LIKE lower\(\$1\) \|\| '%'`).
+			WithArgs("edge").
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+
+		rows := sqlmock.NewRows([]string{"id", "name", "created_at", "updated_at", "last_seen", "heartbeat_interval"}).
+			AddRow(2, "edge-02", now, now, sql.NullTime{}, sql.NullString{})
+		mock.ExpectQuery("SELECT .+ FROM satellites").
+			WithArgs("edge", int32(1), int32(1)).
+			WillReturnRows(rows)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites?limit=1&offset=1&name_prefix=edge&sort=name&order=asc", nil)
+		rr := httptest.NewRecorder()
+		server.listSatelliteHandler(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		require.Contains(t, rr.Body.String(), "edge-02")
+		require.Contains(t, rr.Body.String(), `"limit":1`)
+		require.Contains(t, rr.Body.String(), `"offset":1`)
+		require.Contains(t, rr.Body.String(), `"total":2`)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("rejects invalid limit", func(t *testing.T) {
+		server, mock := newMockServer(t)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites?limit=0", nil)
+		rr := httptest.NewRecorder()
+		server.listSatelliteHandler(rr, req)
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+		require.Contains(t, rr.Body.String(), "limit must be between 1 and 500")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("rejects invalid sort", func(t *testing.T) {
+		server, mock := newMockServer(t)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites?sort=token", nil)
+		rr := httptest.NewRecorder()
+		server.listSatelliteHandler(rr, req)
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+		require.Contains(t, rr.Body.String(), "sort must be one of")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
 }
 
 func TestGetActiveSatellitesHandler(t *testing.T) {

--- a/ground-control/internal/server/satellite_listing_test.go
+++ b/ground-control/internal/server/satellite_listing_test.go
@@ -33,15 +33,12 @@ func TestListSatelliteHandler(t *testing.T) {
 		server.listSatelliteHandler(rr, req)
 
 		require.Equal(t, http.StatusOK, rr.Code)
-		var got struct {
-			Satellites []map[string]any `json:"satellites"`
-			Pagination map[string]any   `json:"pagination"`
-		}
-		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
-		require.Len(t, got.Satellites, 2)
-		require.Equal(t, "edge-01", got.Satellites[0]["Name"])
-		require.Equal(t, "edge-02", got.Satellites[1]["Name"])
-		require.NotNil(t, got.Pagination)
+		var resp SatelliteListResponse
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+		require.Len(t, resp.Satellites, 2)
+		require.Equal(t, "edge-01", resp.Satellites[0].Name)
+		require.Equal(t, "edge-02", resp.Satellites[1].Name)
+		require.Equal(t, int32(2), resp.Pagination.Total)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
@@ -96,10 +93,12 @@ LIMIT $2 OFFSET $3`)).
 		server.listSatelliteHandler(rr, req)
 
 		require.Equal(t, http.StatusOK, rr.Code)
-		require.Contains(t, rr.Body.String(), "edge-02")
-		require.Contains(t, rr.Body.String(), `"limit":1`)
-		require.Contains(t, rr.Body.String(), `"offset":1`)
-		require.Contains(t, rr.Body.String(), `"total":2`)
+		var resp SatelliteListResponse
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+		require.Len(t, resp.Satellites, 1)
+		require.Equal(t, int32(1), resp.Pagination.Limit)
+		require.Equal(t, int32(1), resp.Pagination.Offset)
+		require.Equal(t, int32(2), resp.Pagination.Total)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
@@ -123,8 +122,10 @@ LIMIT $2 OFFSET $3`)).
 		server.listSatelliteHandler(rr, req)
 
 		require.Equal(t, http.StatusOK, rr.Code)
-		require.Contains(t, rr.Body.String(), `"satellites":[]`)
-		require.Contains(t, rr.Body.String(), `"total":0`)
+		var resp SatelliteListResponse
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+		require.Empty(t, resp.Satellites)
+		require.Equal(t, int32(0), resp.Pagination.Total)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 

--- a/ground-control/internal/server/satellite_listing_test.go
+++ b/ground-control/internal/server/satellite_listing_test.go
@@ -31,11 +31,15 @@ func TestListSatelliteHandler(t *testing.T) {
 		server.listSatelliteHandler(rr, req)
 
 		require.Equal(t, http.StatusOK, rr.Code)
-		var got []map[string]any
+		var got struct {
+			Satellites []map[string]any `json:"satellites"`
+			Pagination map[string]any   `json:"pagination"`
+		}
 		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
-		require.Len(t, got, 2)
-		require.Equal(t, "edge-01", got[0]["name"])
-		require.Equal(t, "edge-02", got[1]["name"])
+		require.Len(t, got.Satellites, 2)
+		require.Equal(t, "edge-01", got.Satellites[0]["Name"])
+		require.Equal(t, "edge-02", got.Satellites[1]["Name"])
+		require.NotNil(t, got.Pagination)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 

--- a/ground-control/internal/server/satellite_listing_test.go
+++ b/ground-control/internal/server/satellite_listing_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -30,8 +31,11 @@ func TestListSatelliteHandler(t *testing.T) {
 		server.listSatelliteHandler(rr, req)
 
 		require.Equal(t, http.StatusOK, rr.Code)
-		require.Contains(t, rr.Body.String(), "edge-01")
-		require.Contains(t, rr.Body.String(), "edge-02")
+		var got []map[string]any
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+		require.Len(t, got, 2)
+		require.Equal(t, "edge-01", got[0]["name"])
+		require.Equal(t, "edge-02", got[1]["name"])
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
@@ -79,7 +83,7 @@ LIMIT $2 OFFSET $3`)).
 			WithArgs(`edge\_\%`, int32(1), int32(1)).
 			WillReturnRows(rows)
 
-		req := httptest.NewRequest(http.MethodGet, "/api/satellites?limit=1&offset=1&name_prefix=edge_%&sort=name&order=asc", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites?limit=1&offset=1&name_prefix=edge_%25&sort=name&order=asc", nil)
 		rr := httptest.NewRecorder()
 		server.listSatelliteHandler(rr, req)
 

--- a/ground-control/internal/server/satellite_listing_test.go
+++ b/ground-control/internal/server/satellite_listing_test.go
@@ -25,6 +25,8 @@ func TestListSatelliteHandler(t *testing.T) {
 			AddRow(1, "edge-01", now, now, sql.NullTime{Time: now, Valid: true}, sql.NullString{String: "30s", Valid: true}).
 			AddRow(2, "edge-02", now, now, sql.NullTime{}, sql.NullString{})
 		mock.ExpectQuery("SELECT .+ FROM satellites").WillReturnRows(rows)
+		mock.ExpectQuery("SELECT .+ FROM satellite_labels WHERE satellite_id = ANY").
+			WillReturnRows(sqlmock.NewRows([]string{"satellite_id", "key", "value"}))
 
 		req := httptest.NewRequest(http.MethodGet, "/api/satellites", nil)
 		rr := httptest.NewRecorder()
@@ -86,6 +88,8 @@ ORDER BY name ASC, id ASC
 LIMIT $2 OFFSET $3`)).
 			WithArgs(`edge\_\%`, int32(1), int32(1)).
 			WillReturnRows(rows)
+		mock.ExpectQuery("SELECT .+ FROM satellite_labels WHERE satellite_id = ANY").
+			WillReturnRows(sqlmock.NewRows([]string{"satellite_id", "key", "value"}))
 
 		req := httptest.NewRequest(http.MethodGet, "/api/satellites?limit=1&offset=1&name_prefix=edge_%25&sort=name&order=asc", nil)
 		rr := httptest.NewRecorder()

--- a/ground-control/sql/queries/satellite_labels.sql
+++ b/ground-control/sql/queries/satellite_labels.sql
@@ -1,3 +1,5 @@
+/* tsqllint-disable */
+
 -- name: GetLabelsBySatelliteID :many
 SELECT key, value FROM satellite_labels
 WHERE satellite_id = $1

--- a/ground-control/sql/queries/satellite_labels.sql
+++ b/ground-control/sql/queries/satellite_labels.sql
@@ -1,0 +1,16 @@
+-- name: GetLabelsBySatelliteID :many
+SELECT key, value FROM satellite_labels
+WHERE satellite_id = $1
+ORDER BY key;
+
+-- name: SetLabels :exec
+-- Deletes all labels for a satellite; use within a transaction with subsequent inserts.
+DELETE FROM satellite_labels WHERE satellite_id = $1;
+
+-- name: InsertLabel :exec
+INSERT INTO satellite_labels (satellite_id, key, value)
+VALUES ($1, $2, $3)
+ON CONFLICT (satellite_id, key) DO UPDATE SET value = EXCLUDED.value;
+
+-- name: DeleteLabel :exec
+DELETE FROM satellite_labels WHERE satellite_id = $1 AND key = $2;

--- a/ground-control/sql/queries/satellites.sql
+++ b/ground-control/sql/queries/satellites.sql
@@ -4,7 +4,8 @@ VALUES ($1, NOW(), NOW())
 RETURNING *;
 
 -- name: ListSatellites :many
-SELECT * FROM satellites
+SELECT id, name, created_at, updated_at, last_seen, heartbeat_interval
+FROM PUBLIC.satellites
 ORDER BY name ASC, id ASC;
 
 -- name: GetSatellitesByGroupName :many

--- a/ground-control/sql/queries/satellites.sql
+++ b/ground-control/sql/queries/satellites.sql
@@ -4,7 +4,8 @@ VALUES ($1, NOW(), NOW())
 RETURNING *;
 
 -- name: ListSatellites :many
-SELECT * FROM satellites;
+SELECT * FROM satellites
+ORDER BY name ASC, id ASC;
 
 -- name: GetSatellitesByGroupName :many
 SELECT s.id, s.name, s.created_at, s.updated_at

--- a/ground-control/sql/schema/016_satellite_labels.sql
+++ b/ground-control/sql/schema/016_satellite_labels.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+
+CREATE TABLE satellite_labels (
+    satellite_id INTEGER NOT NULL REFERENCES satellites(id) ON DELETE CASCADE,
+    key         TEXT NOT NULL CHECK (length(key) BETWEEN 1 AND 316),
+    value       TEXT NOT NULL CHECK (length(value) <= 63),
+    PRIMARY KEY (satellite_id, key)
+);
+
+CREATE INDEX idx_satellite_labels_satellite_id ON satellite_labels(satellite_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_satellite_labels_satellite_id;
+DROP TABLE satellite_labels;


### PR DESCRIPTION
Fixes #385

## Description

Adds free-form key-value label support to satellites, enabling operators to tag and filter the fleet by environment, region, hardware class, or any other metadata, without overloading the groups concept.

### What's added

**Database**
- Migration `016_satellite_labels.sql`: `satellite_labels` table with `(satellite_id, key)` primary key and `ON DELETE CASCADE`
- SQL query file `satellite_labels.sql` for sqlc
- Hand-written DB layer (`satellite_labels.go`): atomic `SetLabels`, merge-style `PatchLabels`, `GetLabelsBySatelliteID`, and `labelSelectorClause` helper for list filtering

**API endpoints**
```
GET    /api/satellites/{satellite}/labels          -> returns current label map
PUT    /api/satellites/{satellite}/labels          -> replaces full label set atomically
PATCH  /api/satellites/{satellite}/labels          -> merges changes (null value removes key)
GET    /api/satellites?label=env%3Dproduction      -> filters list with AND-semantics
```

**Validation**
- Key: 1-316 chars, `[a-zA-Z0-9._\-/]` only (Kubernetes label key convention)
- Value: max 63 chars

**Example**
```bash
# Set labels
curl -X PUT /api/satellites/edge-01/labels \
  -d '{"env":"production","region":"us-east","hw":"arm64"}'

# Patch: add tier, remove old-key
curl -X PATCH /api/satellites/edge-01/labels \
  -d '{"tier":"critical","old-key":null}'

# Filter list
GET /api/satellites?label=env%3Dproduction&label=region%3Dus-east
```

### Motivation for the operator

The upcoming Kubernetes operator needs label selectors to target progressive rollouts, maintenance windows, and policy scoping at a subset of satellites without enumerating names. Labels are the prerequisite for any selector-based targeting in Ground Control.

### Also in this PR (from #382 review fixes)
- Extract `normalizeSortOrder`, `parseLimitParam`, `parseOffsetParam`, `parseSortParam`, `parseOrderParam` helpers to bring cyclomatic complexity within the Codacy limit of 8
- Fix URL percent-encoding in test: `edge_%` to `edge_%25`
- Tighten legacy list test to decode JSON array instead of substring matching

## Testing
- Unit tests: `label_handlers_test.go` covers GET/PUT/PATCH handlers, validation errors, 404 on unknown satellite, `parseLabelSelectors` parsing, and `validateLabelKey`
- Not run locally (Go not installed in this environment)

## Checklist
- [x] Migration added
- [x] `PUT /api/satellites/{name}/labels` replaces full label set
- [x] `PATCH /api/satellites/{name}/labels` merges/removes individual keys
- [x] `GET /api/satellites/{name}/labels` returns current labels
- [x] `GET /api/satellites?label=key=value` filters by selector (AND semantics)
- [x] Label key/value validation with clear error messages
- [x] Unit tests for label CRUD, selector parsing, and validation
- [x] Labels deleted on satellite deletion (CASCADE)