### PR TITLE
fix: stop RateLimiter cleanup goroutine on server shutdown

### DIFF
--- a/ground-control/internal/middleware/ratelimit.go
+++ b/ground-control/internal/middleware/ratelimit.go
@@ -15,6 +15,8 @@ type RateLimiter struct {
 	requests     map[string][]time.Time
 	maxRequests  int
 	windowPeriod time.Duration
+	stopCh       chan struct{}
+	once         sync.Once
 }
 
 // NewRateLimiter creates a new rate limiter.
@@ -23,12 +25,19 @@ func NewRateLimiter(maxRequests int, windowPeriod time.Duration) *RateLimiter {
 		requests:     make(map[string][]time.Time),
 		maxRequests:  maxRequests,
 		windowPeriod: windowPeriod,
+		stopCh:       make(chan struct{}),
 	}
 
-	// Start cleanup goroutine
 	go rl.cleanup()
 
 	return rl
+}
+
+// Stop signals the cleanup goroutine to exit.
+func (rl *RateLimiter) Stop() {
+	rl.once.Do(func() {
+		close(rl.stopCh)
+	})
 }
 
 // Allow checks if a request from the given IP is allowed.
@@ -39,7 +48,6 @@ func (rl *RateLimiter) Allow(ip string) bool {
 	now := time.Now()
 	cutoff := now.Add(-rl.windowPeriod)
 
-	// Filter expired timestamps
 	var valid []time.Time
 	for _, t := range rl.requests[ip] {
 		if t.After(cutoff) {
@@ -47,13 +55,11 @@ func (rl *RateLimiter) Allow(ip string) bool {
 		}
 	}
 
-	// Check if rate limit exceeded
 	if len(valid) >= rl.maxRequests {
 		rl.requests[ip] = valid
 		return false
 	}
 
-	// Record this request
 	rl.requests[ip] = append(valid, now)
 	return true
 }
@@ -63,24 +69,29 @@ func (rl *RateLimiter) cleanup() {
 	ticker := time.NewTicker(rl.windowPeriod)
 	defer ticker.Stop()
 
-	for range ticker.C {
-		rl.mu.Lock()
-		cutoff := time.Now().Add(-rl.windowPeriod)
+	for {
+		select {
+		case <-ticker.C:
+			rl.mu.Lock()
+			cutoff := time.Now().Add(-rl.windowPeriod)
 
-		for ip, timestamps := range rl.requests {
-			var valid []time.Time
-			for _, t := range timestamps {
-				if t.After(cutoff) {
-					valid = append(valid, t)
+			for ip, timestamps := range rl.requests {
+				var valid []time.Time
+				for _, t := range timestamps {
+					if t.After(cutoff) {
+						valid = append(valid, t)
+					}
+				}
+				if len(valid) == 0 {
+					delete(rl.requests, ip)
+				} else {
+					rl.requests[ip] = valid
 				}
 			}
-			if len(valid) == 0 {
-				delete(rl.requests, ip)
-			} else {
-				rl.requests[ip] = valid
-			}
+			rl.mu.Unlock()
+		case <-rl.stopCh:
+			return
 		}
-		rl.mu.Unlock()
 	}
 }
 

--- a/ground-control/internal/server/server.go
+++ b/ground-control/internal/server/server.go
@@ -291,4 +291,6 @@ func buildServerTLSConfigWithWatcher(cfg *TLSConfig, cw *middleware.CertWatcher)
 
 	return tlsConfig, nil
 }
-
+func (s *Server) Stop() {
+	s.rateLimiter.Stop()
+}

--- a/ground-control/main.go
+++ b/ground-control/main.go
@@ -65,5 +65,7 @@ func main() {
 
 	if err := httpServer.Shutdown(shutdownCtx); err != nil {
 		log.Printf("HTTP shutdown error: %v", err)
+
 	}
+	serverResult.AppServer.Stop()
 }


### PR DESCRIPTION
- Fixes: #420 

## Description
`NewRateLimiter` in `ground-control/internal/middleware/ratelimit.go` spawned a background cleanup goroutine with no exit path:

```go
go rl.cleanup()
```

`cleanup()` looped on a ticker indefinitely — no stop channel, no context, no `Stop()` method on the struct. on server shutdown the goroutine leaked for the process lifetime. Any code creating multiple `RateLimiter` instances (e.g. tests) accumulated goroutines with no way to clean them up.

## Additional context(testing)
`go build ./...` and `go test ./...` pass cleanly.

<!-- Add any other context about the PR here. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown: background rate-limiting and server components are now cleanly stopped during application shutdown to prevent lingering tasks.
  * Ensures internal cleanup runs after the HTTP server shuts down, reducing shutdown errors and resource leaks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/container-registry/harbor-satellite/pull/421)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->