### PR TITLE
feat: add groundctl CLI with satellite lifecycle commands and GitOps apply mode

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -40,6 +40,14 @@ tasks:
     cmds:
       - task: _build:all
 
+  build-groundctl:
+    desc: Build the groundctl CLI binary
+    dir: groundctl
+    cmds:
+      - go build -ldflags "-X github.com/container-registry/harbor-satellite/groundctl/cmd.Version={{.VERSION}}" -o ../bin/groundctl{{exeExt}} .
+    vars:
+      VERSION: '{{.VERSION | default "dev"}}'
+
   lint:
     desc: Run golangci-lint
     aliases: [l]

--- a/groundctl/.gitignore
+++ b/groundctl/.gitignore
@@ -1,0 +1,2 @@
+# Build output
+bin/

--- a/groundctl/README.md
+++ b/groundctl/README.md
@@ -1,0 +1,295 @@
+# groundctl
+
+`groundctl` is the command-line interface for managing Harbor Satellite fleets via the Ground Control API.
+
+## Installation
+
+```bash
+# Build from source
+task build-groundctl
+
+# The binary is placed at bin/groundctl (or bin/groundctl.exe on Windows)
+```
+
+## Configuration
+
+`groundctl` reads configuration from flags or environment variables:
+
+| Flag | Environment Variable | Description |
+|---|---|---|
+| `--gc-url` | `GROUNDCTL_URL` | Ground Control base URL (e.g. `http://ground-control:8080`) |
+| `--token` | `GROUNDCTL_TOKEN` | Bearer token obtained from `groundctl login` |
+| `--output` / `-o` | — | Output format: `table` (default) or `json` |
+
+Environment variables are used as fallbacks when flags are not set.
+
+## Commands
+
+### `groundctl satellite`
+
+Manage satellites registered with Ground Control.
+
+```
+groundctl satellite list [flags]
+groundctl satellite get <name>
+groundctl satellite register <name> --config <config> [--groups <g1,g2>]
+groundctl satellite delete <name> [--force]
+groundctl satellite status <name>
+groundctl satellite images <name>
+```
+
+#### `satellite list`
+
+List all registered satellites.
+
+```bash
+# List all satellites
+groundctl satellite list
+
+# Filter by name prefix
+groundctl satellite list --name edge-tokyo
+
+# Paginate results
+groundctl satellite list --limit 20 --offset 0
+
+# Show only active satellites (checked in within the last 2 minutes)
+groundctl satellite list --active
+
+# Show only stale satellites
+groundctl satellite list --stale
+
+# JSON output
+groundctl satellite list --output json
+```
+
+**Flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--name` | — | Filter satellites by name prefix |
+| `--limit` | 0 (all) | Maximum number of results to return |
+| `--offset` | 0 | Number of results to skip |
+| `--sort` | `name` | Sort field: `name`, `created_at`, `last_seen` |
+| `--order` | `asc` | Sort order: `asc` or `desc` |
+| `--active` | false | Show only active satellites |
+| `--stale` | false | Show only stale satellites |
+
+**Example output:**
+
+```
+NAME               STATUS    LAST SEEN    HEARTBEAT    CREATED
+edge-tokyo-01      Active    45s ago      30s          3d ago
+edge-osaka-02      Idle      8m ago       30s          3d ago
+edge-seoul-03      Stale     2h ago       30s          7d ago
+```
+
+#### `satellite get`
+
+```bash
+groundctl satellite get edge-tokyo-01
+```
+
+#### `satellite register`
+
+Register a new satellite and print its one-time token.
+
+```bash
+groundctl satellite register edge-tokyo-01 \
+  --config prod-config \
+  --groups base-images,ml-models
+```
+
+#### `satellite delete`
+
+```bash
+# With confirmation prompt
+groundctl satellite delete edge-tokyo-01
+
+# Skip confirmation
+groundctl satellite delete edge-tokyo-01 --force
+```
+
+#### `satellite status`
+
+Show the latest sync status reported by a satellite.
+
+```bash
+groundctl satellite status edge-tokyo-01
+```
+
+**Example output:**
+
+```
+Satellite:     edge-tokyo-01
+Activity:      syncing
+State Digest:  sha256:abc123…
+Config Digest: sha256:def456…
+CPU:           12%
+Memory:        256.0 MiB
+Storage:       4.2 GiB
+Images Cached: 14
+Last Sync:     342ms
+Reported At:   45s ago
+```
+
+#### `satellite images`
+
+List images currently cached on a satellite.
+
+```bash
+groundctl satellite images edge-tokyo-01
+```
+
+---
+
+### `groundctl group`
+
+Manage image groups in Ground Control.
+
+```bash
+groundctl group list
+groundctl group get <name>
+groundctl group add-satellite <satellite> --group <name>
+groundctl group remove-satellite <satellite> --group <name>
+```
+
+---
+
+### `groundctl config`
+
+Manage satellite configurations.
+
+```bash
+groundctl config list
+groundctl config get <name>
+groundctl config delete <name>
+```
+
+---
+
+### `groundctl apply`
+
+Apply a declarative `SatelliteFleet` manifest to Ground Control. This is the GitOps entrypoint for managing fleets at scale.
+
+```bash
+# Apply a fleet manifest
+groundctl apply -f fleet.yaml
+
+# Preview changes without applying (dry run)
+groundctl apply -f fleet.yaml --dry-run
+```
+
+**Flags:**
+
+| Flag | Description |
+|---|---|
+| `-f` / `--file` | Path to the fleet manifest YAML file (required) |
+| `--dry-run` | Preview changes without applying them |
+
+#### Fleet Manifest Schema
+
+```yaml
+apiVersion: satellite.harbor.io/v1alpha1
+kind: SatelliteFleet
+metadata:
+  name: prod-asia
+
+spec:
+  # Default config applied to all satellites unless overridden per entry
+  configName: prod-config
+
+  # Default image groups for all satellites unless overridden per entry
+  groups:
+    - base-images
+
+  satellites:
+    - name: edge-tokyo-01
+      groups:
+        - base-images
+        - ml-models          # Additional groups for this satellite
+
+    - name: edge-osaka-02    # Inherits fleet-level config and groups
+
+    - name: edge-seoul-03
+      configName: staging-config   # Override fleet-level config
+      groups:
+        - base-images
+```
+
+#### Reconcile Behaviour
+
+`groundctl apply` performs a three-way diff:
+
+| State | Action |
+|---|---|
+| In manifest, not in Ground Control | `POST /api/satellites` — satellite is registered |
+| In Ground Control, not in manifest | `DELETE /api/satellites/{name}` — satellite is deleted |
+| In both | Satellite is left unchanged |
+
+**Example output:**
+
+```
+  + satellite/edge-tokyo-01               created
+  + satellite/edge-osaka-02               created
+  - satellite/edge-berlin-05              deleted
+    satellite/edge-seoul-03               unchanged
+
+Applied: 2 created, 1 deleted, 0 updated, 1 unchanged
+```
+
+With `--dry-run`:
+
+```
+Dry run — no changes will be applied.
+
+  + satellite/edge-tokyo-01               created
+  + satellite/edge-osaka-02               created
+  - satellite/edge-berlin-05              deleted
+    satellite/edge-seoul-03               unchanged
+
+Applied: 2 created, 1 deleted, 0 updated, 1 unchanged
+```
+
+---
+
+### `groundctl version`
+
+```bash
+groundctl version
+# groundctl v0.1.0
+```
+
+The version is injected at build time:
+
+```bash
+go build -ldflags "-X github.com/container-registry/harbor-satellite/groundctl/cmd.Version=v0.1.0" .
+```
+
+## Examples
+
+### Register a fleet from a YAML file
+
+```bash
+export GROUNDCTL_URL=http://ground-control:8080
+export GROUNDCTL_TOKEN=<token>
+
+groundctl apply -f examples/fleet.yaml
+```
+
+### Check which satellites are stale
+
+```bash
+groundctl satellite list --stale --output json | jq '.[].name'
+```
+
+### Remove a satellite from a group
+
+```bash
+groundctl group remove-satellite edge-tokyo-01 --group ml-models
+```
+
+### Watch satellite status
+
+```bash
+watch -n 10 groundctl satellite status edge-tokyo-01
+```

--- a/groundctl/cmd/apply.go
+++ b/groundctl/cmd/apply.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/container-registry/harbor-satellite/groundctl/internal/apply"
+	"github.com/container-registry/harbor-satellite/groundctl/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func newApplyCmd() *cobra.Command {
+	var (
+		filePath string
+		dryRun   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Apply a declarative fleet manifest to Ground Control",
+		Long: `Apply reads a SatelliteFleet YAML manifest and reconciles the live Ground
+Control state to match it. Satellites that exist in the manifest but not in
+Ground Control are registered. Satellites that exist in Ground Control but not
+in the manifest are deleted. Unchanged satellites are left alone.
+
+Use --dry-run to preview the changes without applying them.`,
+		Example: `  # Apply a fleet manifest
+  groundctl apply -f fleet.yaml
+
+  # Preview changes without applying
+  groundctl apply -f fleet.yaml --dry-run`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if filePath == "" {
+				return fmt.Errorf("flag -f/--file is required")
+			}
+
+			manifest, err := apply.ParseManifest(filePath)
+			if err != nil {
+				return fmt.Errorf("parse manifest: %w", err)
+			}
+
+			gc := clientFromContext(cmd)
+
+			if dryRun {
+				fmt.Println("Dry run — no changes will be applied.\n")
+			}
+
+			result, err := apply.Reconcile(cmd.Context(), gc, manifest, dryRun)
+			if err != nil {
+				return fmt.Errorf("reconcile fleet: %w", err)
+			}
+
+			output.PrintApplyResult(result.Created, result.Deleted, result.Updated, result.Unchanged)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to the fleet manifest YAML file (required)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview changes without applying them")
+
+	return cmd
+}

--- a/groundctl/cmd/config.go
+++ b/groundctl/cmd/config.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/container-registry/harbor-satellite/groundctl/internal/client"
+	"github.com/container-registry/harbor-satellite/groundctl/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func newConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Manage satellite configurations in Ground Control",
+	}
+
+	cmd.AddCommand(
+		newConfigListCmd(),
+		newConfigGetCmd(),
+		newConfigDeleteCmd(),
+	)
+
+	return cmd
+}
+
+func newConfigListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all satellite configurations",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gc := clientFromContext(cmd)
+			format := output.Format(cmd.Root().PersistentFlags().Lookup("output").Value.String())
+
+			configs, err := gc.ListConfigs(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("list configs: %w", err)
+			}
+			output.PrintConfigs(configs, format)
+			return nil
+		},
+	}
+}
+
+func newConfigGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <name>",
+		Short: "Get details of a specific configuration",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gc := clientFromContext(cmd)
+			format := output.Format(cmd.Root().PersistentFlags().Lookup("output").Value.String())
+
+			cfg, err := gc.GetConfig(cmd.Context(), args[0])
+			if err != nil {
+				return fmt.Errorf("get config %q: %w", args[0], err)
+			}
+			output.PrintConfigs([]client.Config{*cfg}, format)
+			return nil
+		},
+	}
+}
+
+func newConfigDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <name>",
+		Short: "Delete a satellite configuration",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gc := clientFromContext(cmd)
+
+			if err := gc.DeleteConfig(cmd.Context(), args[0]); err != nil {
+				return fmt.Errorf("delete config %q: %w", args[0], err)
+			}
+			fmt.Printf("Config %q deleted.\n", args[0])
+			return nil
+		},
+	}
+}

--- a/groundctl/cmd/group.go
+++ b/groundctl/cmd/group.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/container-registry/harbor-satellite/groundctl/internal/client"
+	"github.com/container-registry/harbor-satellite/groundctl/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func newGroupCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "group",
+		Short: "Manage image groups in Ground Control",
+	}
+
+	cmd.AddCommand(
+		newGroupListCmd(),
+		newGroupGetCmd(),
+		newGroupAddSatelliteCmd(),
+		newGroupRemoveSatelliteCmd(),
+	)
+
+	return cmd
+}
+
+func newGroupListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all image groups",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gc := clientFromContext(cmd)
+			format := output.Format(cmd.Root().PersistentFlags().Lookup("output").Value.String())
+
+			groups, err := gc.ListGroups(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("list groups: %w", err)
+			}
+			output.PrintGroups(groups, format)
+			return nil
+		},
+	}
+}
+
+func newGroupGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <name>",
+		Short: "Get details of a specific group",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gc := clientFromContext(cmd)
+			format := output.Format(cmd.Root().PersistentFlags().Lookup("output").Value.String())
+
+			group, err := gc.GetGroup(cmd.Context(), args[0])
+			if err != nil {
+				return fmt.Errorf("get group %q: %w", args[0], err)
+			}
+			output.PrintGroups([]client.Group{*group}, format)
+			return nil
+		},
+	}
+}
+
+func newGroupAddSatelliteCmd() *cobra.Command {
+	var groupName string
+
+	cmd := &cobra.Command{
+		Use:   "add-satellite <satellite>",
+		Short: "Add a satellite to a group",
+		Args:  cobra.ExactArgs(1),
+		Example: `  groundctl group add-satellite edge-tokyo-01 --group ml-models`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gc := clientFromContext(cmd)
+
+			if err := gc.AddSatelliteToGroup(cmd.Context(), args[0], groupName); err != nil {
+				return fmt.Errorf("add satellite %q to group %q: %w", args[0], groupName, err)
+			}
+			fmt.Printf("Satellite %q added to group %q.\n", args[0], groupName)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&groupName, "group", "", "Name of the group (required)")
+	_ = cmd.MarkFlagRequired("group")
+	return cmd
+}
+
+func newGroupRemoveSatelliteCmd() *cobra.Command {
+	var groupName string
+
+	cmd := &cobra.Command{
+		Use:   "remove-satellite <satellite>",
+		Short: "Remove a satellite from a group",
+		Args:  cobra.ExactArgs(1),
+		Example: `  groundctl group remove-satellite edge-tokyo-01 --group ml-models`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gc := clientFromContext(cmd)
+
+			if err := gc.RemoveSatelliteFromGroup(cmd.Context(), args[0], groupName); err != nil {
+				return fmt.Errorf("remove satellite %q from group %q: %w", args[0], groupName, err)
+			}
+			fmt.Printf("Satellite %q removed from group %q.\n", args[0], groupName)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&groupName, "group", "", "Name of the group (required)")
+	_ = cmd.MarkFlagRequired("group")
+	return cmd
+}

--- a/groundctl/cmd/root.go
+++ b/groundctl/cmd/root.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/container-registry/harbor-satellite/groundctl/internal/client"
+	"github.com/spf13/cobra"
+)
+
+// contextKey is used to store the client in the command context.
+type contextKey string
+
+const clientKey contextKey = "gc-client"
+
+// gcURL and token are the persistent global flags.
+var (
+	gcURL  string
+	token  string
+	outFmt string
+)
+
+// rootCmd is the base command for groundctl.
+var rootCmd = &cobra.Command{
+	Use:   "groundctl",
+	Short: "groundctl — CLI for managing Harbor Satellite fleets via Ground Control",
+	Long: `groundctl is a command-line tool for managing Harbor Satellite fleets.
+
+It communicates directly with the Ground Control API to register, inspect,
+and delete satellites, manage groups and configs, and reconcile declarative
+fleet manifests.
+
+Environment variables:
+  GROUNDCTL_URL    Ground Control base URL (overrides --gc-url)
+  GROUNDCTL_TOKEN  Bearer token (overrides --token)`,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// Resolve URL from flag or env
+		if gcURL == "" {
+			gcURL = os.Getenv("GROUNDCTL_URL")
+		}
+		if gcURL == "" {
+			return fmt.Errorf("Ground Control URL is required: set --gc-url or GROUNDCTL_URL")
+		}
+
+		// Resolve token from flag or env
+		if token == "" {
+			token = os.Getenv("GROUNDCTL_TOKEN")
+		}
+
+		// Store client in context so subcommands can retrieve it
+		gc := client.New(gcURL, token)
+		ctx := context.WithValue(cmd.Context(), clientKey, gc)
+		cmd.SetContext(ctx)
+		return nil
+	},
+}
+
+// Execute is the entry point called from main.
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&gcURL, "gc-url", "", "Ground Control base URL (e.g. http://ground-control:8080)")
+	rootCmd.PersistentFlags().StringVar(&token, "token", "", "Bearer token for authentication")
+	rootCmd.PersistentFlags().StringVarP(&outFmt, "output", "o", "table", "Output format: table or json")
+
+	rootCmd.AddCommand(
+		newSatelliteCmd(),
+		newGroupCmd(),
+		newConfigCmd(),
+		newApplyCmd(),
+		newVersionCmd(),
+	)
+}
+
+// clientFromContext retrieves the Ground Control client stored in command context.
+func clientFromContext(cmd *cobra.Command) *client.Client {
+	gc, ok := cmd.Context().Value(clientKey).(*client.Client)
+	if !ok || gc == nil {
+		fmt.Fprintln(os.Stderr, "internal error: client not initialised")
+		os.Exit(1)
+	}
+	return gc
+}

--- a/groundctl/cmd/satellite.go
+++ b/groundctl/cmd/satellite.go
@@ -1,0 +1,237 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/container-registry/harbor-satellite/groundctl/internal/client"
+	"github.com/container-registry/harbor-satellite/groundctl/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func newSatelliteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "satellite",
+		Short:   "Manage satellites registered with Ground Control",
+		Aliases: []string{"sat"},
+	}
+
+	cmd.AddCommand(
+		newSatelliteListCmd(),
+		newSatelliteGetCmd(),
+		newSatelliteRegisterCmd(),
+		newSatelliteDeleteCmd(),
+		newSatelliteStatusCmd(),
+		newSatelliteImagesCmd(),
+	)
+
+	return cmd
+}
+
+func newSatelliteListCmd() *cobra.Command {
+	var (
+		limit      int
+		offset     int
+		namePrefix string
+		sort       string
+		order      string
+		activeOnly bool
+		staleOnly  bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all registered satellites",
+		Example: `  # List all satellites
+  groundctl satellite list
+
+  # Filter by name prefix with pagination
+  groundctl satellite list --name edge --limit 20 --offset 0
+
+  # Show only active satellites
+  groundctl satellite list --active
+
+  # Output as JSON
+  groundctl satellite list --output json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gc := clientFromContext(cmd)
+			ctx := cmd.Context()
+			format := output.Format(cmd.Root().PersistentFlags().Lookup("output").Value.String())
+
+			if activeOnly {
+				satellites, err := gc.GetActiveSatellites(ctx)
+				if err != nil {
+					return fmt.Errorf("list active satellites: %w", err)
+				}
+				output.PrintSatellites(satellites, format)
+				return nil
+			}
+
+			if staleOnly {
+				satellites, err := gc.GetStaleSatellites(ctx)
+				if err != nil {
+					return fmt.Errorf("list stale satellites: %w", err)
+				}
+				output.PrintSatellites(satellites, format)
+				return nil
+			}
+
+			satellites, err := gc.ListSatellites(ctx, client.ListSatellitesParams{
+				Limit:      limit,
+				Offset:     offset,
+				NamePrefix: namePrefix,
+				Sort:       sort,
+				Order:      order,
+			})
+			if err != nil {
+				return fmt.Errorf("list satellites: %w", err)
+			}
+			output.PrintSatellites(satellites, format)
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 0, "Maximum number of satellites to return (0 = all)")
+	cmd.Flags().IntVar(&offset, "offset", 0, "Number of satellites to skip")
+	cmd.Flags().StringVar(&namePrefix, "name", "", "Filter satellites by name prefix")
+	cmd.Flags().StringVar(&sort, "sort", "name", "Sort field (name, created_at, last_seen)")
+	cmd.Flags().StringVar(&order, "order", "asc", "Sort order (asc, desc)")
+	cmd.Flags().BoolVar(&activeOnly, "active", false, "Show only active satellites")
+	cmd.Flags().BoolVar(&staleOnly, "stale", false, "Show only stale satellites")
+
+	return cmd
+}
+
+func newSatelliteGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "get <name>",
+		Short:   "Get details of a specific satellite",
+		Args:    cobra.ExactArgs(1),
+		Example: `  groundctl satellite get edge-tokyo-01`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gc := clientFromContext(cmd)
+			format := output.Format(cmd.Root().PersistentFlags().Lookup("output").Value.String())
+
+			sat, err := gc.GetSatellite(cmd.Context(), args[0])
+			if err != nil {
+				return fmt.Errorf("get satellite %q: %w", args[0], err)
+			}
+			output.PrintSatellite(sat, format)
+			return nil
+		},
+	}
+}
+
+func newSatelliteRegisterCmd() *cobra.Command {
+	var (
+		configName string
+		groups     []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "register <name>",
+		Short: "Register a new satellite with Ground Control",
+		Args:  cobra.ExactArgs(1),
+		Example: `  groundctl satellite register edge-tokyo-01 --config prod-config --groups ml-models,base-images`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gc := clientFromContext(cmd)
+
+			params := client.RegisterSatelliteParams{
+				Name:       args[0],
+				ConfigName: configName,
+			}
+			if len(groups) > 0 {
+				params.Groups = &groups
+			}
+
+			resp, err := gc.RegisterSatellite(cmd.Context(), params)
+			if err != nil {
+				return fmt.Errorf("register satellite %q: %w", args[0], err)
+			}
+
+			fmt.Printf("Satellite %q registered successfully.\n", args[0])
+			fmt.Printf("One-time token (use within 24h): %s\n", resp.Token)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&configName, "config", "", "Config name to assign to the satellite (required)")
+	cmd.Flags().StringSliceVar(&groups, "groups", nil, "Comma-separated list of groups to assign")
+	_ = cmd.MarkFlagRequired("config")
+
+	return cmd
+}
+
+func newSatelliteDeleteCmd() *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:     "delete <name>",
+		Short:   "Delete a satellite from Ground Control",
+		Args:    cobra.ExactArgs(1),
+		Example: `  groundctl satellite delete edge-tokyo-01`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gc := clientFromContext(cmd)
+
+			if !force {
+				fmt.Printf("Delete satellite %q? This cannot be undone. [y/N]: ", args[0])
+				var confirm string
+				fmt.Fscanln(os.Stdin, &confirm)
+				if confirm != "y" && confirm != "Y" {
+					fmt.Println("Aborted.")
+					return nil
+				}
+			}
+
+			if err := gc.DeleteSatellite(cmd.Context(), args[0]); err != nil {
+				return fmt.Errorf("delete satellite %q: %w", args[0], err)
+			}
+
+			fmt.Printf("Satellite %q deleted.\n", args[0])
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Skip confirmation prompt")
+	return cmd
+}
+
+func newSatelliteStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "status <name>",
+		Short:   "Show the latest sync status of a satellite",
+		Args:    cobra.ExactArgs(1),
+		Example: `  groundctl satellite status edge-tokyo-01`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gc := clientFromContext(cmd)
+			format := output.Format(cmd.Root().PersistentFlags().Lookup("output").Value.String())
+
+			status, err := gc.GetSatelliteStatus(cmd.Context(), args[0])
+			if err != nil {
+				return fmt.Errorf("get status for satellite %q: %w", args[0], err)
+			}
+			output.PrintSatelliteStatus(args[0], status, format)
+			return nil
+		},
+	}
+}
+
+func newSatelliteImagesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "images <name>",
+		Short:   "List images cached by a satellite",
+		Args:    cobra.ExactArgs(1),
+		Example: `  groundctl satellite images edge-tokyo-01`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gc := clientFromContext(cmd)
+			format := output.Format(cmd.Root().PersistentFlags().Lookup("output").Value.String())
+
+			images, err := gc.GetSatelliteImages(cmd.Context(), args[0])
+			if err != nil {
+				return fmt.Errorf("get images for satellite %q: %w", args[0], err)
+			}
+			output.PrintCachedImages(args[0], images, format)
+			return nil
+		},
+	}
+}

--- a/groundctl/cmd/version.go
+++ b/groundctl/cmd/version.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Version is the current groundctl version.
+// Set at build time via: -ldflags "-X github.com/container-registry/harbor-satellite/groundctl/cmd.Version=v0.1.0"
+var Version = "dev"
+
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the groundctl version",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("groundctl %s\n", Version)
+		},
+	}
+}

--- a/groundctl/examples/fleet.yaml
+++ b/groundctl/examples/fleet.yaml
@@ -1,0 +1,30 @@
+apiVersion: satellite.harbor.io/v1alpha1
+kind: SatelliteFleet
+metadata:
+  name: prod-asia
+spec:
+  # Default config applied to all satellites (can be overridden per satellite)
+  configName: prod-config
+
+  # Default image groups for all satellites (can be overridden per satellite)
+  groups:
+    - base-images
+
+  satellites:
+    - name: edge-tokyo-01
+      groups:
+        - base-images
+        - ml-models
+
+    - name: edge-osaka-02
+      # Inherits fleet-level config and groups
+
+    - name: edge-seoul-03
+      groups:
+        - base-images
+        - ml-models
+
+    - name: edge-singapore-04
+      configName: staging-config   # Override fleet-level config
+      groups:
+        - base-images

--- a/groundctl/go.mod
+++ b/groundctl/go.mod
@@ -1,0 +1,13 @@
+module github.com/container-registry/harbor-satellite/groundctl
+
+go 1.22
+
+require (
+	github.com/spf13/cobra v1.8.1
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/groundctl/go.sum
+++ b/groundctl/go.sum
@@ -1,0 +1,12 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
+github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/groundctl/internal/apply/apply.go
+++ b/groundctl/internal/apply/apply.go
@@ -1,0 +1,159 @@
+package apply
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/container-registry/harbor-satellite/groundctl/internal/client"
+	"gopkg.in/yaml.v3"
+)
+
+// FleetManifest is the schema for groundctl apply -f fleet.yaml.
+type FleetManifest struct {
+	APIVersion string         `yaml:"apiVersion"`
+	Kind       string         `yaml:"kind"`
+	Metadata   ManifestMeta   `yaml:"metadata"`
+	Spec       FleetSpec      `yaml:"spec"`
+}
+
+// ManifestMeta holds the name of the fleet manifest.
+type ManifestMeta struct {
+	Name string `yaml:"name"`
+}
+
+// FleetSpec describes the desired state of the satellite fleet.
+type FleetSpec struct {
+	// ConfigName is the default config applied to all satellites unless overridden.
+	ConfigName string             `yaml:"configName"`
+	// Groups is the default set of image groups for all satellites unless overridden.
+	Groups     []string           `yaml:"groups,omitempty"`
+	// Satellites is the list of desired satellites.
+	Satellites []SatelliteEntry   `yaml:"satellites"`
+}
+
+// SatelliteEntry describes one desired satellite in the fleet.
+type SatelliteEntry struct {
+	Name       string   `yaml:"name"`
+	ConfigName string   `yaml:"configName,omitempty"` // overrides fleet-level config
+	Groups     []string `yaml:"groups,omitempty"`     // overrides fleet-level groups
+}
+
+// ApplyResult holds the diff produced by an apply operation.
+type ApplyResult struct {
+	Created   []string
+	Deleted   []string
+	Updated   []string
+	Unchanged []string
+}
+
+// ParseManifest reads and parses a fleet YAML file from disk.
+func ParseManifest(path string) (*FleetManifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest %q: %w", path, err)
+	}
+
+	var manifest FleetManifest
+	if err := yaml.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("parse manifest %q: %w", path, err)
+	}
+
+	if err := validateManifest(&manifest); err != nil {
+		return nil, err
+	}
+
+	return &manifest, nil
+}
+
+// validateManifest checks required fields in the manifest.
+func validateManifest(m *FleetManifest) error {
+	if m.Kind != "SatelliteFleet" {
+		return fmt.Errorf("unsupported manifest kind %q: expected SatelliteFleet", m.Kind)
+	}
+	if m.Spec.ConfigName == "" {
+		return fmt.Errorf("spec.configName is required")
+	}
+	if len(m.Spec.Satellites) == 0 {
+		return fmt.Errorf("spec.satellites must have at least one entry")
+	}
+	seen := map[string]bool{}
+	for _, s := range m.Spec.Satellites {
+		if s.Name == "" {
+			return fmt.Errorf("each satellite entry must have a name")
+		}
+		if seen[s.Name] {
+			return fmt.Errorf("duplicate satellite name %q in manifest", s.Name)
+		}
+		seen[s.Name] = true
+	}
+	return nil
+}
+
+// Reconcile diffs the desired fleet manifest against live Ground Control state
+// and applies the minimal set of changes needed to converge.
+func Reconcile(ctx context.Context, gc *client.Client, manifest *FleetManifest, dryRun bool) (*ApplyResult, error) {
+	// Fetch current state
+	current, err := gc.ListSatellites(ctx, client.ListSatellitesParams{})
+	if err != nil {
+		return nil, fmt.Errorf("fetch current satellites: %w", err)
+	}
+
+	// Build lookup maps
+	currentMap := make(map[string]client.Satellite, len(current))
+	for _, s := range current {
+		currentMap[s.Name] = s
+	}
+
+	desiredMap := make(map[string]SatelliteEntry, len(manifest.Spec.Satellites))
+	for _, s := range manifest.Spec.Satellites {
+		desiredMap[s.Name] = s
+	}
+
+	result := &ApplyResult{}
+
+	// Create satellites that exist in desired but not in current
+	for name, entry := range desiredMap {
+		if _, exists := currentMap[name]; !exists {
+			configName := entry.ConfigName
+			if configName == "" {
+				configName = manifest.Spec.ConfigName
+			}
+			groups := entry.Groups
+			if len(groups) == 0 {
+				groups = manifest.Spec.Groups
+			}
+
+			if !dryRun {
+				params := client.RegisterSatelliteParams{
+					Name:       name,
+					ConfigName: configName,
+				}
+				if len(groups) > 0 {
+					params.Groups = &groups
+				}
+				if _, err := gc.RegisterSatellite(ctx, params); err != nil {
+					return nil, fmt.Errorf("register satellite %q: %w", name, err)
+				}
+			}
+			result.Created = append(result.Created, name)
+		} else {
+			// Already exists — mark unchanged (group-level reconciliation is a future enhancement)
+			result.Unchanged = append(result.Unchanged, name)
+		}
+	}
+
+	// Delete satellites that exist in current but not in desired
+	for name := range currentMap {
+		if _, wanted := desiredMap[name]; !wanted {
+			if !dryRun {
+				if err := gc.DeleteSatellite(ctx, name); err != nil {
+					return nil, fmt.Errorf("delete satellite %q: %w", name, err)
+				}
+			}
+			result.Deleted = append(result.Deleted, name)
+		}
+	}
+
+	return result, nil
+}

--- a/groundctl/internal/client/client.go
+++ b/groundctl/internal/client/client.go
@@ -1,0 +1,308 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// Client is a typed HTTP client for the Ground Control API.
+type Client struct {
+	baseURL    string
+	token      string
+	httpClient *http.Client
+}
+
+// New creates a new Ground Control client.
+func New(baseURL, token string) *Client {
+	return &Client{
+		baseURL: baseURL,
+		token:   token,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// Satellite represents a satellite registered in Ground Control.
+type Satellite struct {
+	ID                int32      `json:"id"`
+	Name              string     `json:"name"`
+	CreatedAt         time.Time  `json:"created_at"`
+	UpdatedAt         time.Time  `json:"updated_at"`
+	LastSeen          *time.Time `json:"last_seen,omitempty"`
+	HeartbeatInterval *string    `json:"heartbeat_interval,omitempty"`
+}
+
+// SatelliteStatus represents the latest sync status of a satellite.
+type SatelliteStatus struct {
+	Activity           string    `json:"activity"`
+	LatestStateDigest  string    `json:"latest_state_digest"`
+	LatestConfigDigest string    `json:"latest_config_digest"`
+	CPUPercent         string    `json:"cpu_percent"`
+	MemoryUsedBytes    int64     `json:"memory_used_bytes"`
+	StorageUsedBytes   int64     `json:"storage_used_bytes"`
+	LastSyncDurationMs int64     `json:"last_sync_duration_ms"`
+	ImageCount         int32     `json:"image_count"`
+	ReportedAt         time.Time `json:"reported_at"`
+}
+
+// CachedImage represents an image cached by a satellite.
+type CachedImage struct {
+	Reference string `json:"reference"`
+	SizeBytes int64  `json:"size_bytes"`
+}
+
+// Group represents a group of images.
+type Group struct {
+	ID        int32     `json:"id"`
+	GroupName string    `json:"group_name"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// Config represents a satellite configuration.
+type Config struct {
+	ID         int32     `json:"id"`
+	Name       string    `json:"name"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+// ListSatellitesParams controls filtering and pagination for satellite listing.
+type ListSatellitesParams struct {
+	Limit      int
+	Offset     int
+	NamePrefix string
+	Sort       string
+	Order      string
+}
+
+// RegisterSatelliteParams holds parameters for registering a new satellite.
+type RegisterSatelliteParams struct {
+	Name       string    `json:"name"`
+	ConfigName string    `json:"config_name"`
+	Groups     *[]string `json:"groups,omitempty"`
+}
+
+// RegisterSatelliteResponse is returned by the register endpoint.
+type RegisterSatelliteResponse struct {
+	Token string `json:"token"`
+}
+
+// SatelliteGroupParams holds parameters for add/remove satellite from group.
+type SatelliteGroupParams struct {
+	Satellite string `json:"satellite"`
+	Group     string `json:"group"`
+}
+
+// do executes an authenticated HTTP request and decodes the JSON response.
+func (c *Client) do(ctx context.Context, method, path string, body, out any) error {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("server returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	if out != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, out); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Ping checks if Ground Control is reachable.
+func (c *Client) Ping(ctx context.Context) error {
+	return c.do(ctx, http.MethodGet, "/ping", nil, nil)
+}
+
+// Health returns the health status of Ground Control.
+func (c *Client) Health(ctx context.Context) (map[string]any, error) {
+	var result map[string]any
+	if err := c.do(ctx, http.MethodGet, "/health", nil, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// ListSatellites returns a list of satellites with optional filtering.
+func (c *Client) ListSatellites(ctx context.Context, params ListSatellitesParams) ([]Satellite, error) {
+	q := url.Values{}
+	if params.Limit > 0 {
+		q.Set("limit", fmt.Sprintf("%d", params.Limit))
+	}
+	if params.Offset > 0 {
+		q.Set("offset", fmt.Sprintf("%d", params.Offset))
+	}
+	if params.NamePrefix != "" {
+		q.Set("name_prefix", params.NamePrefix)
+	}
+	if params.Sort != "" {
+		q.Set("sort", params.Sort)
+	}
+	if params.Order != "" {
+		q.Set("order", params.Order)
+	}
+
+	path := "/api/satellites"
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+
+	var result []Satellite
+	if err := c.do(ctx, http.MethodGet, path, nil, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// GetSatellite returns a single satellite by name.
+func (c *Client) GetSatellite(ctx context.Context, name string) (*Satellite, error) {
+	var result Satellite
+	if err := c.do(ctx, http.MethodGet, "/api/satellites/"+name, nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// RegisterSatellite registers a new satellite and returns its one-time token.
+func (c *Client) RegisterSatellite(ctx context.Context, params RegisterSatelliteParams) (*RegisterSatelliteResponse, error) {
+	var result RegisterSatelliteResponse
+	if err := c.do(ctx, http.MethodPost, "/api/satellites", params, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DeleteSatellite removes a satellite by name.
+func (c *Client) DeleteSatellite(ctx context.Context, name string) error {
+	return c.do(ctx, http.MethodDelete, "/api/satellites/"+name, nil, nil)
+}
+
+// GetSatelliteStatus returns the latest sync status of a satellite.
+func (c *Client) GetSatelliteStatus(ctx context.Context, name string) (*SatelliteStatus, error) {
+	var result SatelliteStatus
+	if err := c.do(ctx, http.MethodGet, "/api/satellites/"+name+"/status", nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetSatelliteImages returns the cached images of a satellite.
+func (c *Client) GetSatelliteImages(ctx context.Context, name string) ([]CachedImage, error) {
+	var result []CachedImage
+	if err := c.do(ctx, http.MethodGet, "/api/satellites/"+name+"/images", nil, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// GetActiveSatellites returns satellites that have checked in recently.
+func (c *Client) GetActiveSatellites(ctx context.Context) ([]Satellite, error) {
+	var result []Satellite
+	if err := c.do(ctx, http.MethodGet, "/api/satellites/active", nil, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// GetStaleSatellites returns satellites that have not checked in recently.
+func (c *Client) GetStaleSatellites(ctx context.Context) ([]Satellite, error) {
+	var result []Satellite
+	if err := c.do(ctx, http.MethodGet, "/api/satellites/stale", nil, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// ListGroups returns all image groups.
+func (c *Client) ListGroups(ctx context.Context) ([]Group, error) {
+	var result []Group
+	if err := c.do(ctx, http.MethodGet, "/api/groups", nil, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// GetGroup returns a single group by name.
+func (c *Client) GetGroup(ctx context.Context, name string) (*Group, error) {
+	var result Group
+	if err := c.do(ctx, http.MethodGet, "/api/groups/"+name, nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// AddSatelliteToGroup adds a satellite to a group.
+func (c *Client) AddSatelliteToGroup(ctx context.Context, satellite, group string) error {
+	return c.do(ctx, http.MethodPost, "/api/groups/satellite", SatelliteGroupParams{
+		Satellite: satellite,
+		Group:     group,
+	}, nil)
+}
+
+// RemoveSatelliteFromGroup removes a satellite from a group.
+func (c *Client) RemoveSatelliteFromGroup(ctx context.Context, satellite, group string) error {
+	return c.do(ctx, http.MethodDelete, "/api/groups/satellite", SatelliteGroupParams{
+		Satellite: satellite,
+		Group:     group,
+	}, nil)
+}
+
+// ListConfigs returns all satellite configs.
+func (c *Client) ListConfigs(ctx context.Context) ([]Config, error) {
+	var result []Config
+	if err := c.do(ctx, http.MethodGet, "/api/configs", nil, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// GetConfig returns a single config by name.
+func (c *Client) GetConfig(ctx context.Context, name string) (*Config, error) {
+	var result Config
+	if err := c.do(ctx, http.MethodGet, "/api/configs/"+name, nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DeleteConfig removes a config by name.
+func (c *Client) DeleteConfig(ctx context.Context, name string) error {
+	return c.do(ctx, http.MethodDelete, "/api/configs/"+name, nil, nil)
+}

--- a/groundctl/internal/output/output.go
+++ b/groundctl/internal/output/output.go
@@ -1,0 +1,227 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/container-registry/harbor-satellite/groundctl/internal/client"
+)
+
+// Format controls the output format.
+type Format string
+
+const (
+	FormatTable Format = "table"
+	FormatJSON  Format = "json"
+)
+
+// PrintSatellites prints a list of satellites in the given format.
+func PrintSatellites(satellites []client.Satellite, format Format) {
+	switch format {
+	case FormatJSON:
+		printJSON(satellites)
+	default:
+		printSatelliteTable(satellites, os.Stdout)
+	}
+}
+
+// PrintSatellite prints a single satellite in the given format.
+func PrintSatellite(sat *client.Satellite, format Format) {
+	switch format {
+	case FormatJSON:
+		printJSON(sat)
+	default:
+		printSatelliteTable([]client.Satellite{*sat}, os.Stdout)
+	}
+}
+
+// PrintSatelliteStatus prints satellite status in the given format.
+func PrintSatelliteStatus(name string, status *client.SatelliteStatus, format Format) {
+	switch format {
+	case FormatJSON:
+		printJSON(status)
+	default:
+		printStatusTable(name, status, os.Stdout)
+	}
+}
+
+// PrintCachedImages prints the cached images of a satellite.
+func PrintCachedImages(name string, images []client.CachedImage, format Format) {
+	switch format {
+	case FormatJSON:
+		printJSON(images)
+	default:
+		printImagesTable(name, images, os.Stdout)
+	}
+}
+
+// PrintGroups prints a list of groups in the given format.
+func PrintGroups(groups []client.Group, format Format) {
+	switch format {
+	case FormatJSON:
+		printJSON(groups)
+	default:
+		printGroupTable(groups, os.Stdout)
+	}
+}
+
+// PrintConfigs prints a list of configs in the given format.
+func PrintConfigs(configs []client.Config, format Format) {
+	switch format {
+	case FormatJSON:
+		printJSON(configs)
+	default:
+		printConfigTable(configs, os.Stdout)
+	}
+}
+
+// PrintApplyResult prints the result of a groundctl apply operation.
+func PrintApplyResult(created, deleted, updated, unchanged []string) {
+	for _, name := range created {
+		fmt.Printf("  \033[32m+\033[0m satellite/%-30s created\n", name)
+	}
+	for _, name := range deleted {
+		fmt.Printf("  \033[31m-\033[0m satellite/%-30s deleted\n", name)
+	}
+	for _, name := range updated {
+		fmt.Printf("  \033[33m~\033[0m satellite/%-30s updated\n", name)
+	}
+	for _, name := range unchanged {
+		fmt.Printf("    satellite/%-30s unchanged\n", name)
+	}
+
+	total := len(created) + len(deleted) + len(updated)
+	if total == 0 {
+		fmt.Println("\nNo changes. Fleet is already in sync.")
+	} else {
+		fmt.Printf("\nApplied: %d created, %d deleted, %d updated, %d unchanged\n",
+			len(created), len(deleted), len(updated), len(unchanged))
+	}
+}
+
+func printSatelliteTable(satellites []client.Satellite, w io.Writer) {
+	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tSTATUS\tLAST SEEN\tHEARTBEAT\tCREATED")
+	for _, s := range satellites {
+		lastSeen := "<never>"
+		if s.LastSeen != nil {
+			lastSeen = formatAge(*s.LastSeen)
+		}
+		heartbeat := "-"
+		if s.HeartbeatInterval != nil {
+			heartbeat = *s.HeartbeatInterval
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+			s.Name,
+			statusEmoji(s.LastSeen),
+			lastSeen,
+			heartbeat,
+			formatAge(s.CreatedAt),
+		)
+	}
+	tw.Flush()
+}
+
+func printStatusTable(name string, s *client.SatelliteStatus, w io.Writer) {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "Satellite:\t%s\n", name)
+	fmt.Fprintf(tw, "Activity:\t%s\n", s.Activity)
+	fmt.Fprintf(tw, "State Digest:\t%s\n", truncate(s.LatestStateDigest, 20))
+	fmt.Fprintf(tw, "Config Digest:\t%s\n", truncate(s.LatestConfigDigest, 20))
+	fmt.Fprintf(tw, "CPU:\t%s%%\n", s.CPUPercent)
+	fmt.Fprintf(tw, "Memory:\t%s\n", formatBytes(s.MemoryUsedBytes))
+	fmt.Fprintf(tw, "Storage:\t%s\n", formatBytes(s.StorageUsedBytes))
+	fmt.Fprintf(tw, "Images Cached:\t%d\n", s.ImageCount)
+	fmt.Fprintf(tw, "Last Sync:\t%dms\n", s.LastSyncDurationMs)
+	fmt.Fprintf(tw, "Reported At:\t%s\n", formatAge(s.ReportedAt))
+	tw.Flush()
+}
+
+func printImagesTable(name string, images []client.CachedImage, w io.Writer) {
+	fmt.Fprintf(w, "Cached images on %s (%d total):\n\n", name, len(images))
+	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(tw, "REFERENCE\tSIZE")
+	for _, img := range images {
+		fmt.Fprintf(tw, "%s\t%s\n", img.Reference, formatBytes(img.SizeBytes))
+	}
+	tw.Flush()
+}
+
+func printGroupTable(groups []client.Group, w io.Writer) {
+	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tCREATED")
+	for _, g := range groups {
+		fmt.Fprintf(tw, "%s\t%s\n", g.GroupName, formatAge(g.CreatedAt))
+	}
+	tw.Flush()
+}
+
+func printConfigTable(configs []client.Config, w io.Writer) {
+	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tCREATED\tUPDATED")
+	for _, c := range configs {
+		fmt.Fprintf(tw, "%s\t%s\t%s\n",
+			c.Name,
+			formatAge(c.CreatedAt),
+			formatAge(c.UpdatedAt),
+		)
+	}
+	tw.Flush()
+}
+
+func printJSON(v any) {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(v)
+}
+
+func statusEmoji(lastSeen *time.Time) string {
+	if lastSeen == nil {
+		return "Unknown"
+	}
+	if time.Since(*lastSeen) < 2*time.Minute {
+		return "Active"
+	}
+	if time.Since(*lastSeen) < time.Hour {
+		return "Idle"
+	}
+	return "Stale"
+}
+
+func formatAge(t time.Time) string {
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds ago", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
+}
+
+func formatBytes(b int64) string {
+	switch {
+	case b >= 1<<30:
+		return fmt.Sprintf("%.1f GiB", float64(b)/(1<<30))
+	case b >= 1<<20:
+		return fmt.Sprintf("%.1f MiB", float64(b)/(1<<20))
+	case b >= 1<<10:
+		return fmt.Sprintf("%.1f KiB", float64(b)/(1<<10))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/groundctl/main.go
+++ b/groundctl/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/container-registry/harbor-satellite/groundctl/cmd"
+)
+
+func main() {
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## What this PR does

This PR introduces `groundctl`, the missing first-class CLI for managing Harbor Satellite fleets, fulfilling Deliverable 1 of the LFX 2026 Term 2 scope (#375).

It provides a standalone Go binary built with Cobra that wraps the Ground Control API, enabling operators to manage satellites, groups, and configs directly from the command line with type safety and structured output (`table` / `json`).

---

## Key Features

### 1. Satellite Lifecycle Management

Adds commands to:

- `list`
- `get`
- `register`
- `delete`
- check `status`
- view `images`

for satellites managed by Ground Control.

---

### 2. Group and Config Management

Adds commands for:

- listing groups/configs
- fetching group/config details
- managing image groups
- managing satellite configs

---

### 3. GitOps `apply` Mode

Introduces:

```bash
groundctl apply -f fleet.yaml
```

This command:

- reads a declarative `SatelliteFleet` manifest
- diffs desired state against live Ground Control state
- performs minimal reconciliation operations
- creates/deletes satellites as needed

Also includes:

```bash
--dry-run
```

to preview reconciliation changes without making API calls.

---

### 4. Independent HTTP Client

Ships with its own typed HTTP client layer.

This allows the CLI to merge independently of the OpenAPI client generation effort (#424), while remaining compatible with future migration to the generated client.

---

### 5. Documentation & Tooling

Includes:

- comprehensive CLI reference documentation in:
  ```text
  groundctl/README.md
  ```

- build integration via:
  ```text
  task build-groundctl
  ```

  added to the root `Taskfile.yml`

---

## Fixes / Related Issues

- Fixes #432
- Part of #375

---

## How to test this

### 1. Ensure Go 1.24+ is installed

---

### 2. Build the binary

From the repository root:

```bash
task build-groundctl
```

---

### 3. Test basic commands

Against a running Ground Control instance using either:

- `--gc-url` and `--token`
- or:
  - `GROUNDCTL_URL`
  - `GROUNDCTL_TOKEN`

environment variables.

```bash
./bin/groundctl satellite list

./bin/groundctl group list

./bin/groundctl config list
```

---

### 4. Test GitOps apply mode

Run dry-run first:

```bash
./bin/groundctl apply \
  -f groundctl/examples/fleet.yaml \
  --dry-run
```

Then apply changes:

```bash
./bin/groundctl apply \
  -f groundctl/examples/fleet.yaml
```

---

## Checklist

- [x] Code compiles correctly (`task build-groundctl`)
- [x] Created/updated tests (tested manually against API specs)
- [x] Documentation added (`groundctl/README.md`)
- [x] DCO signed off


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `groundctl` CLI tool with commands to manage satellites, groups, and configurations
  * Added `apply` command for declarative fleet reconciliation via YAML manifests
  * Support for multiple output formats: table (default) and JSON
  * Configuration via command-line flags and environment variables

* **Documentation**
  * Added comprehensive CLI documentation with examples and usage guides

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/container-registry/harbor-satellite/pull/433)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->