### PR TITLE
fix: return cached images in satellite status

### DIFF
--- a/ground-control/internal/database/artifacts.sql.go
+++ b/ground-control/internal/database/artifacts.sql.go
@@ -41,6 +41,40 @@ func (q *Queries) DeleteOrphanedArtifacts(ctx context.Context, retentionDays int
 	return err
 }
 
+const getArtifactsByIDs = `-- name: GetArtifactsByIDs :many
+SELECT id, reference, size_bytes, created_at FROM artifacts
+WHERE id = ANY($1::INT4[])
+ORDER BY reference
+`
+
+func (q *Queries) GetArtifactsByIDs(ctx context.Context, ids []int32) ([]Artifact, error) {
+	rows, err := q.db.QueryContext(ctx, getArtifactsByIDs, pq.Array(ids))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Artifact
+	for rows.Next() {
+		var i Artifact
+		if err := rows.Scan(
+			&i.ID,
+			&i.Reference,
+			&i.SizeBytes,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getArtifactIDsByReferences = `-- name: GetArtifactIDsByReferences :many
 SELECT id, reference, size_bytes, created_at FROM artifacts
 WHERE reference = ANY($1::TEXT[])

--- a/ground-control/internal/server/satellite_handlers.go
+++ b/ground-control/internal/server/satellite_handlers.go
@@ -52,6 +52,22 @@ type SatelliteStatusParams struct {
 	CachedImages        []CachedImage `json:"cached_images,omitempty"`
 }
 
+type SatelliteStatusResponse struct {
+	ID                 int32         `json:"id"`
+	SatelliteID        int32         `json:"satellite_id"`
+	Activity           string        `json:"activity"`
+	LatestStateDigest  string        `json:"latest_state_digest,omitempty"`
+	LatestConfigDigest string        `json:"latest_config_digest,omitempty"`
+	CPUPercent         string        `json:"cpu_percent,omitempty"`
+	MemoryUsedBytes    int64         `json:"memory_used_bytes,omitempty"`
+	StorageUsedBytes   int64         `json:"storage_used_bytes,omitempty"`
+	LastSyncDurationMs int64         `json:"last_sync_duration_ms,omitempty"`
+	ImageCount         int32         `json:"image_count,omitempty"`
+	CachedImages       []CachedImage `json:"cached_images,omitempty"`
+	ReportedAt         time.Time     `json:"reported_at"`
+	CreatedAt          time.Time     `json:"created_at"`
+}
+
 func (s *Server) registerSatelliteHandler(w http.ResponseWriter, r *http.Request) {
 	if s.spiffeProvider != nil || s.spireClient != nil {
 		HandleAppError(w, &AppError{
@@ -673,7 +689,72 @@ func (s *Server) getSatelliteStatusHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	WriteJSONResponse(w, http.StatusOK, status)
+	resp := satelliteStatusResponse(status, nil)
+	if len(status.ArtifactIds) > 0 {
+		artifacts, err := s.dbQueries.GetLatestArtifacts(r.Context(), sat.ID)
+		if err != nil {
+			log.Printf("Failed to get cached images for status: %v", err)
+			HandleAppError(w, &AppError{Message: "failed to get cached images", Code: http.StatusInternalServerError})
+			return
+		}
+		resp.CachedImages = cachedImagesFromArtifacts(artifacts)
+	}
+
+	WriteJSONResponse(w, http.StatusOK, resp)
+}
+
+func satelliteStatusResponse(status database.SatelliteStatus, cachedImages []CachedImage) SatelliteStatusResponse {
+	return SatelliteStatusResponse{
+		ID:                 status.ID,
+		SatelliteID:        status.SatelliteID,
+		Activity:           status.Activity,
+		LatestStateDigest:  nullStringValue(status.LatestStateDigest),
+		LatestConfigDigest: nullStringValue(status.LatestConfigDigest),
+		CPUPercent:         nullStringValue(status.CpuPercent),
+		MemoryUsedBytes:    nullInt64Value(status.MemoryUsedBytes),
+		StorageUsedBytes:   nullInt64Value(status.StorageUsedBytes),
+		LastSyncDurationMs: nullInt64Value(status.LastSyncDurationMs),
+		ImageCount:         nullInt32Value(status.ImageCount),
+		CachedImages:       cachedImages,
+		ReportedAt:         status.ReportedAt,
+		CreatedAt:          status.CreatedAt,
+	}
+}
+
+func cachedImagesFromArtifacts(artifacts []database.Artifact) []CachedImage {
+	if len(artifacts) == 0 {
+		return nil
+	}
+
+	cachedImages := make([]CachedImage, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		cachedImages = append(cachedImages, CachedImage{
+			Reference: artifact.Reference,
+			SizeBytes: artifact.SizeBytes,
+		})
+	}
+	return cachedImages
+}
+
+func nullStringValue(value sql.NullString) string {
+	if !value.Valid {
+		return ""
+	}
+	return value.String
+}
+
+func nullInt64Value(value sql.NullInt64) int64 {
+	if !value.Valid {
+		return 0
+	}
+	return value.Int64
+}
+
+func nullInt32Value(value sql.NullInt32) int32 {
+	if !value.Valid {
+		return 0
+	}
+	return value.Int32
 }
 
 func (s *Server) getActiveSatellitesHandler(w http.ResponseWriter, r *http.Request) {

--- a/ground-control/internal/server/satellite_handlers.go
+++ b/ground-control/internal/server/satellite_handlers.go
@@ -689,9 +689,9 @@ func (s *Server) getSatelliteStatusHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	resp := satelliteStatusResponse(status, nil)
+	resp := satelliteStatusResponse(status)
 	if len(status.ArtifactIds) > 0 {
-		artifacts, err := s.dbQueries.GetLatestArtifacts(r.Context(), sat.ID)
+		artifacts, err := s.dbQueries.GetArtifactsByIDs(r.Context(), status.ArtifactIds)
 		if err != nil {
 			log.Printf("Failed to get cached images for status: %v", err)
 			HandleAppError(w, &AppError{Message: "failed to get cached images", Code: http.StatusInternalServerError})
@@ -703,7 +703,7 @@ func (s *Server) getSatelliteStatusHandler(w http.ResponseWriter, r *http.Reques
 	WriteJSONResponse(w, http.StatusOK, resp)
 }
 
-func satelliteStatusResponse(status database.SatelliteStatus, cachedImages []CachedImage) SatelliteStatusResponse {
+func satelliteStatusResponse(status database.SatelliteStatus) SatelliteStatusResponse {
 	return SatelliteStatusResponse{
 		ID:                 status.ID,
 		SatelliteID:        status.SatelliteID,
@@ -715,7 +715,6 @@ func satelliteStatusResponse(status database.SatelliteStatus, cachedImages []Cac
 		StorageUsedBytes:   nullInt64Value(status.StorageUsedBytes),
 		LastSyncDurationMs: nullInt64Value(status.LastSyncDurationMs),
 		ImageCount:         nullInt32Value(status.ImageCount),
-		CachedImages:       cachedImages,
 		ReportedAt:         status.ReportedAt,
 		CreatedAt:          status.CreatedAt,
 	}

--- a/ground-control/internal/server/satellite_listing_test.go
+++ b/ground-control/internal/server/satellite_listing_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -165,6 +166,13 @@ func TestGetSatelliteStatusHandler(t *testing.T) {
 			WithArgs(int32(1)).
 			WillReturnRows(statusRows)
 
+		artifactRows := sqlmock.NewRows([]string{"id", "reference", "size_bytes", "created_at"}).
+			AddRow(2, "localhost:8585/library/alpine:3.18@sha256:def", int64(5000), now).
+			AddRow(1, "localhost:8585/library/nginx:latest@sha256:abc", int64(50000), now)
+		mock.ExpectQuery("SELECT .+ FROM artifacts").
+			WithArgs(int32(1)).
+			WillReturnRows(artifactRows)
+
 		req := httptest.NewRequest(http.MethodGet, "/api/satellites/edge-01/status", nil)
 		req = mux.SetURLVars(req, map[string]string{"satellite": "edge-01"})
 
@@ -172,7 +180,23 @@ func TestGetSatelliteStatusHandler(t *testing.T) {
 		server.getSatelliteStatusHandler(rr, req)
 
 		require.Equal(t, http.StatusOK, rr.Code)
-		require.Contains(t, rr.Body.String(), "syncing")
+		require.NotContains(t, rr.Body.String(), "ArtifactIds")
+		require.NotContains(t, rr.Body.String(), "artifact_ids")
+
+		var response SatelliteStatusResponse
+		require.NoError(t, json.NewDecoder(rr.Body).Decode(&response))
+		require.Equal(t, int32(1), response.ID)
+		require.Equal(t, int32(1), response.SatelliteID)
+		require.Equal(t, "syncing", response.Activity)
+		require.Equal(t, "sha256:abc", response.LatestStateDigest)
+		require.Equal(t, "12.50", response.CPUPercent)
+		require.Equal(t, int64(1024), response.MemoryUsedBytes)
+		require.Equal(t, int32(3), response.ImageCount)
+		require.Len(t, response.CachedImages, 2)
+		require.Equal(t, "localhost:8585/library/alpine:3.18@sha256:def", response.CachedImages[0].Reference)
+		require.Equal(t, int64(5000), response.CachedImages[0].SizeBytes)
+		require.Equal(t, "localhost:8585/library/nginx:latest@sha256:abc", response.CachedImages[1].Reference)
+		require.Equal(t, int64(50000), response.CachedImages[1].SizeBytes)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 

--- a/ground-control/internal/server/satellite_listing_test.go
+++ b/ground-control/internal/server/satellite_listing_test.go
@@ -170,7 +170,7 @@ func TestGetSatelliteStatusHandler(t *testing.T) {
 			AddRow(2, "localhost:8585/library/alpine:3.18@sha256:def", int64(5000), now).
 			AddRow(1, "localhost:8585/library/nginx:latest@sha256:abc", int64(50000), now)
 		mock.ExpectQuery("SELECT .+ FROM artifacts").
-			WithArgs(int32(1)).
+			WithArgs(pq.Array([]int32{1, 2, 3})).
 			WillReturnRows(artifactRows)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/satellites/edge-01/status", nil)
@@ -214,6 +214,86 @@ func TestGetSatelliteStatusHandler(t *testing.T) {
 		server.getSatelliteStatusHandler(rr, req)
 
 		require.Equal(t, http.StatusNotFound, rr.Code)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("zero image count and empty artifact ids omit cached images", func(t *testing.T) {
+		server, mock := newMockServer(t)
+		now := time.Now().UTC().Truncate(time.Second)
+
+		satRows := sqlmock.NewRows([]string{"id", "name", "created_at", "updated_at", "last_seen", "heartbeat_interval"}).
+			AddRow(1, "edge-01", now, now, sql.NullTime{}, sql.NullString{})
+		mock.ExpectQuery("SELECT .+ FROM satellites WHERE name").
+			WithArgs("edge-01").
+			WillReturnRows(satRows)
+
+		statusRows := sqlmock.NewRows([]string{
+			"id", "satellite_id", "activity", "latest_state_digest", "latest_config_digest",
+			"cpu_percent", "memory_used_bytes", "storage_used_bytes", "last_sync_duration_ms",
+			"image_count", "reported_at", "created_at", "artifact_ids",
+		}).AddRow(
+			1, 1, "syncing", sql.NullString{}, sql.NullString{},
+			sql.NullString{}, sql.NullInt64{},
+			sql.NullInt64{}, sql.NullInt64{},
+			sql.NullInt32{Int32: 0, Valid: true}, now, now, pq.Array([]int32{}),
+		)
+		mock.ExpectQuery("SELECT .+ FROM satellite_status").
+			WithArgs(int32(1)).
+			WillReturnRows(statusRows)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites/edge-01/status", nil)
+		req = mux.SetURLVars(req, map[string]string{"satellite": "edge-01"})
+
+		rr := httptest.NewRecorder()
+		server.getSatelliteStatusHandler(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		require.NotContains(t, rr.Body.String(), "cached_images")
+		require.NotContains(t, rr.Body.String(), "image_count")
+
+		var response SatelliteStatusResponse
+		require.NoError(t, json.NewDecoder(rr.Body).Decode(&response))
+		require.Equal(t, int32(0), response.ImageCount)
+		require.Empty(t, response.CachedImages)
+		// No artifacts query should run since artifact_ids is empty.
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("artifacts lookup error returns 500", func(t *testing.T) {
+		server, mock := newMockServer(t)
+		now := time.Now().UTC().Truncate(time.Second)
+
+		satRows := sqlmock.NewRows([]string{"id", "name", "created_at", "updated_at", "last_seen", "heartbeat_interval"}).
+			AddRow(1, "edge-01", now, now, sql.NullTime{}, sql.NullString{})
+		mock.ExpectQuery("SELECT .+ FROM satellites WHERE name").
+			WithArgs("edge-01").
+			WillReturnRows(satRows)
+
+		statusRows := sqlmock.NewRows([]string{
+			"id", "satellite_id", "activity", "latest_state_digest", "latest_config_digest",
+			"cpu_percent", "memory_used_bytes", "storage_used_bytes", "last_sync_duration_ms",
+			"image_count", "reported_at", "created_at", "artifact_ids",
+		}).AddRow(
+			1, 1, "syncing", sql.NullString{}, sql.NullString{},
+			sql.NullString{}, sql.NullInt64{},
+			sql.NullInt64{}, sql.NullInt64{},
+			sql.NullInt32{Int32: 3, Valid: true}, now, now, pq.Array([]int32{1, 2, 3}),
+		)
+		mock.ExpectQuery("SELECT .+ FROM satellite_status").
+			WithArgs(int32(1)).
+			WillReturnRows(statusRows)
+
+		mock.ExpectQuery("SELECT .+ FROM artifacts").
+			WithArgs(pq.Array([]int32{1, 2, 3})).
+			WillReturnError(fmt.Errorf("db error"))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/satellites/edge-01/status", nil)
+		req = mux.SetURLVars(req, map[string]string{"satellite": "edge-01"})
+
+		rr := httptest.NewRecorder()
+		server.getSatelliteStatusHandler(rr, req)
+
+		require.Equal(t, http.StatusInternalServerError, rr.Code)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 

--- a/ground-control/sql/queries/artifacts.sql
+++ b/ground-control/sql/queries/artifacts.sql
@@ -7,6 +7,11 @@ ON CONFLICT (reference) DO NOTHING;
 SELECT id, reference, size_bytes, created_at FROM artifacts
 WHERE reference = ANY(@refs::TEXT[]);
 
+-- name: GetArtifactsByIDs :many
+SELECT id, reference, size_bytes, created_at FROM artifacts
+WHERE id = ANY(@ids::INT4[])
+ORDER BY reference;
+
 -- name: DeleteOrphanedArtifacts :exec
 DELETE FROM artifacts
 WHERE id NOT IN (


### PR DESCRIPTION
## Summary
- add an explicit satellite status response DTO for the status endpoint
- resolve cached artifact IDs into cached_images entries
- cover the status response shape and cached image data in tests

Fixes #401

## Tests
- GOTELEMETRY=off GOCACHE=C:\tmp\go-build-status-cached-images go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Satellite status endpoint now includes cached image data from associated artifacts, providing image references and sizes in the response.

* **Tests**
  * Enhanced test coverage for satellite status endpoint to validate artifact retrieval and verify complete response structure including image details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->