### PR TITLE
fix: make config publication safer and retry-friendly

### DIFF
--- a/ground-control/internal/database/configs_extra.go
+++ b/ground-control/internal/database/configs_extra.go
@@ -1,0 +1,52 @@
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+const updateConfigIfMatch = `
+UPDATE configs
+SET registry_url = $2,
+    config = $3,
+    updated_at = NOW()
+WHERE config_name = $1
+  AND id = $4
+  AND created_at = $5
+  AND updated_at = $6
+RETURNING id, config_name, registry_url, config, created_at, updated_at
+`
+
+type UpdateConfigIfMatchParams struct {
+	ConfigName        string
+	RegistryUrl       string
+	Config            json.RawMessage
+	ExpectedID        int32
+	ExpectedCreatedAt time.Time
+	ExpectedUpdatedAt time.Time
+}
+
+func (q *Queries) UpdateConfigIfMatch(ctx context.Context, arg UpdateConfigIfMatchParams) (Config, error) {
+	row := q.db.QueryRowContext(
+		ctx,
+		updateConfigIfMatch,
+		arg.ConfigName,
+		arg.RegistryUrl,
+		arg.Config,
+		arg.ExpectedID,
+		arg.ExpectedCreatedAt,
+		arg.ExpectedUpdatedAt,
+	)
+
+	var cfg Config
+	err := row.Scan(
+		&cfg.ID,
+		&cfg.ConfigName,
+		&cfg.RegistryUrl,
+		&cfg.Config,
+		&cfg.CreatedAt,
+		&cfg.UpdatedAt,
+	)
+	return cfg, err
+}

--- a/ground-control/internal/database/configs_extra.go
+++ b/ground-control/internal/database/configs_extra.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"time"
 )
@@ -49,4 +50,37 @@ func (q *Queries) UpdateConfigIfMatch(ctx context.Context, arg UpdateConfigIfMat
 		&cfg.UpdatedAt,
 	)
 	return cfg, err
+}
+
+const deleteConfigIfMatch = `
+DELETE FROM configs
+WHERE id = $1
+  AND updated_at = $2
+`
+
+type DeleteConfigIfMatchParams struct {
+	ID                int32
+	ExpectedUpdatedAt time.Time
+}
+
+func (q *Queries) DeleteConfigIfMatch(ctx context.Context, arg DeleteConfigIfMatchParams) error {
+	result, err := q.db.ExecContext(
+		ctx,
+		deleteConfigIfMatch,
+		arg.ID,
+		arg.ExpectedUpdatedAt,
+	)
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return sql.ErrNoRows
+	}
+
+	return nil
 }

--- a/ground-control/internal/server/cached_images_test.go
+++ b/ground-control/internal/server/cached_images_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/container-registry/harbor-satellite/ground-control/internal/database"
+	"github.com/container-registry/harbor-satellite/ground-control/internal/utils"
 	"github.com/gorilla/mux"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
@@ -29,8 +30,10 @@ func newMockServer(t *testing.T) (*Server, sqlmock.Sqlmock) {
 	})
 
 	return &Server{
-		db:        db,
-		dbQueries: database.New(db),
+		db:                                 db,
+		dbQueries:                          database.New(db),
+		EnsureSatelliteProjectExistsFn:     ensureSatelliteProjectExists,
+		CreateAndPushConfigStateArtifactFn: utils.CreateAndPushConfigStateArtifact,
 	}, mock
 }
 

--- a/ground-control/internal/server/config_handlers.go
+++ b/ground-control/internal/server/config_handlers.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -8,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/container-registry/harbor-satellite/ground-control/internal/database"
 	"github.com/container-registry/harbor-satellite/ground-control/internal/models"
@@ -21,6 +23,30 @@ import (
 type SatelliteConfigParams struct {
 	Satellite  string `json:"satellite,omitempty"`
 	ConfigName string `json:"config_name"`
+}
+
+const configPostCommitTimeout = 30 * time.Second
+
+func newConfigPostCommitContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), configPostCommitTimeout)
+}
+
+func (s *Server) restoreConfigIfUnchanged(ctx context.Context, configName string, existing, saved database.Config) error {
+	_, err := s.dbQueries.UpdateConfigIfMatch(ctx, database.UpdateConfigIfMatchParams{
+		ConfigName:        configName,
+		RegistryUrl:       existing.RegistryUrl,
+		Config:            existing.Config,
+		ExpectedID:        saved.ID,
+		ExpectedCreatedAt: saved.CreatedAt,
+		ExpectedUpdatedAt: saved.UpdatedAt,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return &AppError{
+			Message: "Error: config updated but rollback skipped because a newer config was saved",
+			Code:    http.StatusConflict,
+		}
+	}
+	return err
 }
 
 func (s *Server) createConfigHandler(w http.ResponseWriter, r *http.Request) {
@@ -121,8 +147,11 @@ func (s *Server) createConfigHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	committed = true
 
-	if err := ensureSatelliteProjectExistsFn(r.Context()); err != nil {
-		if cleanupErr := s.dbQueries.DeleteConfig(r.Context(), result.ID); cleanupErr != nil {
+	postCommitCtx, cancel := newConfigPostCommitContext()
+	defer cancel()
+
+	if err := s.EnsureSatelliteProjectExistsFn(postCommitCtx); err != nil {
+		if cleanupErr := s.dbQueries.DeleteConfig(postCommitCtx, result.ID); cleanupErr != nil {
 			log.Printf("Error cleaning up config after project ensure failure: %v", cleanupErr)
 			HandleAppError(w, &AppError{
 				Message: "Error: config saved but cleanup failed after publication setup error",
@@ -135,8 +164,8 @@ func (s *Server) createConfigHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := createAndPushConfigStateArtifactFn(r.Context(), configJson, req.ConfigName); err != nil {
-		if cleanupErr := s.dbQueries.DeleteConfig(r.Context(), result.ID); cleanupErr != nil {
+	if err := s.CreateAndPushConfigStateArtifactFn(postCommitCtx, configJson, req.ConfigName); err != nil {
+		if cleanupErr := s.dbQueries.DeleteConfig(postCommitCtx, result.ID); cleanupErr != nil {
 			log.Printf("Error cleaning up config after artifact publish failure: %v", cleanupErr)
 			HandleAppError(w, &AppError{
 				Message: "Error: config saved but cleanup failed after artifact publication error",
@@ -278,17 +307,17 @@ func (s *Server) updateConfigHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	committed = true
 
-	if err := ensureSatelliteProjectExistsFn(r.Context()); err != nil {
-		if _, restoreErr := s.dbQueries.UpdateConfig(r.Context(), database.UpdateConfigParams{
-			ConfigName:  configName,
-			RegistryUrl: existing.RegistryUrl,
-			Config:      existing.Config,
-		}); restoreErr != nil {
-			log.Printf("Error restoring config after project ensure failure: %v", restoreErr)
-			HandleAppError(w, &AppError{
-				Message: "Error: config updated but rollback failed after publication setup error",
-				Code:    http.StatusInternalServerError,
-			})
+	postCommitCtx, cancel := newConfigPostCommitContext()
+	defer cancel()
+
+	if err := s.EnsureSatelliteProjectExistsFn(postCommitCtx); err != nil {
+		if restoreErr := s.restoreConfigIfUnchanged(postCommitCtx, configName, existing, result); restoreErr != nil {
+			if appErr, ok := restoreErr.(*AppError); ok && appErr.Code == http.StatusConflict {
+				log.Printf("Skipped config restore after project ensure failure because the config changed concurrently: %v", restoreErr)
+			} else {
+				log.Printf("Error restoring config after project ensure failure: %v", restoreErr)
+			}
+			HandleAppError(w, restoreErr)
 			return
 		}
 		log.Println("Error while ensuring project satellite: ", err)
@@ -296,17 +325,14 @@ func (s *Server) updateConfigHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := createAndPushConfigStateArtifactFn(r.Context(), patchedJson, configName); err != nil {
-		if _, restoreErr := s.dbQueries.UpdateConfig(r.Context(), database.UpdateConfigParams{
-			ConfigName:  configName,
-			RegistryUrl: existing.RegistryUrl,
-			Config:      existing.Config,
-		}); restoreErr != nil {
-			log.Printf("Error restoring config after artifact publish failure: %v", restoreErr)
-			HandleAppError(w, &AppError{
-				Message: "Error: config updated but rollback failed after artifact publication error",
-				Code:    http.StatusInternalServerError,
-			})
+	if err := s.CreateAndPushConfigStateArtifactFn(postCommitCtx, patchedJson, configName); err != nil {
+		if restoreErr := s.restoreConfigIfUnchanged(postCommitCtx, configName, existing, result); restoreErr != nil {
+			if appErr, ok := restoreErr.(*AppError); ok && appErr.Code == http.StatusConflict {
+				log.Printf("Skipped config restore after artifact publish failure because the config changed concurrently: %v", restoreErr)
+			} else {
+				log.Printf("Error restoring config after artifact publish failure: %v", restoreErr)
+			}
+			HandleAppError(w, restoreErr)
 			return
 		}
 		log.Println("Error while creating config state artifact: ", err)

--- a/ground-control/internal/server/config_handlers.go
+++ b/ground-control/internal/server/config_handlers.go
@@ -74,22 +74,31 @@ func (s *Server) createConfigHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := ensureSatelliteProjectExists(r.Context()); err != nil {
-		log.Println("Error while ensuring project satellite: ", err)
-		HandleAppError(w, err)
-		return
-	}
-
 	params := database.CreateConfigParams{
 		ConfigName:  req.ConfigName,
 		RegistryUrl: os.Getenv("HARBOR_URL"),
 		Config:      configJson,
 	}
 
-	_, err = q.CreateConfig(r.Context(), params)
+	result, err := q.CreateConfig(r.Context(), params)
 	if err != nil {
 		var pqErr *pq.Error
 		if errors.As(err, &pqErr) && pqErr.Code == "23505" {
+			existing, fetchErr := s.dbQueries.GetConfigByName(r.Context(), req.ConfigName)
+			if fetchErr == nil && jsonSemanticallyEqual(existing.Config, configJson) {
+				committed = true
+				if rollbackErr := tx.Rollback(); rollbackErr != nil {
+					log.Printf("Error: Failed to rollback duplicate config transaction: %v", rollbackErr)
+					HandleAppError(w, &AppError{
+						Message: "Error: Failed to rollback transaction",
+						Code:    http.StatusInternalServerError,
+					})
+					return
+				}
+				WriteJSONResponse(w, http.StatusOK, existing)
+				return
+			}
+
 			log.Printf("error: config with name '%s' already exists", req.ConfigName)
 			HandleAppError(w, &AppError{
 				Message: "error: config already exists",
@@ -98,14 +107,6 @@ func (s *Server) createConfigHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		log.Println("Error persisting config object to database: ", err)
-		HandleAppError(w, err)
-		return
-	}
-
-	// Push config as OCI artifact
-	err = utils.CreateAndPushConfigStateArtifact(r.Context(), configJson, req.ConfigName)
-	if err != nil {
-		log.Println("Error while creating config state artifact: ", err)
 		HandleAppError(w, err)
 		return
 	}
@@ -120,7 +121,38 @@ func (s *Server) createConfigHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	committed = true
 
-	w.WriteHeader(http.StatusCreated)
+	if err := ensureSatelliteProjectExistsFn(r.Context()); err != nil {
+		if cleanupErr := s.dbQueries.DeleteConfig(r.Context(), result.ID); cleanupErr != nil {
+			log.Printf("Error cleaning up config after project ensure failure: %v", cleanupErr)
+			HandleAppError(w, &AppError{
+				Message: "Error: config saved but cleanup failed after publication setup error",
+				Code:    http.StatusInternalServerError,
+			})
+			return
+		}
+		log.Println("Error while ensuring project satellite: ", err)
+		HandleAppError(w, err)
+		return
+	}
+
+	if err := createAndPushConfigStateArtifactFn(r.Context(), configJson, req.ConfigName); err != nil {
+		if cleanupErr := s.dbQueries.DeleteConfig(r.Context(), result.ID); cleanupErr != nil {
+			log.Printf("Error cleaning up config after artifact publish failure: %v", cleanupErr)
+			HandleAppError(w, &AppError{
+				Message: "Error: config saved but cleanup failed after artifact publication error",
+				Code:    http.StatusInternalServerError,
+			})
+			return
+		}
+		log.Println("Error while creating config state artifact: ", err)
+		HandleAppError(w, &AppError{
+			Message: "Error: failed to publish config artifact",
+			Code:    http.StatusBadGateway,
+		})
+		return
+	}
+
+	WriteJSONResponse(w, http.StatusCreated, result)
 }
 
 func (s *Server) updateConfigHandler(w http.ResponseWriter, r *http.Request) {
@@ -209,9 +241,17 @@ func (s *Server) updateConfigHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := ensureSatelliteProjectExists(r.Context()); err != nil {
-		log.Println("Error while ensuring project satellite: ", err)
-		HandleAppError(w, err)
+	if jsonSemanticallyEqual(existing.Config, patchedJson) {
+		committed = true
+		if rollbackErr := tx.Rollback(); rollbackErr != nil {
+			log.Printf("Error: Failed to rollback no-op config update transaction: %v", rollbackErr)
+			HandleAppError(w, &AppError{
+				Message: "Error: Failed to rollback transaction",
+				Code:    http.StatusInternalServerError,
+			})
+			return
+		}
+		WriteJSONResponse(w, http.StatusOK, existing)
 		return
 	}
 
@@ -228,14 +268,6 @@ func (s *Server) updateConfigHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Push config as OCI artifact
-	err = utils.CreateAndPushConfigStateArtifact(r.Context(), patchedJson, configName)
-	if err != nil {
-		log.Println("Error while creating config state artifact: ", err)
-		HandleAppError(w, err)
-		return
-	}
-
 	if err := tx.Commit(); err != nil {
 		log.Printf("Failed to commit transaction: %v", err)
 		HandleAppError(w, &AppError{
@@ -245,6 +277,45 @@ func (s *Server) updateConfigHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	committed = true
+
+	if err := ensureSatelliteProjectExistsFn(r.Context()); err != nil {
+		if _, restoreErr := s.dbQueries.UpdateConfig(r.Context(), database.UpdateConfigParams{
+			ConfigName:  configName,
+			RegistryUrl: existing.RegistryUrl,
+			Config:      existing.Config,
+		}); restoreErr != nil {
+			log.Printf("Error restoring config after project ensure failure: %v", restoreErr)
+			HandleAppError(w, &AppError{
+				Message: "Error: config updated but rollback failed after publication setup error",
+				Code:    http.StatusInternalServerError,
+			})
+			return
+		}
+		log.Println("Error while ensuring project satellite: ", err)
+		HandleAppError(w, err)
+		return
+	}
+
+	if err := createAndPushConfigStateArtifactFn(r.Context(), patchedJson, configName); err != nil {
+		if _, restoreErr := s.dbQueries.UpdateConfig(r.Context(), database.UpdateConfigParams{
+			ConfigName:  configName,
+			RegistryUrl: existing.RegistryUrl,
+			Config:      existing.Config,
+		}); restoreErr != nil {
+			log.Printf("Error restoring config after artifact publish failure: %v", restoreErr)
+			HandleAppError(w, &AppError{
+				Message: "Error: config updated but rollback failed after artifact publication error",
+				Code:    http.StatusInternalServerError,
+			})
+			return
+		}
+		log.Println("Error while creating config state artifact: ", err)
+		HandleAppError(w, &AppError{
+			Message: "Error: failed to publish config artifact",
+			Code:    http.StatusBadGateway,
+		})
+		return
+	}
 
 	WriteJSONResponse(w, http.StatusOK, result)
 }
@@ -329,7 +400,7 @@ func (s *Server) setSatelliteConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-    // TODO: Store the groupStates in memory to survive hot reloads
+	// TODO: Store the groupStates in memory to survive hot reloads
 	var groupStates []string
 	for _, group := range groupList {
 		grp, err := q.GetGroupByID(r.Context(), group.GroupID)

--- a/ground-control/internal/server/config_handlers.go
+++ b/ground-control/internal/server/config_handlers.go
@@ -49,6 +49,20 @@ func (s *Server) restoreConfigIfUnchanged(ctx context.Context, configName string
 	return err
 }
 
+func (s *Server) deleteConfigIfUnchanged(ctx context.Context, saved database.Config) error {
+	err := s.dbQueries.DeleteConfigIfMatch(ctx, database.DeleteConfigIfMatchParams{
+		ID:                saved.ID,
+		ExpectedUpdatedAt: saved.UpdatedAt,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return &AppError{
+			Message: "Error: config saved but cleanup skipped because a newer config was saved",
+			Code:    http.StatusConflict,
+		}
+	}
+	return err
+}
+
 func (s *Server) createConfigHandler(w http.ResponseWriter, r *http.Request) {
 	var req models.ConfigObject
 
@@ -151,12 +165,13 @@ func (s *Server) createConfigHandler(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	if err := s.EnsureSatelliteProjectExistsFn(postCommitCtx); err != nil {
-		if cleanupErr := s.dbQueries.DeleteConfig(postCommitCtx, result.ID); cleanupErr != nil {
-			log.Printf("Error cleaning up config after project ensure failure: %v", cleanupErr)
-			HandleAppError(w, &AppError{
-				Message: "Error: config saved but cleanup failed after publication setup error",
-				Code:    http.StatusInternalServerError,
-			})
+		if cleanupErr := s.deleteConfigIfUnchanged(postCommitCtx, result); cleanupErr != nil {
+			if appErr, ok := cleanupErr.(*AppError); ok && appErr.Code == http.StatusConflict {
+				log.Printf("Skipped config cleanup after project ensure failure because the config changed concurrently: %v", cleanupErr)
+			} else {
+				log.Printf("Error cleaning up config after project ensure failure: %v", cleanupErr)
+			}
+			HandleAppError(w, cleanupErr)
 			return
 		}
 		log.Println("Error while ensuring project satellite: ", err)
@@ -165,12 +180,13 @@ func (s *Server) createConfigHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.CreateAndPushConfigStateArtifactFn(postCommitCtx, configJson, req.ConfigName); err != nil {
-		if cleanupErr := s.dbQueries.DeleteConfig(postCommitCtx, result.ID); cleanupErr != nil {
-			log.Printf("Error cleaning up config after artifact publish failure: %v", cleanupErr)
-			HandleAppError(w, &AppError{
-				Message: "Error: config saved but cleanup failed after artifact publication error",
-				Code:    http.StatusInternalServerError,
-			})
+		if cleanupErr := s.deleteConfigIfUnchanged(postCommitCtx, result); cleanupErr != nil {
+			if appErr, ok := cleanupErr.(*AppError); ok && appErr.Code == http.StatusConflict {
+				log.Printf("Skipped config cleanup after artifact publish failure because the config changed concurrently: %v", cleanupErr)
+			} else {
+				log.Printf("Error cleaning up config after artifact publish failure: %v", cleanupErr)
+			}
+			HandleAppError(w, cleanupErr)
 			return
 		}
 		log.Println("Error while creating config state artifact: ", err)

--- a/ground-control/internal/server/config_handlers_test.go
+++ b/ground-control/internal/server/config_handlers_test.go
@@ -159,6 +159,8 @@ func TestCreateConfigHandler_EmptyName(t *testing.T) {
 }
 
 func TestCreateConfigHandler_PublishFailureDeletesCommittedConfig(t *testing.T) {
+	t.Setenv("HARBOR_URL", "")
+
 	server, mock := newMockServer(t)
 	now := time.Now().UTC().Truncate(time.Second)
 	body := []byte(`{"config_name":"test-config","config":{"app_config":{"log_level":"info"}}}`)
@@ -174,7 +176,7 @@ func TestCreateConfigHandler_PublishFailureDeletesCommittedConfig(t *testing.T) 
 			AddRow(1, "test-config", "", configJSON, now, now))
 	mock.ExpectCommit()
 	mock.ExpectExec("DELETE FROM configs").
-		WithArgs(int32(1)).
+		WithArgs(int32(1), now).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	req := httptest.NewRequest(http.MethodPost, "/api/configs", bytes.NewReader(body))
@@ -188,6 +190,8 @@ func TestCreateConfigHandler_PublishFailureDeletesCommittedConfig(t *testing.T) 
 }
 
 func TestCreateConfigHandler_PostCommitUsesDeadlineContext(t *testing.T) {
+	t.Setenv("HARBOR_URL", "")
+
 	server, mock := newMockServer(t)
 	now := time.Now().UTC().Truncate(time.Second)
 	body := []byte(`{"config_name":"test-config","config":{"app_config":{"log_level":"info"}}}`)
@@ -207,7 +211,7 @@ func TestCreateConfigHandler_PostCommitUsesDeadlineContext(t *testing.T) {
 			AddRow(1, "test-config", "", configJSON, now, now))
 	mock.ExpectCommit()
 	mock.ExpectExec("DELETE FROM configs").
-		WithArgs(int32(1)).
+		WithArgs(int32(1), now).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	req := httptest.NewRequest(http.MethodPost, "/api/configs", bytes.NewReader(body))
@@ -220,7 +224,41 @@ func TestCreateConfigHandler_PostCommitUsesDeadlineContext(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestCreateConfigHandler_PublishFailureSkipsCleanupAfterConcurrentUpdate(t *testing.T) {
+	t.Setenv("HARBOR_URL", "")
+
+	server, mock := newMockServer(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	body := []byte(`{"config_name":"test-config","config":{"app_config":{"log_level":"info"}}}`)
+	configJSON := mustMarshalRequestConfig(t, body)
+
+	server.EnsureSatelliteProjectExistsFn = func(context.Context) error { return nil }
+	server.CreateAndPushConfigStateArtifactFn = func(context.Context, []byte, string) error { return fmt.Errorf("push failed") }
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("INSERT INTO configs").
+		WithArgs("test-config", "", configJSON).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "config_name", "registry_url", "config", "created_at", "updated_at"}).
+			AddRow(1, "test-config", "", configJSON, now, now))
+	mock.ExpectCommit()
+	mock.ExpectExec("DELETE FROM configs").
+		WithArgs(int32(1), now).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/configs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	server.createConfigHandler(rr, req)
+
+	require.Equal(t, http.StatusConflict, rr.Code)
+	require.Contains(t, rr.Body.String(), "cleanup skipped")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestUpdateConfigHandler_PublishFailureRestoresCommittedConfigWhenUnchanged(t *testing.T) {
+	t.Setenv("HARBOR_URL", "")
+
 	server, mock := newMockServer(t)
 	createdAt := time.Now().UTC().Add(-2 * time.Minute).Truncate(time.Second)
 	originalUpdatedAt := createdAt.Add(30 * time.Second)
@@ -278,6 +316,8 @@ func TestUpdateConfigHandler_PublishFailureRestoresCommittedConfigWhenUnchanged(
 }
 
 func TestUpdateConfigHandler_PublishFailureSkipsRestoreAfterConcurrentUpdate(t *testing.T) {
+	t.Setenv("HARBOR_URL", "")
+
 	server, mock := newMockServer(t)
 	createdAt := time.Now().UTC().Add(-2 * time.Minute).Truncate(time.Second)
 	originalUpdatedAt := createdAt.Add(30 * time.Second)

--- a/ground-control/internal/server/config_handlers_test.go
+++ b/ground-control/internal/server/config_handlers_test.go
@@ -12,25 +12,13 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/container-registry/harbor-satellite/ground-control/internal/database"
 	"github.com/container-registry/harbor-satellite/ground-control/internal/models"
+	configpkg "github.com/container-registry/harbor-satellite/pkg/config"
+	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 )
-
-func stubConfigPublicationSideEffects(t *testing.T) {
-	t.Helper()
-
-	origEnsure := ensureSatelliteProjectExistsFn
-	origPush := createAndPushConfigStateArtifactFn
-
-	ensureSatelliteProjectExistsFn = func(context.Context) error { return nil }
-	createAndPushConfigStateArtifactFn = func(context.Context, []byte, string) error { return nil }
-
-	t.Cleanup(func() {
-		ensureSatelliteProjectExistsFn = origEnsure
-		createAndPushConfigStateArtifactFn = origPush
-	})
-}
 
 func mustMarshalRequestConfig(t *testing.T, body []byte) json.RawMessage {
 	t.Helper()
@@ -41,6 +29,20 @@ func mustMarshalRequestConfig(t *testing.T, body []byte) json.RawMessage {
 	configJSON, err := json.Marshal(req.Config)
 	require.NoError(t, err)
 	return configJSON
+}
+
+func mustMergePatchedConfig(t *testing.T, existing json.RawMessage, body []byte) json.RawMessage {
+	t.Helper()
+
+	var req configpkg.Config
+	require.NoError(t, json.Unmarshal(body, &req))
+
+	configJSON, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	patchedJSON, err := jsonpatch.MergePatch(existing, configJSON)
+	require.NoError(t, err)
+	return patchedJSON
 }
 
 func TestListConfigsHandler(t *testing.T) {
@@ -162,14 +164,8 @@ func TestCreateConfigHandler_PublishFailureDeletesCommittedConfig(t *testing.T) 
 	body := []byte(`{"config_name":"test-config","config":{"app_config":{"log_level":"info"}}}`)
 	configJSON := mustMarshalRequestConfig(t, body)
 
-	origEnsure := ensureSatelliteProjectExistsFn
-	origPush := createAndPushConfigStateArtifactFn
-	ensureSatelliteProjectExistsFn = func(context.Context) error { return nil }
-	createAndPushConfigStateArtifactFn = func(context.Context, []byte, string) error { return fmt.Errorf("push failed") }
-	t.Cleanup(func() {
-		ensureSatelliteProjectExistsFn = origEnsure
-		createAndPushConfigStateArtifactFn = origPush
-	})
+	server.EnsureSatelliteProjectExistsFn = func(context.Context) error { return nil }
+	server.CreateAndPushConfigStateArtifactFn = func(context.Context, []byte, string) error { return fmt.Errorf("push failed") }
 
 	mock.ExpectBegin()
 	mock.ExpectQuery("INSERT INTO configs").
@@ -188,6 +184,134 @@ func TestCreateConfigHandler_PublishFailureDeletesCommittedConfig(t *testing.T) 
 	server.createConfigHandler(rr, req)
 
 	require.Equal(t, http.StatusBadGateway, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCreateConfigHandler_PostCommitUsesDeadlineContext(t *testing.T) {
+	server, mock := newMockServer(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	body := []byte(`{"config_name":"test-config","config":{"app_config":{"log_level":"info"}}}`)
+	configJSON := mustMarshalRequestConfig(t, body)
+
+	server.EnsureSatelliteProjectExistsFn = func(ctx context.Context) error {
+		_, ok := ctx.Deadline()
+		require.True(t, ok)
+		return fmt.Errorf("ensure failed")
+	}
+	server.CreateAndPushConfigStateArtifactFn = func(context.Context, []byte, string) error { return nil }
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("INSERT INTO configs").
+		WithArgs("test-config", "", configJSON).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "config_name", "registry_url", "config", "created_at", "updated_at"}).
+			AddRow(1, "test-config", "", configJSON, now, now))
+	mock.ExpectCommit()
+	mock.ExpectExec("DELETE FROM configs").
+		WithArgs(int32(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/configs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	server.createConfigHandler(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUpdateConfigHandler_PublishFailureRestoresCommittedConfigWhenUnchanged(t *testing.T) {
+	server, mock := newMockServer(t)
+	createdAt := time.Now().UTC().Add(-2 * time.Minute).Truncate(time.Second)
+	originalUpdatedAt := createdAt.Add(30 * time.Second)
+	savedUpdatedAt := createdAt.Add(60 * time.Second)
+	restoredUpdatedAt := createdAt.Add(90 * time.Second)
+	existingJSON := json.RawMessage(`{"app_config":{"log_level":"info"}}`)
+	patchBody := []byte(`{"app_config":{"log_level":"debug"}}`)
+	patchedJSON := mustMergePatchedConfig(t, existingJSON, patchBody)
+	restoreResult := database.Config{
+		ID:          1,
+		ConfigName:  "test-config",
+		RegistryUrl: "",
+		Config:      existingJSON,
+		CreatedAt:   createdAt,
+		UpdatedAt:   restoredUpdatedAt,
+	}
+
+	server.EnsureSatelliteProjectExistsFn = func(ctx context.Context) error {
+		_, ok := ctx.Deadline()
+		require.True(t, ok)
+		return nil
+	}
+	server.CreateAndPushConfigStateArtifactFn = func(ctx context.Context, data []byte, name string) error {
+		_, ok := ctx.Deadline()
+		require.True(t, ok)
+		require.JSONEq(t, string(patchedJSON), string(data))
+		require.Equal(t, "test-config", name)
+		return fmt.Errorf("push failed")
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .+ FROM configs WHERE config_name").
+		WithArgs("test-config").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "config_name", "registry_url", "config", "created_at", "updated_at"}).
+			AddRow(1, "test-config", "", existingJSON, createdAt, originalUpdatedAt))
+	mock.ExpectQuery("UPDATE configs").
+		WithArgs("test-config", "", patchedJSON).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "config_name", "registry_url", "config", "created_at", "updated_at"}).
+			AddRow(1, "test-config", "", patchedJSON, createdAt, savedUpdatedAt))
+	mock.ExpectCommit()
+	mock.ExpectQuery("UPDATE configs").
+		WithArgs("test-config", "", existingJSON, int32(1), createdAt, savedUpdatedAt).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "config_name", "registry_url", "config", "created_at", "updated_at"}).
+			AddRow(restoreResult.ID, restoreResult.ConfigName, restoreResult.RegistryUrl, restoreResult.Config, restoreResult.CreatedAt, restoreResult.UpdatedAt))
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/configs/test-config", bytes.NewReader(patchBody))
+	req = mux.SetURLVars(req, map[string]string{"config": "test-config"})
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	server.updateConfigHandler(rr, req)
+
+	require.Equal(t, http.StatusBadGateway, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUpdateConfigHandler_PublishFailureSkipsRestoreAfterConcurrentUpdate(t *testing.T) {
+	server, mock := newMockServer(t)
+	createdAt := time.Now().UTC().Add(-2 * time.Minute).Truncate(time.Second)
+	originalUpdatedAt := createdAt.Add(30 * time.Second)
+	savedUpdatedAt := createdAt.Add(60 * time.Second)
+	existingJSON := json.RawMessage(`{"app_config":{"log_level":"info"}}`)
+	patchBody := []byte(`{"app_config":{"log_level":"debug"}}`)
+	patchedJSON := mustMergePatchedConfig(t, existingJSON, patchBody)
+
+	server.EnsureSatelliteProjectExistsFn = func(context.Context) error { return nil }
+	server.CreateAndPushConfigStateArtifactFn = func(context.Context, []byte, string) error { return fmt.Errorf("push failed") }
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .+ FROM configs WHERE config_name").
+		WithArgs("test-config").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "config_name", "registry_url", "config", "created_at", "updated_at"}).
+			AddRow(1, "test-config", "", existingJSON, createdAt, originalUpdatedAt))
+	mock.ExpectQuery("UPDATE configs").
+		WithArgs("test-config", "", patchedJSON).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "config_name", "registry_url", "config", "created_at", "updated_at"}).
+			AddRow(1, "test-config", "", patchedJSON, createdAt, savedUpdatedAt))
+	mock.ExpectCommit()
+	mock.ExpectQuery("UPDATE configs").
+		WithArgs("test-config", "", existingJSON, int32(1), createdAt, savedUpdatedAt).
+		WillReturnError(sql.ErrNoRows)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/configs/test-config", bytes.NewReader(patchBody))
+	req = mux.SetURLVars(req, map[string]string{"config": "test-config"})
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	server.updateConfigHandler(rr, req)
+
+	require.Equal(t, http.StatusConflict, rr.Code)
+	require.Contains(t, rr.Body.String(), "rollback skipped")
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/ground-control/internal/server/config_handlers_test.go
+++ b/ground-control/internal/server/config_handlers_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -11,9 +12,36 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/container-registry/harbor-satellite/ground-control/internal/models"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 )
+
+func stubConfigPublicationSideEffects(t *testing.T) {
+	t.Helper()
+
+	origEnsure := ensureSatelliteProjectExistsFn
+	origPush := createAndPushConfigStateArtifactFn
+
+	ensureSatelliteProjectExistsFn = func(context.Context) error { return nil }
+	createAndPushConfigStateArtifactFn = func(context.Context, []byte, string) error { return nil }
+
+	t.Cleanup(func() {
+		ensureSatelliteProjectExistsFn = origEnsure
+		createAndPushConfigStateArtifactFn = origPush
+	})
+}
+
+func mustMarshalRequestConfig(t *testing.T, body []byte) json.RawMessage {
+	t.Helper()
+
+	var req models.ConfigObject
+	require.NoError(t, json.Unmarshal(body, &req))
+
+	configJSON, err := json.Marshal(req.Config)
+	require.NoError(t, err)
+	return configJSON
+}
 
 func TestListConfigsHandler(t *testing.T) {
 	t.Run("returns config list", func(t *testing.T) {
@@ -126,6 +154,41 @@ func TestCreateConfigHandler_EmptyName(t *testing.T) {
 	server.createConfigHandler(rr, req)
 
 	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestCreateConfigHandler_PublishFailureDeletesCommittedConfig(t *testing.T) {
+	server, mock := newMockServer(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	body := []byte(`{"config_name":"test-config","config":{"app_config":{"log_level":"info"}}}`)
+	configJSON := mustMarshalRequestConfig(t, body)
+
+	origEnsure := ensureSatelliteProjectExistsFn
+	origPush := createAndPushConfigStateArtifactFn
+	ensureSatelliteProjectExistsFn = func(context.Context) error { return nil }
+	createAndPushConfigStateArtifactFn = func(context.Context, []byte, string) error { return fmt.Errorf("push failed") }
+	t.Cleanup(func() {
+		ensureSatelliteProjectExistsFn = origEnsure
+		createAndPushConfigStateArtifactFn = origPush
+	})
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("INSERT INTO configs").
+		WithArgs("test-config", "", configJSON).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "config_name", "registry_url", "config", "created_at", "updated_at"}).
+			AddRow(1, "test-config", "", configJSON, now, now))
+	mock.ExpectCommit()
+	mock.ExpectExec("DELETE FROM configs").
+		WithArgs(int32(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/configs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	server.createConfigHandler(rr, req)
+
+	require.Equal(t, http.StatusBadGateway, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestDeleteConfigHandler_NotFound(t *testing.T) {

--- a/ground-control/internal/server/helpers.go
+++ b/ground-control/internal/server/helpers.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -17,6 +18,11 @@ import (
 	"github.com/container-registry/harbor-satellite/ground-control/internal/utils"
 	"github.com/container-registry/harbor-satellite/ground-control/pkg/crypto"
 	"github.com/container-registry/harbor-satellite/ground-control/reg/harbor"
+)
+
+var (
+	ensureSatelliteProjectExistsFn     = ensureSatelliteProjectExists
+	createAndPushConfigStateArtifactFn = utils.CreateAndPushConfigStateArtifact
 )
 
 func isConfigInUse(ctx context.Context, q *database.Queries, config database.Config) (bool, error) {
@@ -327,4 +333,18 @@ func normalizeHeartbeatInterval(interval string) (string, error) {
 	seconds := int(duration.Seconds()) % 60
 
 	return fmt.Sprintf("@every %02dh%02dm%02ds", hours, minutes, seconds), nil
+}
+
+func jsonSemanticallyEqual(a, b []byte) bool {
+	var left any
+	if err := json.Unmarshal(a, &left); err != nil {
+		return false
+	}
+
+	var right any
+	if err := json.Unmarshal(b, &right); err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(left, right)
 }

--- a/ground-control/internal/server/helpers.go
+++ b/ground-control/internal/server/helpers.go
@@ -20,11 +20,6 @@ import (
 	"github.com/container-registry/harbor-satellite/ground-control/reg/harbor"
 )
 
-var (
-	ensureSatelliteProjectExistsFn     = ensureSatelliteProjectExists
-	createAndPushConfigStateArtifactFn = utils.CreateAndPushConfigStateArtifact
-)
-
 func isConfigInUse(ctx context.Context, q *database.Queries, config database.Config) (bool, error) {
 	// Check if any satellite is using this config
 	satellites, err := q.ConfigSatelliteList(ctx, config.ID)

--- a/ground-control/internal/server/helpers_test.go
+++ b/ground-control/internal/server/helpers_test.go
@@ -92,3 +92,15 @@ func TestVerifyRobotCredentials(t *testing.T) {
 		require.False(t, crypto.VerifySecret(secret, "not-a-valid-hash"))
 	})
 }
+
+func TestJSONSemanticallyEqual(t *testing.T) {
+	require.True(t, jsonSemanticallyEqual(
+		[]byte(`{"app_config":{"log_level":"info","use_unsecure":true}}`),
+		[]byte(`{"app_config":{"use_unsecure":true,"log_level":"info"}}`),
+	))
+
+	require.False(t, jsonSemanticallyEqual(
+		[]byte(`{"app_config":{"log_level":"info"}}`),
+		[]byte(`{"app_config":{"log_level":"debug"}}`),
+	))
+}

--- a/ground-control/internal/server/server.go
+++ b/ground-control/internal/server/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/container-registry/harbor-satellite/ground-control/internal/database"
 	"github.com/container-registry/harbor-satellite/ground-control/internal/middleware"
 	"github.com/container-registry/harbor-satellite/ground-control/internal/spiffe"
+	"github.com/container-registry/harbor-satellite/ground-control/internal/utils"
 )
 
 type Server struct {
@@ -42,6 +43,9 @@ type Server struct {
 
 	// Satellite status
 	staleThreshold time.Duration
+
+	EnsureSatelliteProjectExistsFn     func(context.Context) error
+	CreateAndPushConfigStateArtifactFn func(context.Context, []byte, string) error
 }
 
 // TLSConfig holds TLS settings for the server.
@@ -168,6 +172,9 @@ func NewServer() *ServerResult {
 
 		// Satellite status
 		staleThreshold: parseDurationEnv("STALE_THRESHOLD", time.Hour),
+
+		EnsureSatelliteProjectExistsFn:     ensureSatelliteProjectExists,
+		CreateAndPushConfigStateArtifactFn: utils.CreateAndPushConfigStateArtifact,
 	}
 
 	// Bootstrap system admin user if not exists
@@ -291,4 +298,3 @@ func buildServerTLSConfigWithWatcher(cfg *TLSConfig, cw *middleware.CertWatcher)
 
 	return tlsConfig, nil
 }
-


### PR DESCRIPTION
- Fixes: #410 

## Description

Changed the flow from normal to update the artifact publication only after a successfull DB commit . This helps in rducing the risk of DB/Harbour drift during config publication.

what i have changed : 
- moved config artifact publication to run after DB commit.
- added compensation logic to clean up or restore DB state if post-commit publication fails. 

## Testing:
used the automated testing comand of `ground-contol` : 
```
go test ./internal/server/...
```

also added small unit test for: 
- cleanup on config artifact publication failure
- semantic JSON equality checks

<!-- Add any other context about the PR here. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Treats semantically identical config creates/updates as no-ops and returns the existing configuration.

* **Bug Fixes**
  * Returns existing config for duplicate submissions instead of erroring.
  * After committing changes, attempts cleanup or restoration if downstream publish/ensure steps fail; failures map to appropriate HTTP errors.
  * Post-commit operations now run with a deadline-bound context to avoid hangs.

* **Tests**
  * Added tests for publish failures, post-commit timeout behavior, concurrent-update cleanup/restore, and JSON semantic-equality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/container-registry/harbor-satellite/pull/415)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->