### PR TITLE
fix: apply bandwidth throttle only to pull transport, not push

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -29,6 +29,9 @@
       "enabled": false,
       "registries": ["docker.io"],
       "runtimes": []
+    },
+    "sync": {
+      "max_bandwidth_mbps": 0
     }
   },
   "zot_config": {

--- a/internal/state/replicator.go
+++ b/internal/state/replicator.go
@@ -34,13 +34,14 @@ type BasicReplicator struct {
 	remoteUsername    string
 	remotePassword    string
 	tlsCfg            config.TLSConfig
+	syncCfg           config.SyncConfig
 }
 
 func NewBasicReplicator(sourceUsername, sourcePassword, sourceRegistry, remoteURL, remoteUsername, remotePassword string, useUnsecure bool) Replicator {
-	return NewBasicReplicatorWithTLS(sourceUsername, sourcePassword, sourceRegistry, remoteURL, remoteUsername, remotePassword, useUnsecure, config.TLSConfig{})
+	return NewBasicReplicatorWithTLS(sourceUsername, sourcePassword, sourceRegistry, remoteURL, remoteUsername, remotePassword, useUnsecure, config.TLSConfig{}, config.SyncConfig{})
 }
 
-func NewBasicReplicatorWithTLS(sourceUsername, sourcePassword, sourceRegistry, remoteURL, remoteUsername, remotePassword string, useUnsecure bool, tlsCfg config.TLSConfig) Replicator {
+func NewBasicReplicatorWithTLS(sourceUsername, sourcePassword, sourceRegistry, remoteURL, remoteUsername, remotePassword string, useUnsecure bool, tlsCfg config.TLSConfig, syncCfg config.SyncConfig) Replicator {
 	return &BasicReplicator{
 		sourceUsername:    sourceUsername,
 		sourcePassword:    sourcePassword,
@@ -50,6 +51,7 @@ func NewBasicReplicatorWithTLS(sourceUsername, sourcePassword, sourceRegistry, r
 		remoteUsername:    remoteUsername,
 		remotePassword:    remotePassword,
 		tlsCfg:            tlsCfg,
+		syncCfg:           syncCfg,
 	}
 }
 
@@ -78,14 +80,30 @@ func (e Entity) GetTag() string {
 // only downloads missing layers from source, saving bandwidth on crash recovery.
 func (r *BasicReplicator) Replicate(ctx context.Context, replicationEntities []Entity) error {
 	log := logger.FromContext(ctx)
-	pullAuth := authn.FromConfig(authn.AuthConfig{
-		Username: r.sourceUsername,
-		Password: r.sourcePassword,
-	})
-	pushAuth := authn.FromConfig(authn.AuthConfig{
-		Username: r.remoteUsername,
-		Password: r.remotePassword,
-	})
+
+	nameOpts, pullOpts, pushOpts, err := r.buildRemoteOptions(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, entity := range replicationEntities {
+		select {
+		case <-ctx.Done():
+			log.Warn().Err(ctx.Err()).Msg("Context cancelled, stopping replication")
+			return ctx.Err()
+		default:
+		}
+		if err := r.replicateOne(ctx, entity, nameOpts, pullOpts, pushOpts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *BasicReplicator) buildRemoteOptions(ctx context.Context) ([]name.Option, []remote.Option, []remote.Option, error) {
+	pullAuth := authn.FromConfig(authn.AuthConfig{Username: r.sourceUsername, Password: r.sourcePassword})
+	pushAuth := authn.FromConfig(authn.AuthConfig{Username: r.remoteUsername, Password: r.remotePassword})
 
 	var nameOpts []name.Option
 	pullOpts := []remote.Option{remote.WithAuth(pullAuth), remote.WithContext(ctx)}
@@ -93,85 +111,96 @@ func (r *BasicReplicator) Replicate(ctx context.Context, replicationEntities []E
 
 	if r.useUnsecure {
 		nameOpts = append(nameOpts, name.Insecure)
-	} else {
-		transport, err := r.buildTLSTransport()
-		if err != nil {
-			return fmt.Errorf("build TLS transport: %w", err)
+		if r.syncCfg.MaxBandwidthMbps > 0 {
+			pullOpts = append(pullOpts, remote.WithTransport(newThrottledTransport(http.DefaultTransport, r.syncCfg.MaxBandwidthMbps)))
 		}
-		if transport != nil {
-			pullOpts = append(pullOpts, remote.WithTransport(transport))
-			pushOpts = append(pushOpts, remote.WithTransport(transport))
-		}
+
+		return nameOpts, pullOpts, pushOpts, nil
 	}
 
-	for _, entity := range replicationEntities {
-		// Check context cancellation before processing each image
-		select {
-		case <-ctx.Done():
-			log.Warn().Err(ctx.Err()).Msg("Context cancelled, stopping replication")
-			return ctx.Err()
-		default:
-		}
-
-		srcRef := fmt.Sprintf("%s/%s/%s:%s", r.sourceRegistry, entity.GetRepository(), entity.GetName(), entity.GetTag())
-		dstRef := fmt.Sprintf("%s/%s/%s:%s", r.remoteRegistryURL, entity.GetRepository(), entity.GetName(), entity.GetTag())
-
-		src, err := name.ParseReference(srcRef, nameOpts...)
-		if err != nil {
-			return fmt.Errorf("parse source ref %s: %w", srcRef, err)
-		}
-
-		dst, err := name.ParseReference(dstRef, nameOpts...)
-		if err != nil {
-			return fmt.Errorf("parse dest ref %s: %w", dstRef, err)
-		}
-
-		// Lazy fetch: only the manifest is downloaded, no layer data yet
-		desc, err := remote.Get(src, pullOpts...)
-		if err != nil {
-			log.Error().Msgf("Failed to fetch image descriptor: %v", err)
-			return err
-		}
-
-		img, err := desc.Image()
-		if err != nil {
-			log.Error().Msgf("Failed to resolve image: %v", err)
-			return err
-		}
-
-		// Lazy OCI conversion, no data materialized
-		ociImage := mutate.MediaType(img, types.OCIManifestSchema1)
-
-		// Check if image already exists at destination with same digest
-		srcDigest, err := ociImage.Digest()
-		if err != nil {
-			return fmt.Errorf("compute source digest: %w", err)
-		}
-
-		dstDesc, dstErr := remote.Head(dst, pushOpts...)
-		if dstErr == nil && dstDesc.Digest == srcDigest {
-			log.Info().Msgf("Image %s already up-to-date at destination, skipping", entity.GetName())
-			continue
-		}
-
-		// Log which layers need pulling vs already present
-		srcLayers, err := ociImage.Layers()
-		if err != nil {
-			return fmt.Errorf("get source layers: %w", err)
-		}
-
-		missing := r.countMissingLayers(dst, srcLayers, pushOpts)
-		log.Info().Msgf("Replicating image %s: %d/%d layers to pull", entity.GetName(), missing, len(srcLayers))
-
-		// remote.Write streams layers one-by-one. For each layer it HEAD-checks
-		// the destination first; only missing blobs are pulled from source.
-		// Manifest is pushed last.
-		if err := remote.Write(dst, ociImage, pushOpts...); err != nil {
-			log.Error().Msgf("Failed to replicate image: %v", err)
-			return err
-		}
-		log.Info().Msgf("Image %s replicated successfully", entity.GetName())
+	tlsTransport, err := r.buildTLSTransport()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("build transport: %w", err)
 	}
+
+	if tlsTransport != nil {
+		pushOpts = append(pushOpts, remote.WithTransport(tlsTransport))
+	}
+
+	var pullBase http.RoundTripper = http.DefaultTransport
+	if tlsTransport != nil {
+		pullBase = tlsTransport
+	}
+
+	if r.syncCfg.MaxBandwidthMbps > 0 {
+		pullOpts = append(pullOpts, remote.WithTransport(newThrottledTransport(pullBase, r.syncCfg.MaxBandwidthMbps)))
+	} else if tlsTransport != nil {
+		pullOpts = append(pullOpts, remote.WithTransport(tlsTransport))
+	}
+
+	return nameOpts, pullOpts, pushOpts, nil
+}
+
+func (r *BasicReplicator) replicateOne(ctx context.Context, entity Entity, nameOpts []name.Option, pullOpts []remote.Option, pushOpts []remote.Option) error {
+	log := logger.FromContext(ctx)
+
+	srcRef := fmt.Sprintf("%s/%s/%s:%s", r.sourceRegistry, entity.GetRepository(), entity.GetName(), entity.GetTag())
+	dstRef := fmt.Sprintf("%s/%s/%s:%s", r.remoteRegistryURL, entity.GetRepository(), entity.GetName(), entity.GetTag())
+
+	src, err := name.ParseReference(srcRef, nameOpts...)
+	if err != nil {
+		return fmt.Errorf("parse source ref %s: %w", srcRef, err)
+	}
+
+	dst, err := name.ParseReference(dstRef, nameOpts...)
+	if err != nil {
+		return fmt.Errorf("parse dest ref %s: %w", dstRef, err)
+	}
+
+	// Lazy fetch: only the manifest is downloaded, no layer data yet
+	desc, err := remote.Get(src, pullOpts...)
+	if err != nil {
+		log.Error().Msgf("Failed to fetch image descriptor: %v", err)
+		return err
+	}
+
+	img, err := desc.Image()
+	if err != nil {
+		log.Error().Msgf("Failed to resolve image: %v", err)
+		return err
+	}
+
+	// Lazy OCI conversion, no data materialized
+	ociImage := mutate.MediaType(img, types.OCIManifestSchema1)
+
+	srcDigest, err := ociImage.Digest()
+	if err != nil {
+		return fmt.Errorf("compute source digest: %w", err)
+	}
+
+	dstDesc, dstErr := remote.Head(dst, pushOpts...)
+	if dstErr == nil && dstDesc.Digest == srcDigest {
+		log.Info().Msgf("Image %s already up-to-date at destination, skipping", entity.GetName())
+		return nil
+	}
+
+	srcLayers, err := ociImage.Layers()
+	if err != nil {
+		return fmt.Errorf("get source layers: %w", err)
+	}
+
+	missing := r.countMissingLayers(dst, srcLayers, pushOpts)
+	log.Info().Msgf("Replicating image %s: %d/%d layers to pull", entity.GetName(), missing, len(srcLayers))
+
+	// remote.Write streams layers one-by-one; HEAD-checks destination per blob,
+	// only missing blobs are pulled. Manifest is pushed last.
+	if err := remote.Write(dst, ociImage, pushOpts...); err != nil {
+		log.Error().Msgf("Failed to replicate image: %v", err)
+		return err
+	}
+
+	log.Info().Msgf("Image %s replicated successfully", entity.GetName())
+
 	return nil
 }
 
@@ -246,11 +275,12 @@ func (r *BasicReplicator) DeleteReplicationEntity(ctx context.Context, replicati
 	return nil
 }
 
+// buildTLSTransport returns an http.Transport with TLS configured, or nil when
+// no TLS config is set (callers then use the default transport).
 func (r *BasicReplicator) buildTLSTransport() (http.RoundTripper, error) {
-	if r.tlsCfg.CertFile == "" && r.tlsCfg.CAFile == "" {
+	if r.tlsCfg.CertFile == "" && r.tlsCfg.CAFile == "" && !r.tlsCfg.SkipVerify {
 		return nil, nil
 	}
-
 	cfg := &satTLS.Config{
 		CertFile:   r.tlsCfg.CertFile,
 		KeyFile:    r.tlsCfg.KeyFile,
@@ -258,13 +288,11 @@ func (r *BasicReplicator) buildTLSTransport() (http.RoundTripper, error) {
 		SkipVerify: r.tlsCfg.SkipVerify,
 		MinVersion: tls.VersionTLS12,
 	}
-
 	tlsConfig, err := satTLS.LoadClientTLSConfig(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("load TLS config: %w", err)
 	}
-
-	return &http.Transport{
-		TLSClientConfig: tlsConfig,
-	}, nil
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	base.TLSClientConfig = tlsConfig
+	return base, nil
 }

--- a/internal/state/replicator.go
+++ b/internal/state/replicator.go
@@ -149,34 +149,16 @@ func (r *BasicReplicator) buildRemoteOptions(ctx context.Context) ([]name.Option
 func (r *BasicReplicator) replicateOne(ctx context.Context, entity Entity, nameOpts []name.Option, pullOpts []remote.Option, pushOpts []remote.Option) error {
 	log := logger.FromContext(ctx)
 
-	srcRef := fmt.Sprintf("%s/%s/%s:%s", r.sourceRegistry, entity.GetRepository(), entity.GetName(), entity.GetTag())
-	dstRef := fmt.Sprintf("%s/%s/%s:%s", r.remoteRegistryURL, entity.GetRepository(), entity.GetName(), entity.GetTag())
-
-	src, err := name.ParseReference(srcRef, nameOpts...)
+	src, dst, err := r.parseReplicationRefs(entity, nameOpts)
 	if err != nil {
-		return fmt.Errorf("parse source ref %s: %w", srcRef, err)
-	}
-
-	dst, err := name.ParseReference(dstRef, nameOpts...)
-	if err != nil {
-		return fmt.Errorf("parse dest ref %s: %w", dstRef, err)
-	}
-
-	// Lazy fetch: only the manifest is downloaded, no layer data yet
-	desc, err := remote.Get(src, pullOpts...)
-	if err != nil {
-		log.Error().Msgf("Failed to fetch image descriptor: %v", err)
 		return err
 	}
 
-	img, err := desc.Image()
+	ociImage, err := fetchOCIImage(src, pullOpts)
 	if err != nil {
-		log.Error().Msgf("Failed to resolve image: %v", err)
+		log.Error().Msgf("Failed to fetch image: %v", err)
 		return err
 	}
-
-	// Lazy OCI conversion, no data materialized
-	ociImage := mutate.MediaType(img, types.OCIManifestSchema1)
 
 	srcDigest, err := ociImage.Digest()
 	if err != nil {
@@ -207,6 +189,39 @@ func (r *BasicReplicator) replicateOne(ctx context.Context, entity Entity, nameO
 	log.Info().Msgf("Image %s replicated successfully", entity.GetName())
 
 	return nil
+}
+
+func (r *BasicReplicator) parseReplicationRefs(entity Entity, nameOpts []name.Option) (name.Reference, name.Reference, error) {
+	srcRef := fmt.Sprintf("%s/%s/%s:%s", r.sourceRegistry, entity.GetRepository(), entity.GetName(), entity.GetTag())
+	dstRef := fmt.Sprintf("%s/%s/%s:%s", r.remoteRegistryURL, entity.GetRepository(), entity.GetName(), entity.GetTag())
+
+	src, err := name.ParseReference(srcRef, nameOpts...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse source ref %s: %w", srcRef, err)
+	}
+
+	dst, err := name.ParseReference(dstRef, nameOpts...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse dest ref %s: %w", dstRef, err)
+	}
+
+	return src, dst, nil
+}
+
+func fetchOCIImage(src name.Reference, pullOpts []remote.Option) (v1.Image, error) {
+	// Lazy fetch: only the manifest is downloaded, no layer data yet
+	desc, err := remote.Get(src, pullOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("fetch image descriptor: %w", err)
+	}
+
+	img, err := desc.Image()
+	if err != nil {
+		return nil, fmt.Errorf("resolve image: %w", err)
+	}
+
+	// Lazy OCI conversion, no data materialized
+	return mutate.MediaType(img, types.OCIManifestSchema1), nil
 }
 
 // countMissingLayers checks which source layers are absent from the destination

--- a/internal/state/replicator.go
+++ b/internal/state/replicator.go
@@ -37,11 +37,16 @@ type BasicReplicator struct {
 	syncCfg           config.SyncConfig
 }
 
-func NewBasicReplicator(sourceUsername, sourcePassword, sourceRegistry, remoteURL, remoteUsername, remotePassword string, useUnsecure bool) Replicator {
-	return NewBasicReplicatorWithTLS(sourceUsername, sourcePassword, sourceRegistry, remoteURL, remoteUsername, remotePassword, useUnsecure, config.TLSConfig{}, config.SyncConfig{})
+type ReplicatorOptions struct {
+	TLSConfig  config.TLSConfig
+	SyncConfig config.SyncConfig
 }
 
-func NewBasicReplicatorWithTLS(sourceUsername, sourcePassword, sourceRegistry, remoteURL, remoteUsername, remotePassword string, useUnsecure bool, tlsCfg config.TLSConfig, syncCfg config.SyncConfig) Replicator {
+func NewBasicReplicator(sourceUsername, sourcePassword, sourceRegistry, remoteURL, remoteUsername, remotePassword string, useUnsecure bool) Replicator {
+	return NewBasicReplicatorWithTLS(sourceUsername, sourcePassword, sourceRegistry, remoteURL, remoteUsername, remotePassword, useUnsecure, ReplicatorOptions{})
+}
+
+func NewBasicReplicatorWithTLS(sourceUsername, sourcePassword, sourceRegistry, remoteURL, remoteUsername, remotePassword string, useUnsecure bool, opts ReplicatorOptions) Replicator {
 	return &BasicReplicator{
 		sourceUsername:    sourceUsername,
 		sourcePassword:    sourcePassword,
@@ -50,8 +55,8 @@ func NewBasicReplicatorWithTLS(sourceUsername, sourcePassword, sourceRegistry, r
 		sourceRegistry:    sourceRegistry,
 		remoteUsername:    remoteUsername,
 		remotePassword:    remotePassword,
-		tlsCfg:            tlsCfg,
-		syncCfg:           syncCfg,
+		tlsCfg:            opts.TLSConfig,
+		syncCfg:           opts.SyncConfig,
 	}
 }
 

--- a/internal/state/state_process.go
+++ b/internal/state/state_process.go
@@ -535,7 +535,7 @@ func (f *FetchAndReplicateStateProcess) setupReplication() (Replicator, string, 
 		}
 	}
 
-	replicator := NewBasicReplicator(srcUsername, srcPassword, sourceURL, remoteURL, remoteUsername, remotePassword, useUnsecure)
+	replicator := NewBasicReplicatorWithTLS(srcUsername, srcPassword, sourceURL, remoteURL, remoteUsername, remotePassword, useUnsecure, f.cm.GetTLSConfig(), f.cm.GetSyncConfig())
 
 	// Set up direct delivery if enabled, clear if disabled
 	dd := f.cm.GetDirectDeliveryConfig()

--- a/internal/state/state_process.go
+++ b/internal/state/state_process.go
@@ -535,7 +535,7 @@ func (f *FetchAndReplicateStateProcess) setupReplication() (Replicator, string, 
 		}
 	}
 
-	replicator := NewBasicReplicatorWithTLS(srcUsername, srcPassword, sourceURL, remoteURL, remoteUsername, remotePassword, useUnsecure, f.cm.GetTLSConfig(), f.cm.GetSyncConfig())
+	replicator := NewBasicReplicatorWithTLS(srcUsername, srcPassword, sourceURL, remoteURL, remoteUsername, remotePassword, useUnsecure, ReplicatorOptions{TLSConfig: f.cm.GetTLSConfig(), SyncConfig: f.cm.GetSyncConfig()})
 
 	// Set up direct delivery if enabled, clear if disabled
 	dd := f.cm.GetDirectDeliveryConfig()

--- a/internal/state/throttle.go
+++ b/internal/state/throttle.go
@@ -1,0 +1,68 @@
+package state
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	"golang.org/x/time/rate"
+)
+
+// throttledTransport wraps an http.RoundTripper and caps download throughput
+// using a token-bucket limiter. Upload is not throttled because image pushes
+// to the local Zot registry are loopback transfers.
+type throttledTransport struct {
+	base    http.RoundTripper
+	limiter *rate.Limiter
+}
+
+// newThrottledTransport wraps base with a rate limiter set to mbps megabits/sec.
+// Burst is set to 64 KiB or a quarter-second of transfer, whichever is larger,
+// so normal HTTP read sizes (4-64 KiB) never exceed it.
+func newThrottledTransport(base http.RoundTripper, mbps float64) *throttledTransport {
+	bytesPerSec := mbps * 125_000 // 1 Mbps = 125,000 bytes/sec
+	burst := int(bytesPerSec / 4)
+	if burst < 64*1024 {
+		burst = 64 * 1024
+	}
+	return &throttledTransport{
+		base:    base,
+		limiter: rate.NewLimiter(rate.Limit(bytesPerSec), burst),
+	}
+}
+
+func (t *throttledTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body = &throttledReader{body: resp.Body, limiter: t.limiter, ctx: req.Context()}
+	return resp, nil
+}
+
+type throttledReader struct {
+	body    io.ReadCloser
+	limiter *rate.Limiter
+	ctx     context.Context
+}
+
+func (r *throttledReader) Read(p []byte) (int, error) {
+	// Cap the read to burst so WaitN(n) is always valid (WaitN rejects n > Burst).
+	limit := r.limiter.Burst()
+	if len(p) < limit {
+		limit = len(p)
+	}
+
+	n, err := r.body.Read(p[:limit])
+	if n > 0 {
+		if waitErr := r.limiter.WaitN(r.ctx, n); waitErr != nil {
+			return n, waitErr
+		}
+	}
+
+	return n, err
+}
+
+func (r *throttledReader) Close() error {
+	return r.body.Close()
+}

--- a/internal/state/throttle_test.go
+++ b/internal/state/throttle_test.go
@@ -1,0 +1,100 @@
+package state
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/container-registry/harbor-satellite/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestThrottledTransport_PassesThrough(t *testing.T) {
+	want := []byte("hello throttled world")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(want)
+	}))
+	t.Cleanup(srv.Close)
+
+	// 100 Mbps — effectively unthrottled for a small payload
+	tr := newThrottledTransport(http.DefaultTransport, 100)
+	client := &http.Client{Transport: tr}
+
+	resp, err := client.Get(srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	got, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestThrottledTransport_LimitsRate(t *testing.T) {
+	// 1 Mbps = 125,000 bytes/sec. 250 KB should take at least 1s.
+	payload := bytes.Repeat([]byte("x"), 250_000)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(payload)
+	}))
+	t.Cleanup(srv.Close)
+
+	tr := newThrottledTransport(http.DefaultTransport, 1)
+	client := &http.Client{Transport: tr}
+
+	start := time.Now()
+	resp, err := client.Get(srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	_, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	elapsed := time.Since(start)
+	require.GreaterOrEqual(t, elapsed, time.Second, "transfer should be throttled to ~1 Mbps")
+}
+
+func TestThrottledReader_ContextCancellation(t *testing.T) {
+	payload := bytes.Repeat([]byte("y"), 1_000_000)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(payload)
+	}))
+	t.Cleanup(srv.Close)
+
+	// Very low limit so token-bucket waits long enough for the deadline to fire.
+	tr := newThrottledTransport(http.DefaultTransport, 0.01)
+	client := &http.Client{Transport: tr}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	_, err = io.ReadAll(resp.Body)
+	require.Error(t, err, "context cancellation should surface as a read error")
+}
+
+func TestNewBasicReplicatorWithTLS_ThrottledReplication(t *testing.T) {
+	_, srcAddr := newTestRegistry(t)
+	_, dstAddr := newTestRegistry(t)
+
+	pushImage(t, srcAddr, "library", "busybox", "latest", 1)
+
+	r := NewBasicReplicatorWithTLS("", "", srcAddr, dstAddr, "", "", true,
+		config.TLSConfig{},
+		config.SyncConfig{MaxBandwidthMbps: 100},
+	)
+
+	ctx := testContext()
+	err := r.Replicate(ctx, []Entity{{Name: "busybox", Repository: "library", Tag: "latest"}})
+	require.NoError(t, err)
+}

--- a/internal/state/throttle_test.go
+++ b/internal/state/throttle_test.go
@@ -90,8 +90,7 @@ func TestNewBasicReplicatorWithTLS_ThrottledReplication(t *testing.T) {
 	pushImage(t, srcAddr, "library", "busybox", "latest", 1)
 
 	r := NewBasicReplicatorWithTLS("", "", srcAddr, dstAddr, "", "", true,
-		config.TLSConfig{},
-		config.SyncConfig{MaxBandwidthMbps: 100},
+		ReplicatorOptions{SyncConfig: config.SyncConfig{MaxBandwidthMbps: 100}},
 	)
 
 	ctx := testContext()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,6 +50,12 @@ type DirectDeliveryConfig struct {
 	ImageDir string `json:"image_dir,omitempty"` // auto-detected if empty
 }
 
+// SyncConfig controls bandwidth usage during image replication.
+// MaxBandwidthMbps caps bytes-on-wire; 0 means unlimited.
+type SyncConfig struct {
+	MaxBandwidthMbps float64 `json:"max_bandwidth_mbps,omitempty"`
+}
+
 type AppConfig struct {
 	GroundControlURL          URL                    `json:"ground_control_url,omitempty"`
 	LogLevel                  string                 `json:"log_level,omitempty"`
@@ -66,6 +72,7 @@ type AppConfig struct {
 	RegistryFallback          RegistryFallbackConfig `json:"registry_fallback,omitempty"`
 	HarborRegistryURL         string                 `json:"harbor_registry_url,omitempty"`
 	DirectDelivery            DirectDeliveryConfig   `json:"direct_delivery,omitempty"`
+	Sync                      SyncConfig             `json:"sync,omitempty"`
 }
 
 type StateConfig struct {

--- a/pkg/config/getters.go
+++ b/pkg/config/getters.go
@@ -189,3 +189,9 @@ func (cm *ConfigManager) GetDirectDeliveryConfig() DirectDeliveryConfig {
 	defer cm.mu.RUnlock()
 	return cm.config.AppConfig.DirectDelivery
 }
+
+func (cm *ConfigManager) GetSyncConfig() SyncConfig {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.config.AppConfig.Sync
+}

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -70,6 +70,7 @@ func ValidateAndEnforceDefaults(config *Config, defaultGroundControlURL string) 
 	}
 
 	warnings = append(warnings, validateRegistryFallbackConfig(config)...)
+	warnings = append(warnings, validateSyncConfig(config)...)
 
 	return config, warnings, nil
 }
@@ -217,6 +218,16 @@ func validateRegistryFallbackConfig(config *Config) []string {
 		}
 	}
 
+	return warnings
+}
+
+// validateSyncConfig validates bandwidth throttle settings.
+func validateSyncConfig(config *Config) []string {
+	var warnings []string
+	if config.AppConfig.Sync.MaxBandwidthMbps < 0 {
+		warnings = append(warnings, "sync.max_bandwidth_mbps cannot be negative, disabling throttle")
+		config.AppConfig.Sync.MaxBandwidthMbps = 0
+	}
 	return warnings
 }
 


### PR DESCRIPTION
Satellites with TLS configured and `sync.max_bandwidth_mbps` set were having their push-to-Zot transfers throttled, contradicting the explicit design intent in `throttle.go`: push to the local Zot registry is a loopback transfer and should never be rate-limited.

The insecure path already handled this correctly, applying the throttled transport only to `pullOpts`. The secure/TLS path was combining both TLS and throttle into a single transport and applying it to both `pullOpts` and `pushOpts`, so local writes were capped at the configured bandwidth limit.

The fix separates the two concerns: `buildTLSTransport` returns a TLS-only transport (used for push), and a separate `newThrottledTransport` wrapping that TLS base is applied to pull only. `buildTLSTransport` now also correctly handles `SkipVerify: true` configs that have no cert/CA files, and clones `http.DefaultTransport` rather than constructing a bare `&http.Transport{}` so connection pooling and proxy settings are preserved.

`Replicate` was also refactored into `buildRemoteOptions` and `replicateOne` to bring cyclomatic complexity within the project's lint limits.

Adds `SyncConfig` to `AppConfig` with a `max_bandwidth_mbps` field (0 = unlimited), wired through the config validator and `GetSyncConfig` getter. Tests cover pass-through behavior, rate limiting, context cancellation, and end-to-end replication with throttle enabled.

Fixes #393.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bandwidth throttling support for image replication operations, allowing administrators to set maximum bandwidth limits (in Mbps) to control network resource usage.
  * Introduced new sync configuration settings for enhanced replication control.

* **Tests**
  * Added test coverage for bandwidth throttling and replication functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->