### PR TITLE
feat: setup codecov integration for test coverage report

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,39 @@ on:
       - "assets/**"
 
 jobs:
+  unit-tests:
+    name: Unit Tests and Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.11"
+          cache: true
+
+      - name: Run unit tests for satellite (with coverage)
+        run: |
+          go test -v -count=1 -coverprofile=coverage-satellite.out -covermode=atomic ./...
+
+      - name: Run unit tests for ground-control (with coverage)
+        working-directory: ground-control
+        run: |
+          go test -v -count=1 -coverprofile=coverage-ground-control.out -covermode=atomic ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v6
+        with:
+          files: coverage-satellite.out,ground-control/coverage-ground-control.out
+          flags: unittests
+          verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   vulnerability-check:
     runs-on: container-registry
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -32,7 +32,7 @@ jobs:
           go test -v -count=1 -coverprofile=coverage-ground-control.out -covermode=atomic ./...
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: coverage-satellite.out,ground-control/coverage-ground-control.out
           flags: unittests


### PR DESCRIPTION
- Fixes: #297 

## Description
This PR integrates Codecov into the CI pipeline to provide automated code coverage reporting (like harbor-cli). It improves visibility into test quality without imposing any merge restrictions.

## Changes
- Added a minimal unit-tests job 
- Configured coverage generation for both the satellite and ground-control modules 
- Integrated codecov for automated report uploading

## Note to Maintainers
This integration is purely informational. It will not block PRs or enforce any minimum coverage percentages. To enable the reporting:
1. Activate this repo on Codecov website
2. Add the CODECOV_TOKEN to GitHub secrets



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs automated unit tests and collects coverage on pull requests, with Go toolchain setup and caching.
  * Coverage reports from multiple modules are uploaded to Codecov.
  * Workflow excludes specified non-code paths from triggering runs to reduce noise.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/container-registry/harbor-satellite/pull/431?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->