### PR TITLE
feat: cosign image signature verification before replication

### DIFF
--- a/internal/policy/signature.go
+++ b/internal/policy/signature.go
@@ -77,6 +77,42 @@ type cosignVerifier struct {
 	keys []*ecdsa.PublicKey
 }
 
+// buildRemoteOpts returns the name and remote options for the given credentials.
+func buildRemoteOpts(ctx context.Context, insecure bool, username, password string) ([]name.Option, []remote.Option) {
+	var nameOpts []name.Option
+	opts := []remote.Option{remote.WithContext(ctx)}
+	if insecure {
+		nameOpts = append(nameOpts, name.Insecure)
+	}
+	if username != "" || password != "" {
+		opts = append(opts, remote.WithAuth(authn.FromConfig(authn.AuthConfig{
+			Username: username,
+			Password: password,
+		})))
+	}
+	return nameOpts, opts
+}
+
+// fetchSigImage resolves the cosign signature artifact tag for ref and pulls it.
+func fetchSigImage(ref name.Reference, nameOpts []name.Option, opts []remote.Option) (v1.Image, error) {
+	head, err := remote.Head(ref, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("resolve digest for %q: %w", ref, err)
+	}
+	sigRef, err := name.ParseReference(
+		fmt.Sprintf("%s:sha256-%s.sig", ref.Context().String(), head.Digest.Hex),
+		nameOpts...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("build sig ref: %w", err)
+	}
+	img, err := remote.Image(sigRef, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("fetch signature artifact: %w", err)
+	}
+	return img, nil
+}
+
 // Verify fetches the cosign signature artifact for imageRef from the source
 // registry and checks it against each configured public key. Returns nil when
 // at least one key verifies a signature.
@@ -89,41 +125,16 @@ type cosignVerifier struct {
 // the annotation dev.cosignproject.cosign/signature; the layer blob is the
 // simple-signing payload that was signed.
 func (v *cosignVerifier) Verify(ctx context.Context, imageRef string, insecure bool, username, password string) error {
-	var nameOpts []name.Option
-	if insecure {
-		nameOpts = append(nameOpts, name.Insecure)
-	}
-
-	opts := []remote.Option{remote.WithContext(ctx)}
-	if username != "" || password != "" {
-		opts = append(opts, remote.WithAuth(authn.FromConfig(authn.AuthConfig{
-			Username: username,
-			Password: password,
-		})))
-	}
+	nameOpts, opts := buildRemoteOpts(ctx, insecure, username, password)
 
 	ref, err := name.ParseReference(imageRef, nameOpts...)
 	if err != nil {
 		return fmt.Errorf("parse ref %q: %w", imageRef, err)
 	}
 
-	head, err := remote.Head(ref, opts...)
+	sigImg, err := fetchSigImage(ref, nameOpts, opts)
 	if err != nil {
-		return fmt.Errorf("resolve digest for %q: %w", imageRef, err)
-	}
-
-	sigTagStr := fmt.Sprintf("sha256-%s.sig", head.Digest.Hex)
-	sigRef, err := name.ParseReference(
-		fmt.Sprintf("%s:%s", ref.Context().String(), sigTagStr),
-		nameOpts...,
-	)
-	if err != nil {
-		return fmt.Errorf("build sig ref: %w", err)
-	}
-
-	sigImg, err := remote.Image(sigRef, opts...)
-	if err != nil {
-		return v.handleMissing(imageRef, fmt.Errorf("fetch signature artifact: %w", err))
+		return v.handleMissing(imageRef, err)
 	}
 
 	manifest, err := sigImg.Manifest()

--- a/internal/policy/signature.go
+++ b/internal/policy/signature.go
@@ -1,0 +1,227 @@
+package policy
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+const cosignSigAnnotation = "dev.cosignproject.cosign/signature"
+
+// Action controls what happens when signature verification fails.
+type Action string
+
+const (
+	// ActionBlock rejects unsigned images and halts replication.
+	ActionBlock Action = "block"
+	// ActionWarn logs a warning but allows replication to continue.
+	ActionWarn Action = "warn"
+)
+
+// Config is the signature_policy subsection of AppConfig.
+type Config struct {
+	Enabled    bool     `json:"enabled,omitempty"`
+	PublicKeys []string `json:"public_keys,omitempty"`
+	Action     Action   `json:"action,omitempty"`
+}
+
+// Verifier checks an image's cosign signature before it is replicated.
+type Verifier interface {
+	Verify(ctx context.Context, imageRef string, insecure bool, username, password string) error
+}
+
+type nopVerifier struct{}
+
+func (nopVerifier) Verify(_ context.Context, _ string, _ bool, _, _ string) error { return nil }
+
+// New returns a Verifier for the given Config.
+// Returns a no-op verifier when cfg.Enabled is false.
+func New(cfg Config) (Verifier, error) {
+	if !cfg.Enabled {
+		return nopVerifier{}, nil
+	}
+	if len(cfg.PublicKeys) == 0 {
+		return nil, fmt.Errorf("signature_policy: at least one public_key path is required when enabled")
+	}
+	if cfg.Action == "" {
+		cfg.Action = ActionBlock
+	}
+	if cfg.Action != ActionBlock && cfg.Action != ActionWarn {
+		return nil, fmt.Errorf("signature_policy: invalid action %q, must be %q or %q", cfg.Action, ActionBlock, ActionWarn)
+	}
+
+	keys := make([]*ecdsa.PublicKey, 0, len(cfg.PublicKeys))
+	for _, path := range cfg.PublicKeys {
+		k, err := loadECPublicKey(path)
+		if err != nil {
+			return nil, fmt.Errorf("signature_policy: load key %s: %w", path, err)
+		}
+		keys = append(keys, k)
+	}
+	return &cosignVerifier{cfg: cfg, keys: keys}, nil
+}
+
+type cosignVerifier struct {
+	cfg  Config
+	keys []*ecdsa.PublicKey
+}
+
+// Verify fetches the cosign signature artifact for imageRef from the source
+// registry and checks it against each configured public key. Returns nil when
+// at least one key verifies a signature.
+//
+// Signature artifacts follow the cosign storage convention:
+//
+//	<registry>/<repo>/<name>:sha256-<hex>.sig
+//
+// Each layer in the signature manifest carries the ECDSA sig (DER, base64) in
+// the annotation dev.cosignproject.cosign/signature; the layer blob is the
+// simple-signing payload that was signed.
+func (v *cosignVerifier) Verify(ctx context.Context, imageRef string, insecure bool, username, password string) error {
+	var nameOpts []name.Option
+	if insecure {
+		nameOpts = append(nameOpts, name.Insecure)
+	}
+
+	opts := []remote.Option{remote.WithContext(ctx)}
+	if username != "" || password != "" {
+		opts = append(opts, remote.WithAuth(authn.FromConfig(authn.AuthConfig{
+			Username: username,
+			Password: password,
+		})))
+	}
+
+	ref, err := name.ParseReference(imageRef, nameOpts...)
+	if err != nil {
+		return fmt.Errorf("parse ref %q: %w", imageRef, err)
+	}
+
+	head, err := remote.Head(ref, opts...)
+	if err != nil {
+		return fmt.Errorf("resolve digest for %q: %w", imageRef, err)
+	}
+
+	sigTagStr := fmt.Sprintf("sha256-%s.sig", head.Digest.Hex)
+	sigRef, err := name.ParseReference(
+		fmt.Sprintf("%s:%s", ref.Context().String(), sigTagStr),
+		nameOpts...,
+	)
+	if err != nil {
+		return fmt.Errorf("build sig ref: %w", err)
+	}
+
+	sigImg, err := remote.Image(sigRef, opts...)
+	if err != nil {
+		return v.handleMissing(imageRef, fmt.Errorf("fetch signature artifact: %w", err))
+	}
+
+	manifest, err := sigImg.Manifest()
+	if err != nil {
+		return v.handleMissing(imageRef, fmt.Errorf("get signature manifest: %w", err))
+	}
+
+	if len(manifest.Layers) == 0 {
+		return v.handleMissing(imageRef, fmt.Errorf("no signatures found for %s", imageRef))
+	}
+
+	for _, layerDesc := range manifest.Layers {
+		if err := v.verifyLayer(sigImg, layerDesc); err == nil {
+			return nil
+		}
+	}
+
+	return v.handleMissing(imageRef, fmt.Errorf("no valid cosign signature found for %s", imageRef))
+}
+
+func (v *cosignVerifier) verifyLayer(img v1.Image, desc v1.Descriptor) error {
+	sigB64, ok := desc.Annotations[cosignSigAnnotation]
+	if !ok {
+		return fmt.Errorf("layer missing signature annotation")
+	}
+
+	sigDER, err := base64.StdEncoding.DecodeString(sigB64)
+	if err != nil {
+		return fmt.Errorf("decode signature: %w", err)
+	}
+
+	layer, err := img.LayerByDigest(desc.Digest)
+	if err != nil {
+		return fmt.Errorf("fetch layer: %w", err)
+	}
+
+	// The simple-signing payload blob is pushed uncompressed (raw JSON);
+	// Compressed() returns the stored bytes as-is from the registry.
+	rc, err := layer.Compressed()
+	if err != nil {
+		return fmt.Errorf("open layer: %w", err)
+	}
+	defer rc.Close()
+
+	payload, err := io.ReadAll(rc)
+	if err != nil {
+		return fmt.Errorf("read layer: %w", err)
+	}
+
+	hash := sha256.Sum256(payload)
+
+	for _, key := range v.keys {
+		if ecdsa.VerifyASN1(key, hash[:], sigDER) {
+			return nil
+		}
+	}
+	return fmt.Errorf("signature does not match any configured key")
+}
+
+func (v *cosignVerifier) handleMissing(imageRef string, cause error) error {
+	if v.cfg.Action == ActionWarn {
+		return &WarnError{Ref: imageRef, cause: cause}
+	}
+	return cause
+}
+
+// WarnError is returned when Action is "warn" and verification fails.
+// Callers can check with IsWarnError to treat it as a non-fatal condition.
+type WarnError struct {
+	Ref   string
+	cause error
+}
+
+func (e *WarnError) Error() string { return fmt.Sprintf("unverified image %s (warn-only): %v", e.Ref, e.cause) }
+func (e *WarnError) Unwrap() error { return e.cause }
+
+// IsWarnError reports whether err is a non-fatal signature warning.
+func IsWarnError(err error) bool {
+	_, ok := err.(*WarnError)
+	return ok
+}
+
+func loadECPublicKey(path string) (*ecdsa.PublicKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read key file: %w", err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block in %s", path)
+	}
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse PKIX key: %w", err)
+	}
+	ecPub, ok := pub.(*ecdsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("expected ECDSA public key, got %T", pub)
+	}
+	return ecPub, nil
+}

--- a/internal/policy/signature_test.go
+++ b/internal/policy/signature_test.go
@@ -1,0 +1,311 @@
+package policy
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/static"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/stretchr/testify/require"
+)
+
+// generateKey creates a P-256 ECDSA key pair and writes the public key to a PEM
+// file at path. Returns the private key for signing test payloads.
+func generateKey(t *testing.T, path string) *ecdsa.PrivateKey {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	der, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	require.NoError(t, err)
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	require.NoError(t, pem.Encode(f, &pem.Block{Type: "PUBLIC KEY", Bytes: der}))
+	return key
+}
+
+// signPayload returns a DER-encoded ECDSA signature over sha256(payload).
+func signPayload(t *testing.T, key *ecdsa.PrivateKey, payload []byte) []byte {
+	t.Helper()
+	hash := sha256.Sum256(payload)
+	r, s, err := ecdsa.Sign(rand.Reader, key, hash[:])
+	require.NoError(t, err)
+	sig, err := asn1.Marshal(struct{ R, S *big.Int }{r, s})
+	require.NoError(t, err)
+	return sig
+}
+
+// simpleSigning builds the cosign simple-signing payload JSON for the given digest.
+func simpleSigning(digest v1.Hash, ref string) []byte {
+	type criticalImage struct {
+		DockerManifestDigest string `json:"docker-manifest-digest"`
+	}
+	type criticalIdentity struct {
+		DockerReference string `json:"docker-reference"`
+	}
+	type critical struct {
+		Identity criticalIdentity `json:"identity"`
+		Image    criticalImage    `json:"image"`
+		Type     string           `json:"type"`
+	}
+	payload, _ := json.Marshal(struct {
+		Critical critical `json:"critical"`
+	}{
+		Critical: critical{
+			Identity: criticalIdentity{DockerReference: ref},
+			Image:    criticalImage{DockerManifestDigest: digest.String()},
+			Type:     "cosign container image signature",
+		},
+	})
+	return payload
+}
+
+// newTestRegistry starts an in-process OCI registry and returns the server
+// and its host:port address.
+func newTestRegistry(t *testing.T) (*httptest.Server, string) {
+	t.Helper()
+	srv := httptest.NewServer(registry.New())
+	t.Cleanup(srv.Close)
+	return srv, strings.TrimPrefix(srv.URL, "http://")
+}
+
+// pushSignedImage pushes a random image to addr/repo/name:tag and then pushes a
+// cosign signature artifact for it signed with key. Returns the image digest.
+func pushSignedImage(t *testing.T, key *ecdsa.PrivateKey, addr, repo, imgName, tag string) v1.Hash {
+	t.Helper()
+
+	img, err := random.Image(512, 1)
+	require.NoError(t, err)
+
+	imgRef, err := name.ParseReference(fmt.Sprintf("%s/%s/%s:%s", addr, repo, imgName, tag), name.Insecure)
+	require.NoError(t, err)
+	require.NoError(t, remote.Write(imgRef, img))
+
+	digest, err := img.Digest()
+	require.NoError(t, err)
+
+	refStr := fmt.Sprintf("%s/%s/%s:%s", addr, repo, imgName, tag)
+	payload := simpleSigning(digest, refStr)
+	sigDER := signPayload(t, key, payload)
+
+	sigLayer := static.NewLayer(payload, "application/vnd.dev.cosign.simplesigning.v1+json")
+	sigLayerHash, err := sigLayer.Digest()
+	require.NoError(t, err)
+
+	sigImg, err := mutate.AppendLayers(emptyImage(), sigLayer)
+	require.NoError(t, err)
+
+	sigImg = mutate.Annotations(sigImg, map[string]string{}).(v1.Image)
+	sigImg, err = setLayerAnnotation(sigImg, sigLayerHash, cosignSigAnnotation, base64.StdEncoding.EncodeToString(sigDER))
+	require.NoError(t, err)
+
+	sigTag := fmt.Sprintf("sha256-%s.sig", digest.Hex)
+	sigRef, err := name.ParseReference(
+		fmt.Sprintf("%s/%s/%s:%s", addr, repo, imgName, sigTag),
+		name.Insecure,
+	)
+	require.NoError(t, err)
+	require.NoError(t, remote.Write(sigRef, sigImg))
+
+	return digest
+}
+
+// emptyImage returns a minimal OCI image with no layers.
+func emptyImage() v1.Image {
+	base, err := random.Image(0, 0)
+	if err != nil {
+		panic(err)
+	}
+	img, _ := mutate.AppendLayers(
+		mutate.MediaType(
+			mutate.ConfigMediaType(base, types.OCIContentDescriptor),
+			types.OCIManifestSchema1,
+		),
+	)
+	return img
+}
+
+// setLayerAnnotation rebuilds the manifest with an annotation on the descriptor
+// for the layer identified by hash.
+func setLayerAnnotation(img v1.Image, hash v1.Hash, key, val string) (v1.Image, error) {
+	manifest, err := img.Manifest()
+	if err != nil {
+		return nil, err
+	}
+	for i, l := range manifest.Layers {
+		if l.Digest == hash {
+			if manifest.Layers[i].Annotations == nil {
+				manifest.Layers[i].Annotations = map[string]string{}
+			}
+			manifest.Layers[i].Annotations[key] = val
+		}
+	}
+	return &annotatedImage{Image: img, manifest: manifest}, nil
+}
+
+// annotatedImage wraps a v1.Image to return a modified manifest.
+// Both Manifest() and RawManifest() are overridden because remote.Write
+// serialises via RawManifest() when pushing to a registry.
+type annotatedImage struct {
+	v1.Image
+	manifest *v1.Manifest
+}
+
+func (a *annotatedImage) Manifest() (*v1.Manifest, error) { return a.manifest, nil }
+
+func (a *annotatedImage) RawManifest() ([]byte, error) {
+	return json.Marshal(a.manifest)
+}
+
+// --- tests ---
+
+func TestNew_Disabled(t *testing.T) {
+	v, err := New(Config{Enabled: false})
+	require.NoError(t, err)
+	require.NoError(t, v.Verify(context.Background(), "reg/img:tag", false, "", ""))
+}
+
+func TestNew_EnabledNoKeys(t *testing.T) {
+	_, err := New(Config{Enabled: true})
+	require.ErrorContains(t, err, "public_key")
+}
+
+func TestNew_InvalidAction(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "key.pem")
+	generateKey(t, keyPath)
+
+	_, err := New(Config{Enabled: true, PublicKeys: []string{keyPath}, Action: "invalid"})
+	require.ErrorContains(t, err, "invalid action")
+}
+
+func TestNew_DefaultsToBlock(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "key.pem")
+	generateKey(t, keyPath)
+
+	v, err := New(Config{Enabled: true, PublicKeys: []string{keyPath}})
+	require.NoError(t, err)
+	cv, ok := v.(*cosignVerifier)
+	require.True(t, ok)
+	require.Equal(t, ActionBlock, cv.cfg.Action)
+}
+
+func TestNew_MissingKeyFile(t *testing.T) {
+	_, err := New(Config{Enabled: true, PublicKeys: []string{"/nonexistent/key.pem"}})
+	require.ErrorContains(t, err, "read key file")
+}
+
+func TestNew_NonPEMKeyFile(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "key.pem")
+	require.NoError(t, os.WriteFile(keyPath, []byte("not a pem"), 0o600))
+
+	_, err := New(Config{Enabled: true, PublicKeys: []string{keyPath}})
+	require.ErrorContains(t, err, "no PEM block")
+}
+
+func TestWarnError(t *testing.T) {
+	inner := fmt.Errorf("no sigs")
+	w := &WarnError{Ref: "docker.io/library/alpine:latest", cause: inner}
+
+	require.True(t, IsWarnError(w))
+	require.False(t, IsWarnError(fmt.Errorf("plain error")))
+	require.Contains(t, w.Error(), "alpine")
+	require.ErrorIs(t, w, inner)
+}
+
+func TestVerify_ValidSignature(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "cosign.pub")
+	privKey := generateKey(t, keyPath)
+
+	_, addr := newTestRegistry(t)
+	pushSignedImage(t, privKey, addr, "library", "signed", "latest")
+
+	v, err := New(Config{Enabled: true, PublicKeys: []string{keyPath}})
+	require.NoError(t, err)
+
+	err = v.Verify(context.Background(), addr+"/library/signed:latest", true, "", "")
+	require.NoError(t, err)
+}
+
+func TestVerify_WrongKey(t *testing.T) {
+	dir := t.TempDir()
+	signingKeyPath := filepath.Join(dir, "signing.pub")
+	signingKey := generateKey(t, signingKeyPath)
+
+	wrongKeyPath := filepath.Join(dir, "wrong.pub")
+	generateKey(t, wrongKeyPath) // different key
+
+	_, addr := newTestRegistry(t)
+	pushSignedImage(t, signingKey, addr, "library", "signed", "latest")
+
+	v, err := New(Config{Enabled: true, PublicKeys: []string{wrongKeyPath}, Action: ActionBlock})
+	require.NoError(t, err)
+
+	err = v.Verify(context.Background(), addr+"/library/signed:latest", true, "", "")
+	require.Error(t, err)
+	require.False(t, IsWarnError(err))
+}
+
+func TestVerify_WarnMode_MissingSignature(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "key.pub")
+	generateKey(t, keyPath)
+
+	_, addr := newTestRegistry(t)
+	// Push image without any signature artifact
+	img, _ := random.Image(512, 1)
+	imgRef, _ := name.ParseReference(addr+"/library/unsigned:latest", name.Insecure)
+	require.NoError(t, remote.Write(imgRef, img))
+
+	v, err := New(Config{Enabled: true, PublicKeys: []string{keyPath}, Action: ActionWarn})
+	require.NoError(t, err)
+
+	err = v.Verify(context.Background(), addr+"/library/unsigned:latest", true, "", "")
+	require.Error(t, err)
+	require.True(t, IsWarnError(err))
+}
+
+func TestVerify_BlockMode_MissingSignature(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "key.pub")
+	generateKey(t, keyPath)
+
+	_, addr := newTestRegistry(t)
+	img, _ := random.Image(512, 1)
+	imgRef, _ := name.ParseReference(addr+"/library/unsigned:latest", name.Insecure)
+	require.NoError(t, remote.Write(imgRef, img))
+
+	v, err := New(Config{Enabled: true, PublicKeys: []string{keyPath}, Action: ActionBlock})
+	require.NoError(t, err)
+
+	err = v.Verify(context.Background(), addr+"/library/unsigned:latest", true, "", "")
+	require.Error(t, err)
+	require.False(t, IsWarnError(err))
+}

--- a/internal/state/replicator.go
+++ b/internal/state/replicator.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/container-registry/harbor-satellite/internal/logger"
+	"github.com/container-registry/harbor-satellite/internal/policy"
 	satTLS "github.com/container-registry/harbor-satellite/internal/tls"
 	"github.com/container-registry/harbor-satellite/pkg/config"
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -34,6 +35,7 @@ type BasicReplicator struct {
 	remoteUsername    string
 	remotePassword    string
 	tlsCfg            config.TLSConfig
+	verifier          policy.Verifier
 }
 
 func NewBasicReplicator(sourceUsername, sourcePassword, sourceRegistry, remoteURL, remoteUsername, remotePassword string, useUnsecure bool) Replicator {
@@ -51,6 +53,23 @@ func NewBasicReplicatorWithTLS(sourceUsername, sourcePassword, sourceRegistry, r
 		remotePassword:    remotePassword,
 		tlsCfg:            tlsCfg,
 	}
+}
+
+// NewBasicReplicatorWithVerifier creates a replicator that checks cosign
+// signatures before pushing each image. Pass nil to skip verification.
+func NewBasicReplicatorWithVerifier(sourceUsername, sourcePassword, sourceRegistry, remoteURL, remoteUsername, remotePassword string, useUnsecure bool, tlsCfg config.TLSConfig, v policy.Verifier) Replicator {
+	r := &BasicReplicator{
+		sourceUsername:    sourceUsername,
+		sourcePassword:    sourcePassword,
+		useUnsecure:       useUnsecure,
+		remoteRegistryURL: remoteURL,
+		sourceRegistry:    sourceRegistry,
+		remoteUsername:    remoteUsername,
+		remotePassword:    remotePassword,
+		tlsCfg:            tlsCfg,
+		verifier:          v,
+	}
+	return r
 }
 
 // Entity represents an image or artifact which needs to be handled by the replicator
@@ -76,16 +95,12 @@ func (e Entity) GetTag() string {
 // Replicate replicates images from the source registry to the local registry.
 // Before pulling, it checks which blobs already exist at the destination and
 // only downloads missing layers from source, saving bandwidth on crash recovery.
+// When a signature verifier is configured, each image is verified before push.
 func (r *BasicReplicator) Replicate(ctx context.Context, replicationEntities []Entity) error {
 	log := logger.FromContext(ctx)
-	pullAuth := authn.FromConfig(authn.AuthConfig{
-		Username: r.sourceUsername,
-		Password: r.sourcePassword,
-	})
-	pushAuth := authn.FromConfig(authn.AuthConfig{
-		Username: r.remoteUsername,
-		Password: r.remotePassword,
-	})
+
+	pullAuth := authn.FromConfig(authn.AuthConfig{Username: r.sourceUsername, Password: r.sourcePassword})
+	pushAuth := authn.FromConfig(authn.AuthConfig{Username: r.remoteUsername, Password: r.remotePassword})
 
 	var nameOpts []name.Option
 	pullOpts := []remote.Option{remote.WithAuth(pullAuth), remote.WithContext(ctx)}
@@ -105,74 +120,108 @@ func (r *BasicReplicator) Replicate(ctx context.Context, replicationEntities []E
 	}
 
 	for _, entity := range replicationEntities {
-		// Check context cancellation before processing each image
 		select {
 		case <-ctx.Done():
 			log.Warn().Err(ctx.Err()).Msg("Context cancelled, stopping replication")
 			return ctx.Err()
 		default:
 		}
-
-		srcRef := fmt.Sprintf("%s/%s/%s:%s", r.sourceRegistry, entity.GetRepository(), entity.GetName(), entity.GetTag())
-		dstRef := fmt.Sprintf("%s/%s/%s:%s", r.remoteRegistryURL, entity.GetRepository(), entity.GetName(), entity.GetTag())
-
-		src, err := name.ParseReference(srcRef, nameOpts...)
-		if err != nil {
-			return fmt.Errorf("parse source ref %s: %w", srcRef, err)
-		}
-
-		dst, err := name.ParseReference(dstRef, nameOpts...)
-		if err != nil {
-			return fmt.Errorf("parse dest ref %s: %w", dstRef, err)
-		}
-
-		// Lazy fetch: only the manifest is downloaded, no layer data yet
-		desc, err := remote.Get(src, pullOpts...)
-		if err != nil {
-			log.Error().Msgf("Failed to fetch image descriptor: %v", err)
+		if err := r.replicateOne(ctx, entity, nameOpts, pullOpts, pushOpts); err != nil {
 			return err
 		}
-
-		img, err := desc.Image()
-		if err != nil {
-			log.Error().Msgf("Failed to resolve image: %v", err)
-			return err
-		}
-
-		// Lazy OCI conversion, no data materialized
-		ociImage := mutate.MediaType(img, types.OCIManifestSchema1)
-
-		// Check if image already exists at destination with same digest
-		srcDigest, err := ociImage.Digest()
-		if err != nil {
-			return fmt.Errorf("compute source digest: %w", err)
-		}
-
-		dstDesc, dstErr := remote.Head(dst, pushOpts...)
-		if dstErr == nil && dstDesc.Digest == srcDigest {
-			log.Info().Msgf("Image %s already up-to-date at destination, skipping", entity.GetName())
-			continue
-		}
-
-		// Log which layers need pulling vs already present
-		srcLayers, err := ociImage.Layers()
-		if err != nil {
-			return fmt.Errorf("get source layers: %w", err)
-		}
-
-		missing := r.countMissingLayers(dst, srcLayers, pushOpts)
-		log.Info().Msgf("Replicating image %s: %d/%d layers to pull", entity.GetName(), missing, len(srcLayers))
-
-		// remote.Write streams layers one-by-one. For each layer it HEAD-checks
-		// the destination first; only missing blobs are pulled from source.
-		// Manifest is pushed last.
-		if err := remote.Write(dst, ociImage, pushOpts...); err != nil {
-			log.Error().Msgf("Failed to replicate image: %v", err)
-			return err
-		}
-		log.Info().Msgf("Image %s replicated successfully", entity.GetName())
 	}
 	return nil
+}
+
+// replicateOne handles a single entity: optional signature check, skip-if-current,
+// layer dedup logging, and final push.
+func (r *BasicReplicator) replicateOne(
+	ctx context.Context,
+	entity Entity,
+	nameOpts []name.Option,
+	pullOpts, pushOpts []remote.Option,
+) error {
+	log := logger.FromContext(ctx)
+
+	srcRef := fmt.Sprintf("%s/%s/%s:%s", r.sourceRegistry, entity.GetRepository(), entity.GetName(), entity.GetTag())
+	dstRef := fmt.Sprintf("%s/%s/%s:%s", r.remoteRegistryURL, entity.GetRepository(), entity.GetName(), entity.GetTag())
+
+	if err := r.checkSignature(ctx, srcRef, entity.GetName()); err != nil {
+		return err
+	}
+
+	src, err := name.ParseReference(srcRef, nameOpts...)
+	if err != nil {
+		return fmt.Errorf("parse source ref %s: %w", srcRef, err)
+	}
+
+	dst, err := name.ParseReference(dstRef, nameOpts...)
+	if err != nil {
+		return fmt.Errorf("parse dest ref %s: %w", dstRef, err)
+	}
+
+	// Lazy fetch: only the manifest is downloaded, no layer data yet
+	desc, err := remote.Get(src, pullOpts...)
+	if err != nil {
+		log.Error().Msgf("Failed to fetch image descriptor: %v", err)
+		return err
+	}
+
+	img, err := desc.Image()
+	if err != nil {
+		log.Error().Msgf("Failed to resolve image: %v", err)
+		return err
+	}
+
+	// Lazy OCI conversion, no data materialized
+	ociImage := mutate.MediaType(img, types.OCIManifestSchema1)
+
+	srcDigest, err := ociImage.Digest()
+	if err != nil {
+		return fmt.Errorf("compute source digest: %w", err)
+	}
+
+	dstDesc, dstErr := remote.Head(dst, pushOpts...)
+	if dstErr == nil && dstDesc.Digest == srcDigest {
+		log.Info().Msgf("Image %s already up-to-date at destination, skipping", entity.GetName())
+		return nil
+	}
+
+	srcLayers, err := ociImage.Layers()
+	if err != nil {
+		return fmt.Errorf("get source layers: %w", err)
+	}
+
+	missing := r.countMissingLayers(dst, srcLayers, pushOpts)
+	log.Info().Msgf("Replicating image %s: %d/%d layers to pull", entity.GetName(), missing, len(srcLayers))
+
+	// remote.Write streams layers one-by-one. For each layer it HEAD-checks
+	// the destination first; only missing blobs are pulled from source.
+	// Manifest is pushed last.
+	if err := remote.Write(dst, ociImage, pushOpts...); err != nil {
+		log.Error().Msgf("Failed to replicate image: %v", err)
+		return err
+	}
+	log.Info().Msgf("Image %s replicated successfully", entity.GetName())
+	return nil
+}
+
+// checkSignature verifies the cosign signature of imageRef when a verifier is
+// configured. Warn-mode failures are logged and replication continues.
+func (r *BasicReplicator) checkSignature(ctx context.Context, imageRef, entityName string) error {
+	if r.verifier == nil {
+		return nil
+	}
+	log := logger.FromContext(ctx)
+	err := r.verifier.Verify(ctx, imageRef, r.useUnsecure, r.sourceUsername, r.sourcePassword)
+	if err == nil {
+		return nil
+	}
+	if policy.IsWarnError(err) {
+		log.Warn().Msgf("signature warning for %s: %v", entityName, err)
+		return nil
+	}
+	return fmt.Errorf("signature check: %w", err)
 }
 
 // countMissingLayers checks which source layers are absent from the destination

--- a/internal/state/replicator.go
+++ b/internal/state/replicator.go
@@ -55,10 +55,17 @@ func NewBasicReplicatorWithTLS(sourceUsername, sourcePassword, sourceRegistry, r
 	}
 }
 
+// VerificationConfig bundles optional TLS and signature verification settings.
+type VerificationConfig struct {
+	TLS      config.TLSConfig
+	Verifier policy.Verifier
+}
+
 // NewBasicReplicatorWithVerifier creates a replicator that checks cosign
-// signatures before pushing each image. Pass nil to skip verification.
-func NewBasicReplicatorWithVerifier(sourceUsername, sourcePassword, sourceRegistry, remoteURL, remoteUsername, remotePassword string, useUnsecure bool, tlsCfg config.TLSConfig, v policy.Verifier) Replicator {
-	r := &BasicReplicator{
+// signatures before pushing each image. Pass a zero VerificationConfig to
+// disable both TLS and verification.
+func NewBasicReplicatorWithVerifier(sourceUsername, sourcePassword, sourceRegistry, remoteURL, remoteUsername, remotePassword string, useUnsecure bool, vcfg VerificationConfig) Replicator {
+	return &BasicReplicator{
 		sourceUsername:    sourceUsername,
 		sourcePassword:    sourcePassword,
 		useUnsecure:       useUnsecure,
@@ -66,10 +73,9 @@ func NewBasicReplicatorWithVerifier(sourceUsername, sourcePassword, sourceRegist
 		sourceRegistry:    sourceRegistry,
 		remoteUsername:    remoteUsername,
 		remotePassword:    remotePassword,
-		tlsCfg:            tlsCfg,
-		verifier:          v,
+		tlsCfg:            vcfg.TLS,
+		verifier:          vcfg.Verifier,
 	}
-	return r
 }
 
 // Entity represents an image or artifact which needs to be handled by the replicator
@@ -133,6 +139,41 @@ func (r *BasicReplicator) Replicate(ctx context.Context, replicationEntities []E
 	return nil
 }
 
+type ociImageInfo struct {
+	image  v1.Image
+	digest v1.Hash
+	layers []v1.Layer
+}
+
+// fetchOCIImage pulls the image descriptor, resolves the image, converts it to
+// OCI media type, and returns the image together with its digest and layers.
+func fetchOCIImage(src name.Reference, opts []remote.Option) (ociImageInfo, error) {
+	desc, err := remote.Get(src, opts...)
+	if err != nil {
+		return ociImageInfo{}, err
+	}
+	img, err := desc.Image()
+	if err != nil {
+		return ociImageInfo{}, err
+	}
+	ociImage := mutate.MediaType(img, types.OCIManifestSchema1)
+	digest, err := ociImage.Digest()
+	if err != nil {
+		return ociImageInfo{}, fmt.Errorf("compute source digest: %w", err)
+	}
+	layers, err := ociImage.Layers()
+	if err != nil {
+		return ociImageInfo{}, fmt.Errorf("get source layers: %w", err)
+	}
+	return ociImageInfo{image: ociImage, digest: digest, layers: layers}, nil
+}
+
+// isUpToDate returns true when the image at dst already matches srcDigest.
+func isUpToDate(dst name.Reference, srcDigest v1.Hash, opts []remote.Option) bool {
+	dstDesc, err := remote.Head(dst, opts...)
+	return err == nil && dstDesc.Digest == srcDigest
+}
+
 // replicateOne handles a single entity: optional signature check, skip-if-current,
 // layer dedup logging, and final push.
 func (r *BasicReplicator) replicateOne(
@@ -160,45 +201,23 @@ func (r *BasicReplicator) replicateOne(
 		return fmt.Errorf("parse dest ref %s: %w", dstRef, err)
 	}
 
-	// Lazy fetch: only the manifest is downloaded, no layer data yet
-	desc, err := remote.Get(src, pullOpts...)
+	info, err := fetchOCIImage(src, pullOpts)
 	if err != nil {
-		log.Error().Msgf("Failed to fetch image descriptor: %v", err)
+		log.Error().Msgf("Failed to fetch image: %v", err)
 		return err
 	}
 
-	img, err := desc.Image()
-	if err != nil {
-		log.Error().Msgf("Failed to resolve image: %v", err)
-		return err
-	}
-
-	// Lazy OCI conversion, no data materialized
-	ociImage := mutate.MediaType(img, types.OCIManifestSchema1)
-
-	srcDigest, err := ociImage.Digest()
-	if err != nil {
-		return fmt.Errorf("compute source digest: %w", err)
-	}
-
-	dstDesc, dstErr := remote.Head(dst, pushOpts...)
-	if dstErr == nil && dstDesc.Digest == srcDigest {
+	if isUpToDate(dst, info.digest, pushOpts) {
 		log.Info().Msgf("Image %s already up-to-date at destination, skipping", entity.GetName())
 		return nil
 	}
 
-	srcLayers, err := ociImage.Layers()
-	if err != nil {
-		return fmt.Errorf("get source layers: %w", err)
-	}
+	missing := r.countMissingLayers(dst, info.layers, pushOpts)
+	log.Info().Msgf("Replicating image %s: %d/%d layers to pull", entity.GetName(), missing, len(info.layers))
 
-	missing := r.countMissingLayers(dst, srcLayers, pushOpts)
-	log.Info().Msgf("Replicating image %s: %d/%d layers to pull", entity.GetName(), missing, len(srcLayers))
-
-	// remote.Write streams layers one-by-one. For each layer it HEAD-checks
-	// the destination first; only missing blobs are pulled from source.
-	// Manifest is pushed last.
-	if err := remote.Write(dst, ociImage, pushOpts...); err != nil {
+	// remote.Write streams layers one-by-one, HEAD-checking each blob at the
+	// destination first; only missing blobs are pulled from source.
+	if err := remote.Write(dst, info.image, pushOpts...); err != nil {
 		log.Error().Msgf("Failed to replicate image: %v", err)
 		return err
 	}

--- a/internal/state/replicator_test.go
+++ b/internal/state/replicator_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/container-registry/harbor-satellite/internal/policy"
-	"github.com/container-registry/harbor-satellite/pkg/config"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
@@ -373,7 +372,7 @@ func TestReplicate_SignatureBlock(t *testing.T) {
 	pushImage(t, srcAddr, "library", "alpine", "latest", 1)
 
 	verifier := &fakeVerifier{err: fmt.Errorf("image is not signed")}
-	r := NewBasicReplicatorWithVerifier("", "", srcAddr, dstAddr, "", "", true, config.TLSConfig{}, verifier)
+	r := NewBasicReplicatorWithVerifier("", "", srcAddr, dstAddr, "", "", true, VerificationConfig{Verifier: verifier})
 
 	err := r.Replicate(testContext(), []Entity{
 		{Name: "alpine", Repository: "library", Tag: "latest"},
@@ -387,7 +386,7 @@ func TestReplicate_SignatureWarn(t *testing.T) {
 	pushImage(t, srcAddr, "library", "alpine", "latest", 1)
 
 	verifier := &fakeVerifier{err: &policy.WarnError{Ref: "alpine:latest"}}
-	r := NewBasicReplicatorWithVerifier("", "", srcAddr, dstAddr, "", "", true, config.TLSConfig{}, verifier)
+	r := NewBasicReplicatorWithVerifier("", "", srcAddr, dstAddr, "", "", true, VerificationConfig{Verifier: verifier})
 
 	err := r.Replicate(testContext(), []Entity{
 		{Name: "alpine", Repository: "library", Tag: "latest"},
@@ -406,7 +405,7 @@ func TestReplicate_SignaturePass(t *testing.T) {
 	pushImage(t, srcAddr, "library", "alpine", "latest", 1)
 
 	verifier := &fakeVerifier{err: nil}
-	r := NewBasicReplicatorWithVerifier("", "", srcAddr, dstAddr, "", "", true, config.TLSConfig{}, verifier)
+	r := NewBasicReplicatorWithVerifier("", "", srcAddr, dstAddr, "", "", true, VerificationConfig{Verifier: verifier})
 
 	err := r.Replicate(testContext(), []Entity{
 		{Name: "alpine", Repository: "library", Tag: "latest"},

--- a/internal/state/replicator_test.go
+++ b/internal/state/replicator_test.go
@@ -2,10 +2,13 @@ package state
 
 import (
 	"context"
+	"fmt"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/container-registry/harbor-satellite/internal/policy"
+	"github.com/container-registry/harbor-satellite/pkg/config"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
@@ -15,6 +18,11 @@ import (
 	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/stretchr/testify/require"
 )
+
+// fakeVerifier is a test double for policy.Verifier.
+type fakeVerifier struct{ err error }
+
+func (f *fakeVerifier) Verify(_ context.Context, _ string, _ bool, _, _ string) error { return f.err }
 
 // newTestRegistry starts an in-memory OCI registry and returns the server
 // and its host:port address.
@@ -357,4 +365,51 @@ func TestDeleteReplicationEntity_CancelledContextStopsProcessing(t *testing.T) {
 	})
 
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestReplicate_SignatureBlock(t *testing.T) {
+	_, srcAddr := newTestRegistry(t)
+	_, dstAddr := newTestRegistry(t)
+	pushImage(t, srcAddr, "library", "alpine", "latest", 1)
+
+	verifier := &fakeVerifier{err: fmt.Errorf("image is not signed")}
+	r := NewBasicReplicatorWithVerifier("", "", srcAddr, dstAddr, "", "", true, config.TLSConfig{}, verifier)
+
+	err := r.Replicate(testContext(), []Entity{
+		{Name: "alpine", Repository: "library", Tag: "latest"},
+	})
+	require.ErrorContains(t, err, "signature check")
+}
+
+func TestReplicate_SignatureWarn(t *testing.T) {
+	_, srcAddr := newTestRegistry(t)
+	_, dstAddr := newTestRegistry(t)
+	pushImage(t, srcAddr, "library", "alpine", "latest", 1)
+
+	verifier := &fakeVerifier{err: &policy.WarnError{Ref: "alpine:latest"}}
+	r := NewBasicReplicatorWithVerifier("", "", srcAddr, dstAddr, "", "", true, config.TLSConfig{}, verifier)
+
+	err := r.Replicate(testContext(), []Entity{
+		{Name: "alpine", Repository: "library", Tag: "latest"},
+	})
+	require.NoError(t, err, "warn-mode failure must not block replication")
+
+	dstRef, err := name.ParseReference(dstAddr+"/library/alpine:latest", name.Insecure)
+	require.NoError(t, err)
+	_, err = remote.Head(dstRef)
+	require.NoError(t, err, "image should be present at destination despite signature warning")
+}
+
+func TestReplicate_SignaturePass(t *testing.T) {
+	_, srcAddr := newTestRegistry(t)
+	_, dstAddr := newTestRegistry(t)
+	pushImage(t, srcAddr, "library", "alpine", "latest", 1)
+
+	verifier := &fakeVerifier{err: nil}
+	r := NewBasicReplicatorWithVerifier("", "", srcAddr, dstAddr, "", "", true, config.TLSConfig{}, verifier)
+
+	err := r.Replicate(testContext(), []Entity{
+		{Name: "alpine", Repository: "library", Tag: "latest"},
+	})
+	require.NoError(t, err)
 }

--- a/internal/state/state_process.go
+++ b/internal/state/state_process.go
@@ -547,7 +547,7 @@ func (f *FetchAndReplicateStateProcess) setupReplication() (Replicator, string, 
 			verifier = v
 		}
 	}
-	replicator := NewBasicReplicatorWithVerifier(srcUsername, srcPassword, sourceURL, remoteURL, remoteUsername, remotePassword, useUnsecure, f.cm.GetTLSConfig(), verifier)
+	replicator := NewBasicReplicatorWithVerifier(srcUsername, srcPassword, sourceURL, remoteURL, remoteUsername, remotePassword, useUnsecure, VerificationConfig{TLS: f.cm.GetTLSConfig(), Verifier: verifier})
 
 	// Set up direct delivery if enabled, clear if disabled
 	dd := f.cm.GetDirectDeliveryConfig()

--- a/internal/state/state_process.go
+++ b/internal/state/state_process.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/container-registry/harbor-satellite/internal/logger"
+	"github.com/container-registry/harbor-satellite/internal/policy"
 	"github.com/container-registry/harbor-satellite/internal/utils"
 	"github.com/container-registry/harbor-satellite/pkg/config"
 	"github.com/rs/zerolog"
@@ -535,7 +536,18 @@ func (f *FetchAndReplicateStateProcess) setupReplication() (Replicator, string, 
 		}
 	}
 
-	replicator := NewBasicReplicator(srcUsername, srcPassword, sourceURL, remoteURL, remoteUsername, remotePassword, useUnsecure)
+	var verifier policy.Verifier
+	if sp := f.cm.GetSignaturePolicyConfig(); sp.Enabled {
+		v, err := policy.New(policy.Config{
+			Enabled:    sp.Enabled,
+			PublicKeys: sp.PublicKeys,
+			Action:     policy.Action(sp.Action),
+		})
+		if err == nil {
+			verifier = v
+		}
+	}
+	replicator := NewBasicReplicatorWithVerifier(srcUsername, srcPassword, sourceURL, remoteURL, remoteUsername, remotePassword, useUnsecure, f.cm.GetTLSConfig(), verifier)
 
 	// Set up direct delivery if enabled, clear if disabled
 	dd := f.cm.GetDirectDeliveryConfig()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,6 +50,21 @@ type DirectDeliveryConfig struct {
 	ImageDir string `json:"image_dir,omitempty"` // auto-detected if empty
 }
 
+// SignaturePolicy controls whether and how the satellite verifies cosign
+// signatures before replicating an image to the local registry.
+//
+// When enabled, the satellite fetches the cosign signature OCI artifact
+// (stored at <repo>:sha256-<digest>.sig) and verifies at least one layer
+// signature against the provided ECDSA public keys.
+//
+// Action "block" (default) aborts replication on failure.
+// Action "warn" logs a warning but continues replication.
+type SignaturePolicy struct {
+	Enabled    bool     `json:"enabled,omitempty"`
+	PublicKeys []string `json:"public_keys,omitempty"`
+	Action     string   `json:"action,omitempty"`
+}
+
 type AppConfig struct {
 	GroundControlURL          URL                    `json:"ground_control_url,omitempty"`
 	LogLevel                  string                 `json:"log_level,omitempty"`
@@ -66,6 +81,7 @@ type AppConfig struct {
 	RegistryFallback          RegistryFallbackConfig `json:"registry_fallback,omitempty"`
 	HarborRegistryURL         string                 `json:"harbor_registry_url,omitempty"`
 	DirectDelivery            DirectDeliveryConfig   `json:"direct_delivery,omitempty"`
+	SignaturePolicy           SignaturePolicy         `json:"signature_policy,omitempty"`
 }
 
 type StateConfig struct {

--- a/pkg/config/getters.go
+++ b/pkg/config/getters.go
@@ -189,3 +189,9 @@ func (cm *ConfigManager) GetDirectDeliveryConfig() DirectDeliveryConfig {
 	defer cm.mu.RUnlock()
 	return cm.config.AppConfig.DirectDelivery
 }
+
+func (cm *ConfigManager) GetSignaturePolicyConfig() SignaturePolicy {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.config.AppConfig.SignaturePolicy
+}


### PR DESCRIPTION
Adds a `signature_policy` configuration block to the satellite that lets operators require cosign-signed images before they are replicated to the local registry.

When enabled, the satellite fetches the cosign signature OCI artifact stored at `<repo>:sha256-<digest>.sig` and verifies at least one ECDSA signature layer against the configured public keys. This is implemented entirely using existing dependencies (go-containerregistry for OCI transport, stdlib crypto/ecdsa for verification) with no new module requirements.

The policy supports two failure modes:
- `block` (default): replication is aborted for unsigned or unverifiable images
- `warn`: a warning is logged but replication continues, useful for gradual rollout

Config example:
```json
{
  "app_config": {
    "signature_policy": {
      "enabled": true,
      "public_keys": ["/etc/satellite/cosign.pub"],
      "action": "block"
    }
  }
}
```

New `internal/policy` package introduces a `Verifier` interface so the replicator remains testable with mocks. The `cosignVerifier` implementation handles key loading, signature artifact fetching, and ECDSA verification. Replicator tests cover block, warn, and pass scenarios via a `fakeVerifier`. Policy unit tests cover key loading, action defaults, warn/block modes, and end-to-end verification against a real in-process OCI registry.

Closes #257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Optional signature verification for container images is now available during the replication process. Administrators can configure which public keys to use for verification and choose failure behavior: block replication when verification fails, or log warnings and allow replication to proceed. Configuration is managed through the new `signature_policy` settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->