### PR TITLE
fix: read satellite and group from request body in removeSatelliteFromGroup

### DIFF
--- a/ground-control/internal/server/satellite_handlers.go
+++ b/ground-control/internal/server/satellite_handlers.go
@@ -1220,9 +1220,13 @@ func (s *Server) addSatelliteToGroup(w http.ResponseWriter, r *http.Request) {
 
 // If the satellite is removed from the group, the state artifact must be updated accordingly as well.
 func (s *Server) removeSatelliteFromGroup(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	groupName := vars["group"]
-	satelliteName := vars["satellite"]
+	var req SatelliteGroupParams
+	if err := DecodeRequestBody(r, &req); err != nil {
+		HandleAppError(w, err)
+		return
+	}
+	groupName := req.Group
+	satelliteName := req.Satellite
 
 	tx, err := s.db.BeginTx(r.Context(), nil)
 	if err != nil {


### PR DESCRIPTION
 ## Description
 
`removeSatelliteFromGroup` was extracting `satellite` and `group` from URL path
variables via `mux.Vars(r)`, but the route is registered as:
 
    DELETE /api/groups/satellite
 
This route has **no path parameters**,both values must come from the JSON
request body. As a result, `groupName` and `satelliteName` were always empty
strings, causing the handler to always return `"Satellite Not Found"`.
 
**Fix:** Switch to `DecodeRequestBody` with the existing `SatelliteGroupParams`
struct, consistent with how `addSatelliteToGroup` (the corresponding `POST` handler
on the same `/api/groups/satellite` route) already works.
 
**Before:**
 
    vars := mux.Vars(r)
    groupName := vars["group"]
    satelliteName := vars["satellite"]
 
**After:**
 
    var req SatelliteGroupParams
    if err := DecodeRequestBody(r, &req); err != nil {
        HandleAppError(w, err)
        return
    }
    groupName := req.Group
    satelliteName := req.Satellite
 
## Testing
 
Tested manually against a local Ground Control instance with Harbor running.
 
`DELETE /api/groups/satellite` with body:
 
    {
      "satellite": "sputnik-1",
      "group": "edge-kazakhstan"
    }
 
Previously returned `{"message": "Satellite Not Found", "code": 400}`.
After the fix returns `{}` with status `200`, and the satellite is correctly
removed from the group as verified via `GET /api/groups/edge-kazakhstan/satellites`.
 
## Additional context
 
The `addSatelliteToGroup` handler on the corresponding `POST /api/groups/satellite`
route was already implemented correctly using `DecodeRequestBody`. This fix
brings `removeSatelliteFromGroup` into consistency with it.
 
No schema, migration, or API contract changes the request body shape
(`{"satellite": "...", "group": "..."}`) is unchanged.
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request parameter handling for satellite group removal operations to ensure proper data validation and processing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/container-registry/harbor-satellite/pull/430)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->