### PR TITLE
fix: stream artifact export to prevent OOM in extractArtifactJSON

### DIFF
--- a/internal/state/fetcher.go
+++ b/internal/state/fetcher.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"archive/tar"
-	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -193,13 +192,20 @@ func (f *URLStateFetcher) buildTLSTransport() (http.RoundTripper, error) {
 func (f *URLStateFetcher) extractArtifactJSON(url string, img v1.Image, out any, log *zerolog.Logger) error {
 	log.Debug().Msgf("Extracting artifacts.json from the state artifact: %s", url)
 
-	tarContent := new(bytes.Buffer)
-	if err := crane.Export(img, tarContent); err != nil {
-		log.Error().Msgf("Error exporting the fs contents of the state artifact: %s", url)
-		return fmt.Errorf("failed to export the state artifact: %v", err)
-	}
+	pr, pw := io.Pipe()
 
-	tr := tar.NewReader(tarContent)
+	go func() {
+		if err := crane.Export(img, pw); err != nil {
+			log.Error().Err(err).Msg("failed exporting state artifact")
+			_ = pw.CloseWithError(err)
+			return
+		}
+		_ = pw.Close()
+	}()
+
+	defer pr.Close() // Ensure the pipe is closed to unblock the export goroutine if we return early
+
+	tr := tar.NewReader(pr)
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
@@ -219,6 +225,7 @@ func (f *URLStateFetcher) extractArtifactJSON(url string, img v1.Image, out any,
 			return json.Unmarshal(artifactsJSON, out)
 		}
 	}
+
 	log.Error().Msgf("artifacts.json not present for the state artifact: %s", url)
 	return fmt.Errorf("artifacts.json not found in the state artifact")
 }


### PR DESCRIPTION
## Summary

This PR fixes the OOM risk in `extractArtifactJSON()` by replacing the in-memory `bytes.Buffer` export path with streaming using `io.Pipe()`.

Previously, the function exported the full container image filesystem into a `bytes.Buffer` before parsing it with `tar.NewReader()`. This caused the entire tarball to be loaded into RAM, creating unbounded memory growth for large artifacts and making the Satellite process vulnerable to OOM crashes.

This change streams the export directly into the tar reader, keeping memory usage constant and preventing large image syncs from exhausting system memory.

---

## Changes Made

### Before

```go
tarContent := new(bytes.Buffer)

if err := crane.Export(img, tarContent); err != nil {
    return fmt.Errorf("failed to export the state artifact: %v", err)
}

tr := tar.NewReader(tarContent)
```

This buffered the full image export in memory.

---

### After

```go
pr, pw := io.Pipe()

go func() {
    if err := crane.Export(img, pw); err != nil {
        _ = pw.CloseWithError(err)
        return
    }
    _ = pw.Close()
}()

defer pr.Close()

tr := tar.NewReader(pr)
```

This streams the tarball directly without loading the full content into RAM.

---

## Why This Matters

This issue is especially important for edge environments where Harbor Satellite nodes often run with limited memory.

Large artifacts such as:

* ML model images
* multi-layer container images
* large offline deployment bundles

could cause the previous implementation to allocate massive amounts of memory and trigger process termination by the OS OOM killer.

The new implementation avoids this entirely.

---
<img width="2706" height="1846" alt="bug-fix" src="https://github.com/user-attachments/assets/a92620a8-2b18-4ada-82c3-cfe87961cbdd" />

## Local Verification

I verified the issue using a standalone reproduction script with a simulated 200MB artifact.

### Old implementation (`bytes.Buffer`)

```text
Memory BEFORE Export: 388 MB
Memory AFTER Export: 588 MB
Extra Memory Used: ~200 MB
```

### New implementation (`io.Pipe`)

```text
Memory BEFORE Stream: 258 MB
Memory AFTER Stream: 258 MB
Extra Memory Used: 0 MB
```

This confirms that the previous implementation buffered the full tarball in memory, while the new implementation keeps memory usage flat.

---

## Additional Improvements

* Added proper pipe closure handling to prevent goroutine leaks
* Added `CloseWithError()` for correct error propagation from `crane.Export()`
* Added error logging for export failures

---

fixed #417
