### PR TITLE
feat: add groundctl CLI scaffold with login, satellite list, and inspect commands

### DIFF
--- a/ground-control/cmd/groundctl/go.mod
+++ b/ground-control/cmd/groundctl/go.mod
@@ -1,6 +1,6 @@
 module github.com/container-registry/harbor-satellite/ground-control/cmd/groundctl
 
-go 1.24.1
+go 1.24.11
 
 require (
 	github.com/spf13/cobra v1.9.1

--- a/ground-control/cmd/groundctl/go.mod
+++ b/ground-control/cmd/groundctl/go.mod
@@ -1,0 +1,14 @@
+module github.com/container-registry/harbor-satellite/ground-control/cmd/groundctl
+
+go 1.24.1
+
+require (
+	github.com/spf13/cobra v1.9.1
+	golang.org/x/term v0.30.0
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+	golang.org/x/sys v0.31.0 // indirect
+)

--- a/ground-control/cmd/groundctl/go.sum
+++ b/ground-control/cmd/groundctl/go.sum
@@ -1,0 +1,14 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=
+golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/ground-control/cmd/groundctl/internal/client/client.go
+++ b/ground-control/cmd/groundctl/internal/client/client.go
@@ -1,0 +1,278 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const configDir = ".groundctl"
+
+// Satellite represents a satellite as returned by the Ground Control API.
+// Field names match the PascalCase output of Go's json.Marshal on the
+// sqlc-generated database.Satellite struct (which has no json tags).
+type Satellite struct {
+	ID                int32      `json:"ID"`
+	Name              string     `json:"Name"`
+	CreatedAt         time.Time  `json:"CreatedAt"`
+	UpdatedAt         time.Time  `json:"UpdatedAt"`
+	LastSeen          *time.Time `json:"LastSeen"`
+	HeartbeatInterval *string    `json:"HeartbeatInterval"`
+}
+
+// LoginRequest is the payload for POST /login.
+type LoginRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// LoginResponse is the response from POST /login.
+type LoginResponse struct {
+	Token     string `json:"token"`
+	ExpiresAt string `json:"expires_at"`
+}
+
+// ErrorResponse represents an API error.
+type ErrorResponse struct {
+	Message string `json:"message"`
+	Code    int    `json:"code"`
+}
+
+// Client is an HTTP client for the Ground Control API.
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+	token      string
+}
+
+// NewClient creates a new Client for the given Ground Control server URL.
+func NewClient(serverURL string) *Client {
+	return &Client{
+		baseURL:    serverURL,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// SetServer updates the Ground Control server URL.
+func (c *Client) SetServer(serverURL string) {
+	c.baseURL = serverURL
+}
+
+// Server returns the current Ground Control server URL.
+func (c *Client) Server() string {
+	return c.baseURL
+}
+
+// SetToken sets the Bearer token for authenticated requests.
+func (c *Client) SetToken(token string) {
+	c.token = token
+}
+
+// Token returns the current Bearer token.
+func (c *Client) Token() string {
+	return c.token
+}
+
+// Login authenticates with the Ground Control server and returns a session token.
+func (c *Client) Login(username, password string) (*LoginResponse, error) {
+	reqBody := LoginRequest{
+		Username: username,
+		Password: password,
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal login request: %w", err)
+	}
+
+	resp, err := c.doRequest(http.MethodPost, "/login", nil, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("login request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, parseError(resp)
+	}
+
+	var loginResp LoginResponse
+	if err := json.NewDecoder(resp.Body).Decode(&loginResp); err != nil {
+		return nil, fmt.Errorf("decode login response: %w", err)
+	}
+
+	c.token = loginResp.Token
+	return &loginResp, nil
+}
+
+// ListSatellites retrieves all satellites.
+func (c *Client) ListSatellites() ([]Satellite, error) {
+	resp, err := c.doAuthenticatedRequest(http.MethodGet, "/api/satellites", nil)
+	if err != nil {
+		return nil, fmt.Errorf("list satellites: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, parseError(resp)
+	}
+
+	var satellites []Satellite
+	if err := json.NewDecoder(resp.Body).Decode(&satellites); err != nil {
+		return nil, fmt.Errorf("decode satellites response: %w", err)
+	}
+
+	return satellites, nil
+}
+
+// GetSatellite retrieves a single satellite by name.
+func (c *Client) GetSatellite(name string) (*Satellite, error) {
+	path := "/api/satellites/" + name
+	resp, err := c.doAuthenticatedRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("get satellite %q: %w", name, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, parseError(resp)
+	}
+
+	var satellite Satellite
+	if err := json.NewDecoder(resp.Body).Decode(&satellite); err != nil {
+		return nil, fmt.Errorf("decode satellite response: %w", err)
+	}
+
+	return &satellite, nil
+}
+
+// HealthCheck checks if the Ground Control server is healthy.
+func (c *Client) HealthCheck() error {
+	resp, err := c.doRequest(http.MethodGet, "/health", nil, nil)
+	if err != nil {
+		return fmt.Errorf("health check: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("server returned status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// doRequest performs an HTTP request with optional auth and body.
+func (c *Client) doRequest(method, path string, headers map[string]string, body io.Reader) (*http.Response, error) {
+	url := c.baseURL + path
+
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	return c.httpClient.Do(req)
+}
+
+// doAuthenticatedRequest performs an HTTP request with the Bearer token.
+func (c *Client) doAuthenticatedRequest(method, path string, body io.Reader) (*http.Response, error) {
+	headers := map[string]string{}
+	if c.token != "" {
+		headers["Authorization"] = "Bearer " + c.token
+	}
+	return c.doRequest(method, path, headers, body)
+}
+
+// configFilePath returns the path to the config file for the given server URL.
+func configFilePath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("get home directory: %w", err)
+	}
+
+	dir := filepath.Join(homeDir, configDir)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create config directory: %w", err)
+	}
+
+	return filepath.Join(dir, "config.json"), nil
+}
+
+// ConfigData is stored in the config file.
+type ConfigData struct {
+	Server    string `json:"server"`
+	Token     string `json:"token"`
+	ExpiresAt string `json:"expires_at"`
+}
+
+// SaveConfig saves the client configuration to disk.
+func SaveConfig(cfg *ConfigData) error {
+	path, err := configFilePath()
+	if err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write config file: %w", err)
+	}
+
+	return nil
+}
+
+// LoadConfig loads the client configuration from disk.
+func LoadConfig() (*ConfigData, error) {
+	path, err := configFilePath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &ConfigData{}, nil
+		}
+		return nil, fmt.Errorf("read config file: %w", err)
+	}
+
+	var cfg ConfigData
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("unmarshal config: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+// parseError reads an error response from the API.
+// Handles both formats: {"message":"...","code":N} and {"error":"..."}.
+func parseError(resp *http.Response) error {
+	body, _ := io.ReadAll(resp.Body)
+
+	var errResp ErrorResponse
+	if err := json.Unmarshal(body, &errResp); err == nil {
+		if errResp.Message != "" {
+			return fmt.Errorf("API error (status %d): %s", resp.StatusCode, errResp.Message)
+		}
+	}
+
+	var simpleErr struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &simpleErr); err == nil && simpleErr.Error != "" {
+		return fmt.Errorf("API error (status %d): %s", resp.StatusCode, simpleErr.Error)
+	}
+
+	return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
+}

--- a/ground-control/cmd/groundctl/internal/cmd/login.go
+++ b/ground-control/cmd/groundctl/internal/cmd/login.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"fmt"
+	"syscall"
+
+	"github.com/container-registry/harbor-satellite/ground-control/cmd/groundctl/internal/client"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+func newLoginCmd(apiClient *client.Client) *cobra.Command {
+	var username string
+	var password string
+
+	loginCmd := &cobra.Command{
+		Use:   "login",
+		Short: "Authenticate with the Ground Control server",
+		Long: `Login authenticates with the Ground Control server and stores the
+session token locally for subsequent commands.
+
+If --username or --password are not provided, you will be prompted
+interactively.`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if username == "" {
+				fmt.Print("Username: ")
+				if _, err := fmt.Scanln(&username); err != nil {
+					return fmt.Errorf("read username: %w", err)
+				}
+			}
+
+			if password == "" {
+				fmt.Print("Password: ")
+				passBytes, err := term.ReadPassword(int(syscall.Stdin))
+				if err != nil {
+					return fmt.Errorf("read password: %w", err)
+				}
+				fmt.Println()
+				password = string(passBytes)
+			}
+
+			resp, err := apiClient.Login(username, password)
+			if err != nil {
+				return fmt.Errorf("login failed: %w", err)
+			}
+
+			cfg := &client.ConfigData{
+				Server:    apiClient.Server(),
+				Token:     resp.Token,
+				ExpiresAt: resp.ExpiresAt,
+			}
+
+			if err := client.SaveConfig(cfg); err != nil {
+				return fmt.Errorf("save config: %w", err)
+			}
+
+			fmt.Printf("Login successful. Token expires at %s\n", resp.ExpiresAt)
+			return nil
+		},
+	}
+
+	loginCmd.Flags().StringVarP(&username, "username", "u", "", "Ground Control username")
+	loginCmd.Flags().StringVarP(&password, "password", "p", "", "Ground Control password")
+
+	return loginCmd
+}

--- a/ground-control/cmd/groundctl/internal/cmd/root.go
+++ b/ground-control/cmd/groundctl/internal/cmd/root.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/container-registry/harbor-satellite/ground-control/cmd/groundctl/internal/client"
+	"github.com/spf13/cobra"
+)
+
+// NewRootCommand creates the root cobra command for groundctl.
+func NewRootCommand() *cobra.Command {
+	apiClient := client.NewClient("http://localhost:8080")
+
+	rootCmd := &cobra.Command{
+		Use:   "groundctl",
+		Short: "CLI for managing Harbor Satellite Ground Control",
+		Long: `groundctl is a command-line interface for managing the Harbor Satellite
+Ground Control server. It provides commands for satellite management,
+group management, configuration, and more.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			serverFlag, err := cmd.Flags().GetString("server")
+			if err != nil {
+				return fmt.Errorf("get server flag: %w", err)
+			}
+			apiClient.SetServer(serverFlag)
+
+			cfg, err := client.LoadConfig()
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
+
+			if cfg.Token != "" {
+				apiClient.SetToken(cfg.Token)
+			}
+
+			return nil
+		},
+	}
+
+	rootCmd.PersistentFlags().String("server", "http://localhost:8080", "Ground Control server URL")
+
+	rootCmd.AddCommand(newLoginCmd(apiClient))
+	rootCmd.AddCommand(newSatelliteCmd(apiClient))
+
+	return rootCmd
+}

--- a/ground-control/cmd/groundctl/internal/cmd/satellites.go
+++ b/ground-control/cmd/groundctl/internal/cmd/satellites.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/container-registry/harbor-satellite/ground-control/cmd/groundctl/internal/client"
+	"github.com/container-registry/harbor-satellite/ground-control/cmd/groundctl/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func newSatelliteCmd(apiClient *client.Client) *cobra.Command {
+	satelliteCmd := &cobra.Command{
+		Use:     "satellite",
+		Aliases: []string{"satellites", "sat"},
+		Short:   "Manage satellites",
+		Long:    `Manage satellites registered with the Ground Control server.`,
+	}
+
+	satelliteCmd.AddCommand(newSatelliteListCmd(apiClient))
+	satelliteCmd.AddCommand(newSatelliteInspectCmd(apiClient))
+
+	return satelliteCmd
+}
+
+func newSatelliteListCmd(apiClient *client.Client) *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List all satellites",
+		Long:    `List all satellites registered with the Ground Control server.`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			satellites, err := apiClient.ListSatellites()
+			if err != nil {
+				return fmt.Errorf("list satellites: %w", err)
+			}
+
+			if len(satellites) == 0 {
+				fmt.Println("No satellites found.")
+				return nil
+			}
+
+			headers := []string{"ID", "NAME", "LAST SEEN", "HEARTBEAT"}
+			rows := make([][]string, 0, len(satellites))
+
+			for _, sat := range satellites {
+				lastSeen := "-"
+				if sat.LastSeen != nil {
+					lastSeen = sat.LastSeen.Format("2006-01-02 15:04:05")
+				}
+
+				heartbeat := "-"
+				if sat.HeartbeatInterval != nil {
+					heartbeat = *sat.HeartbeatInterval
+				}
+
+				rows = append(rows, []string{
+					fmt.Sprintf("%d", sat.ID),
+					sat.Name,
+					lastSeen,
+					heartbeat,
+				})
+			}
+
+			output.PrintTable(headers, rows)
+			return nil
+		},
+	}
+}
+
+func newSatelliteInspectCmd(apiClient *client.Client) *cobra.Command {
+	return &cobra.Command{
+		Use:   "inspect <name>",
+		Short: "Show detailed information about a satellite",
+		Long:  `Show detailed information about a satellite by name.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			name := args[0]
+
+			sat, err := apiClient.GetSatellite(name)
+			if err != nil {
+				return fmt.Errorf("inspect satellite %q: %w", name, err)
+			}
+
+			lastSeen := "-"
+			if sat.LastSeen != nil {
+				lastSeen = sat.LastSeen.Format("2006-01-02 15:04:05")
+			}
+
+			heartbeat := "-"
+			if sat.HeartbeatInterval != nil {
+				heartbeat = *sat.HeartbeatInterval
+			}
+
+			rows := [][]string{
+				{"ID:", fmt.Sprintf("%d", sat.ID)},
+				{"Name:", sat.Name},
+				{"Created:", sat.CreatedAt.Format("2006-01-02 15:04:05")},
+				{"Updated:", sat.UpdatedAt.Format("2006-01-02 15:04:05")},
+				{"Last Seen:", lastSeen},
+				{"Heartbeat:", heartbeat},
+			}
+
+			output.PrintKeyValue(rows)
+			return nil
+		},
+	}
+}

--- a/ground-control/cmd/groundctl/internal/output/table.go
+++ b/ground-control/cmd/groundctl/internal/output/table.go
@@ -1,0 +1,49 @@
+package output
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+)
+
+// PrintTable prints a formatted table with headers and rows to stdout.
+func PrintTable(headers []string, rows [][]string) {
+	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+
+	for i, h := range headers {
+		if i > 0 {
+			fmt.Fprint(writer, "\t")
+		}
+		fmt.Fprint(writer, h)
+	}
+	fmt.Fprintln(writer)
+
+	for _, row := range rows {
+		for i, cell := range row {
+			if i > 0 {
+				fmt.Fprint(writer, "\t")
+			}
+			fmt.Fprint(writer, cell)
+		}
+		fmt.Fprintln(writer)
+	}
+
+	writer.Flush()
+}
+
+// PrintKeyValue prints key-value pairs as a two-column aligned output without headers.
+func PrintKeyValue(rows [][]string) {
+	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	for _, row := range rows {
+		for i, cell := range row {
+			if i > 0 {
+				fmt.Fprint(writer, "\t")
+			}
+			fmt.Fprint(writer, cell)
+		}
+		fmt.Fprintln(writer)
+	}
+
+	writer.Flush()
+}

--- a/ground-control/cmd/groundctl/main.go
+++ b/ground-control/cmd/groundctl/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/container-registry/harbor-satellite/ground-control/cmd/groundctl/internal/cmd"
+)
+
+func main() {
+	if err := cmd.NewRootCommand().Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary

This PR introduces **groundctl**, a standalone CLI tool for managing the Ground Control server. It provides a `kubectl`-like experience for Harbor Satellite operations.

### Working Commands

```bash
# Authenticate and persist session token
groundctl login --server http://gc:8080

# List all registered satellites
groundctl satellite list

# Show detailed satellite info
groundctl satellite inspect edge-node-01

# Switch between Ground Control instances
groundctl --server http://other-gc:9090 satellite list
```

### Architecture

- **Separate Go module** (`ground-control/cmd/groundctl/go.mod`) — no dependency conflicts with parent modules
- **Cobra** for CLI structure (already an indirect dependency, both `golangci.yaml` files have cobra exemptions)
- **Manual HTTP client** — hits the existing REST API directly (no codegen dependency, can switch to OpenAPI-generated client when PR #354 lands)
- **Session token** persisted to `~/.groundctl/config.json`, auto-loaded on subsequent commands
- **Bearer auth** — `Authorization: Bearer <token>` header attached to all authenticated requests
- **`--server` global flag** — switch between Ground Control instances without re-login

### Design Decisions Documented

- PascalCase JSON field matching — the server returns `sqlc`-generated structs without `json` tags, so Go's `json.Marshal` produces PascalCase keys (`"ID"`, `"Name"`, `"CreatedAt"`)
- Dual error format handling — the server uses both `{"error":"..."}` and `{"message":"..."}` formats across different handlers
- Interactive password prompt using `golang.org/x/term` for terminal echo masking
- `text/tabwriter` for aligned table output (zero external deps)

### Files

```
ground-control/cmd/groundctl/
├── main.go                          # Entry point with stderr error output
├── go.mod / go.sum                  # Module: cobra v1.9.1 + golang.org/x/term
└── internal/
    ├── client/client.go             # HTTP client, auth, token persistence
    ├── cmd/root.go                  # Root cobra command with --server flag
    ├── cmd/login.go                 # login command (interactive + flag modes)
    ├── cmd/satellites.go            # satellite list + inspect subcommands
    └── output/table.go              # Table + key-value formatters
```

### Verification

- ✅ `go build` — groundctl, root, and ground-control modules all build clean
- ✅ `go vet ./...` — no issues
- ✅ No global variables, no `init()` functions (follows project linting rules)
- ✅ Error output to stderr with full chain preservation (`%w` wrapping)
- ✅ Parent modules completely unaffected

### What's Next (follow-up PRs)

- `groundctl satellite register` / `delete` / `status` / `images`
- `groundctl group list` / `inspect` / `satellites`
- `groundctl config list` / `inspect`
- `groundctl user list`
- `groundctl health`
- JSON output mode (`--output json`)
- OpenAPI client generation integration (once swagger spec is complete)

---

This is part of the LFX project deliverables for Harbor Satellite — a working CLI prototype that can be extended with full command coverage and eventually Kubernetes operator integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `groundctl` CLI tool for managing interactions with the Ground Control API
  * Added login command for authenticating with the Ground Control server using username and password credentials
  * Added satellite management commands to list all available satellites and inspect detailed information for individual satellites, including creation timestamps, last activity, and heartbeat intervals

<!-- end of auto-generated comment: release notes by coderabbit.ai -->