### PR TITLE
fix: continue replication on per-image failure instead of aborting group

### DIFF
--- a/internal/state/replicator.go
+++ b/internal/state/replicator.go
@@ -173,8 +173,7 @@ func (r *BasicReplicator) replicateOne(
 		return fmt.Errorf("compute source digest: %w", err)
 	}
 
-	dstDesc, dstErr := remote.Head(dst, pushOpts...)
-	if dstErr == nil && dstDesc.Digest == srcDigest {
+	if r.isUpToDate(dst, srcDigest, pushOpts) {
 		log.Info().Msgf("Image %s already up-to-date at destination, skipping", entity.GetName())
 		return nil
 	}
@@ -193,6 +192,13 @@ func (r *BasicReplicator) replicateOne(
 		return fmt.Errorf("write image %s: %w", entity.GetName(), err)
 	}
 	return nil
+}
+
+// isUpToDate reports whether the destination already holds an image with the
+// same digest as srcDigest, meaning no transfer is needed.
+func (r *BasicReplicator) isUpToDate(dst name.Reference, srcDigest v1.Hash, pushOpts []remote.Option) bool {
+	dstDesc, err := remote.Head(dst, pushOpts...)
+	return err == nil && dstDesc.Digest == srcDigest
 }
 
 // countMissingLayers checks which source layers are absent from the destination

--- a/internal/state/replicator.go
+++ b/internal/state/replicator.go
@@ -154,18 +154,11 @@ func (r *BasicReplicator) replicateOne(
 		return fmt.Errorf("parse dest ref %s: %w", dstRef, err)
 	}
 
-	// Lazy fetch: only the manifest is downloaded, no layer data yet
-	desc, err := remote.Get(src, pullOpts...)
+	// Fetch manifest and resolve to OCI image (no layer data yet).
+	img, err := fetchOCIImage(src, pullOpts)
 	if err != nil {
-		return fmt.Errorf("fetch image descriptor for %s: %w", entity.GetName(), err)
+		return fmt.Errorf("fetch image %s: %w", entity.GetName(), err)
 	}
-
-	img, err := desc.Image()
-	if err != nil {
-		return fmt.Errorf("resolve image %s: %w", entity.GetName(), err)
-	}
-
-	// Lazy OCI conversion, no data materialized
 	ociImage := mutate.MediaType(img, types.OCIManifestSchema1)
 
 	srcDigest, err := ociImage.Digest()
@@ -192,6 +185,20 @@ func (r *BasicReplicator) replicateOne(
 		return fmt.Errorf("write image %s: %w", entity.GetName(), err)
 	}
 	return nil
+}
+
+// fetchOCIImage fetches the manifest from src and resolves it to a v1.Image.
+// Only the manifest is downloaded; layers remain lazy until explicitly read.
+func fetchOCIImage(src name.Reference, pullOpts []remote.Option) (v1.Image, error) {
+	desc, err := remote.Get(src, pullOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("fetch descriptor: %w", err)
+	}
+	img, err := desc.Image()
+	if err != nil {
+		return nil, fmt.Errorf("resolve image: %w", err)
+	}
+	return img, nil
 }
 
 // isUpToDate reports whether the destination already holds an image with the

--- a/internal/state/replicator.go
+++ b/internal/state/replicator.go
@@ -3,6 +3,7 @@ package state
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -20,7 +21,9 @@ import (
 
 type Replicator interface {
 	// Replicate copies images from the source registry to the local registry.
-	Replicate(ctx context.Context, replicationEntities []Entity) error
+	// It processes every entity even if individual ones fail, returning a slice
+	// of entities that could not be replicated alongside a joined error.
+	Replicate(ctx context.Context, replicationEntities []Entity) ([]Entity, error)
 	// DeleteReplicationEntity deletes the image from the local registry.
 	DeleteReplicationEntity(ctx context.Context, replicationEntity []Entity) error
 }
@@ -74,9 +77,9 @@ func (e Entity) GetTag() string {
 }
 
 // Replicate replicates images from the source registry to the local registry.
-// Before pulling, it checks which blobs already exist at the destination and
-// only downloads missing layers from source, saving bandwidth on crash recovery.
-func (r *BasicReplicator) Replicate(ctx context.Context, replicationEntities []Entity) error {
+// Every entity is attempted regardless of individual failures. Failed entities
+// are returned alongside a joined error so callers can track partial success.
+func (r *BasicReplicator) Replicate(ctx context.Context, replicationEntities []Entity) ([]Entity, error) {
 	log := logger.FromContext(ctx)
 	pullAuth := authn.FromConfig(authn.AuthConfig{
 		Username: r.sourceUsername,
@@ -96,7 +99,7 @@ func (r *BasicReplicator) Replicate(ctx context.Context, replicationEntities []E
 	} else {
 		transport, err := r.buildTLSTransport()
 		if err != nil {
-			return fmt.Errorf("build TLS transport: %w", err)
+			return nil, fmt.Errorf("build TLS transport: %w", err)
 		}
 		if transport != nil {
 			pullOpts = append(pullOpts, remote.WithTransport(transport))
@@ -104,73 +107,90 @@ func (r *BasicReplicator) Replicate(ctx context.Context, replicationEntities []E
 		}
 	}
 
+	var failed []Entity
+	var errs []error
+
 	for _, entity := range replicationEntities {
-		// Check context cancellation before processing each image
 		select {
 		case <-ctx.Done():
 			log.Warn().Err(ctx.Err()).Msg("Context cancelled, stopping replication")
-			return ctx.Err()
+			return failed, ctx.Err()
 		default:
 		}
 
-		srcRef := fmt.Sprintf("%s/%s/%s:%s", r.sourceRegistry, entity.GetRepository(), entity.GetName(), entity.GetTag())
-		dstRef := fmt.Sprintf("%s/%s/%s:%s", r.remoteRegistryURL, entity.GetRepository(), entity.GetName(), entity.GetTag())
-
-		src, err := name.ParseReference(srcRef, nameOpts...)
-		if err != nil {
-			return fmt.Errorf("parse source ref %s: %w", srcRef, err)
-		}
-
-		dst, err := name.ParseReference(dstRef, nameOpts...)
-		if err != nil {
-			return fmt.Errorf("parse dest ref %s: %w", dstRef, err)
-		}
-
-		// Lazy fetch: only the manifest is downloaded, no layer data yet
-		desc, err := remote.Get(src, pullOpts...)
-		if err != nil {
-			log.Error().Msgf("Failed to fetch image descriptor: %v", err)
-			return err
-		}
-
-		img, err := desc.Image()
-		if err != nil {
-			log.Error().Msgf("Failed to resolve image: %v", err)
-			return err
-		}
-
-		// Lazy OCI conversion, no data materialized
-		ociImage := mutate.MediaType(img, types.OCIManifestSchema1)
-
-		// Check if image already exists at destination with same digest
-		srcDigest, err := ociImage.Digest()
-		if err != nil {
-			return fmt.Errorf("compute source digest: %w", err)
-		}
-
-		dstDesc, dstErr := remote.Head(dst, pushOpts...)
-		if dstErr == nil && dstDesc.Digest == srcDigest {
-			log.Info().Msgf("Image %s already up-to-date at destination, skipping", entity.GetName())
+		if err := r.replicateOne(ctx, entity, nameOpts, pullOpts, pushOpts); err != nil {
+			log.Error().Err(err).Msgf("Failed to replicate %s, continuing with remaining images", entity.GetName())
+			failed = append(failed, entity)
+			errs = append(errs, fmt.Errorf("%s: %w", entity.GetName(), err))
 			continue
 		}
-
-		// Log which layers need pulling vs already present
-		srcLayers, err := ociImage.Layers()
-		if err != nil {
-			return fmt.Errorf("get source layers: %w", err)
-		}
-
-		missing := r.countMissingLayers(dst, srcLayers, pushOpts)
-		log.Info().Msgf("Replicating image %s: %d/%d layers to pull", entity.GetName(), missing, len(srcLayers))
-
-		// remote.Write streams layers one-by-one. For each layer it HEAD-checks
-		// the destination first; only missing blobs are pulled from source.
-		// Manifest is pushed last.
-		if err := remote.Write(dst, ociImage, pushOpts...); err != nil {
-			log.Error().Msgf("Failed to replicate image: %v", err)
-			return err
-		}
 		log.Info().Msgf("Image %s replicated successfully", entity.GetName())
+	}
+
+	return failed, errors.Join(errs...)
+}
+
+// replicateOne copies a single image from source to destination.
+// It skips images that are already up-to-date at the destination.
+func (r *BasicReplicator) replicateOne(
+	ctx context.Context,
+	entity Entity,
+	nameOpts []name.Option,
+	pullOpts []remote.Option,
+	pushOpts []remote.Option,
+) error {
+	log := logger.FromContext(ctx)
+
+	srcRef := fmt.Sprintf("%s/%s/%s:%s", r.sourceRegistry, entity.GetRepository(), entity.GetName(), entity.GetTag())
+	dstRef := fmt.Sprintf("%s/%s/%s:%s", r.remoteRegistryURL, entity.GetRepository(), entity.GetName(), entity.GetTag())
+
+	src, err := name.ParseReference(srcRef, nameOpts...)
+	if err != nil {
+		return fmt.Errorf("parse source ref %s: %w", srcRef, err)
+	}
+
+	dst, err := name.ParseReference(dstRef, nameOpts...)
+	if err != nil {
+		return fmt.Errorf("parse dest ref %s: %w", dstRef, err)
+	}
+
+	// Lazy fetch: only the manifest is downloaded, no layer data yet
+	desc, err := remote.Get(src, pullOpts...)
+	if err != nil {
+		return fmt.Errorf("fetch image descriptor for %s: %w", entity.GetName(), err)
+	}
+
+	img, err := desc.Image()
+	if err != nil {
+		return fmt.Errorf("resolve image %s: %w", entity.GetName(), err)
+	}
+
+	// Lazy OCI conversion, no data materialized
+	ociImage := mutate.MediaType(img, types.OCIManifestSchema1)
+
+	srcDigest, err := ociImage.Digest()
+	if err != nil {
+		return fmt.Errorf("compute source digest: %w", err)
+	}
+
+	dstDesc, dstErr := remote.Head(dst, pushOpts...)
+	if dstErr == nil && dstDesc.Digest == srcDigest {
+		log.Info().Msgf("Image %s already up-to-date at destination, skipping", entity.GetName())
+		return nil
+	}
+
+	srcLayers, err := ociImage.Layers()
+	if err != nil {
+		return fmt.Errorf("get source layers: %w", err)
+	}
+
+	missing := r.countMissingLayers(dst, srcLayers, pushOpts)
+	log.Info().Msgf("Replicating image %s: %d/%d layers to pull", entity.GetName(), missing, len(srcLayers))
+
+	// remote.Write streams layers one-by-one, HEAD-checking each blob at the
+	// destination first so only missing blobs are pulled from source.
+	if err := remote.Write(dst, ociImage, pushOpts...); err != nil {
+		return fmt.Errorf("write image %s: %w", entity.GetName(), err)
 	}
 	return nil
 }

--- a/internal/state/replicator.go
+++ b/internal/state/replicator.go
@@ -16,8 +16,16 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
+
+// maxConsecutiveBatchFailures bounds how many registry-wide errors (auth,
+// rate-limiting, connectivity) in a row we tolerate before giving up on the
+// rest of the batch. Once the registry is down or throttling us, every
+// remaining entity would fail the same way, so there's no point burning
+// through the whole list one doomed attempt at a time.
+const maxConsecutiveBatchFailures = 3
 
 type Replicator interface {
 	// Replicate copies images from the source registry to the local registry.
@@ -109,8 +117,9 @@ func (r *BasicReplicator) Replicate(ctx context.Context, replicationEntities []E
 
 	var failed []Entity
 	var errs []error
+	consecutiveBatchFailures := 0
 
-	for _, entity := range replicationEntities {
+	for i, entity := range replicationEntities {
 		select {
 		case <-ctx.Done():
 			log.Warn().Err(ctx.Err()).Msg("Context cancelled, stopping replication")
@@ -122,12 +131,47 @@ func (r *BasicReplicator) Replicate(ctx context.Context, replicationEntities []E
 			log.Error().Err(err).Msgf("Failed to replicate %s, continuing with remaining images", entity.GetName())
 			failed = append(failed, entity)
 			errs = append(errs, fmt.Errorf("%s: %w", entity.GetName(), err))
+
+			if isBatchLevelError(err) {
+				consecutiveBatchFailures++
+				if consecutiveBatchFailures >= maxConsecutiveBatchFailures {
+					remaining := replicationEntities[i+1:]
+					log.Error().Msgf("Aborting replication after %d consecutive registry-level failures, skipping %d remaining images", consecutiveBatchFailures, len(remaining))
+					for _, e := range remaining {
+						failed = append(failed, e)
+						errs = append(errs, fmt.Errorf("%s: skipped after repeated registry-level failures", e.GetName()))
+					}
+					break
+				}
+			} else {
+				consecutiveBatchFailures = 0
+			}
 			continue
 		}
+		consecutiveBatchFailures = 0
 		log.Info().Msgf("Image %s replicated successfully", entity.GetName())
 	}
 
 	return failed, errors.Join(errs...)
+}
+
+// isBatchLevelError reports whether err looks like a registry-wide failure
+// (unauthorized, forbidden, rate-limited, or a server error) rather than an
+// issue specific to a single image. These are the cases where retrying the
+// next image is very likely to fail the same way.
+func isBatchLevelError(err error) bool {
+	var terr *transport.Error
+	if !errors.As(err, &terr) {
+		return false
+	}
+	switch terr.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusTooManyRequests,
+		http.StatusInternalServerError, http.StatusBadGateway,
+		http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
 }
 
 // replicateOne copies a single image from source to destination.

--- a/internal/state/replicator.go
+++ b/internal/state/replicator.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/rs/zerolog"
 )
 
 // maxConsecutiveBatchFailures bounds how many registry-wide errors (auth,
@@ -129,22 +130,12 @@ func (r *BasicReplicator) Replicate(ctx context.Context, replicationEntities []E
 
 		if err := r.replicateOne(ctx, entity, nameOpts, pullOpts, pushOpts); err != nil {
 			log.Error().Err(err).Msgf("Failed to replicate %s, continuing with remaining images", entity.GetName())
-			failed = append(failed, entity)
-			errs = append(errs, fmt.Errorf("%s: %w", entity.GetName(), err))
-
-			if isBatchLevelError(err) {
-				consecutiveBatchFailures++
-				if consecutiveBatchFailures >= maxConsecutiveBatchFailures {
-					remaining := replicationEntities[i+1:]
-					log.Error().Msgf("Aborting replication after %d consecutive registry-level failures, skipping %d remaining images", consecutiveBatchFailures, len(remaining))
-					for _, e := range remaining {
-						failed = append(failed, e)
-						errs = append(errs, fmt.Errorf("%s: skipped after repeated registry-level failures", e.GetName()))
-					}
-					break
-				}
-			} else {
-				consecutiveBatchFailures = 0
+			var aborted bool
+			failed, errs, consecutiveBatchFailures, aborted = recordReplicationFailure(
+				log, replicationEntities, i, entity, err, failed, errs, consecutiveBatchFailures,
+			)
+			if aborted {
+				break
 			}
 			continue
 		}
@@ -153,6 +144,42 @@ func (r *BasicReplicator) Replicate(ctx context.Context, replicationEntities []E
 	}
 
 	return failed, errors.Join(errs...)
+}
+
+// recordReplicationFailure appends entity's failure to failed/errs and
+// updates the consecutive-batch-failure count. Once that count hits
+// maxConsecutiveBatchFailures, it also marks every entity after index i as
+// failed and reports that Replicate should stop, since a registry-wide
+// error means the rest of the batch is doomed to the same outcome.
+func recordReplicationFailure(
+	log *zerolog.Logger,
+	entities []Entity,
+	i int,
+	entity Entity,
+	err error,
+	failed []Entity,
+	errs []error,
+	consecutiveBatchFailures int,
+) ([]Entity, []error, int, bool) {
+	failed = append(failed, entity)
+	errs = append(errs, fmt.Errorf("%s: %w", entity.GetName(), err))
+
+	if !isBatchLevelError(err) {
+		return failed, errs, 0, false
+	}
+
+	consecutiveBatchFailures++
+	if consecutiveBatchFailures < maxConsecutiveBatchFailures {
+		return failed, errs, consecutiveBatchFailures, false
+	}
+
+	remaining := entities[i+1:]
+	log.Error().Msgf("Aborting replication after %d consecutive registry-level failures, skipping %d remaining images", consecutiveBatchFailures, len(remaining))
+	for _, e := range remaining {
+		failed = append(failed, e)
+		errs = append(errs, fmt.Errorf("%s: skipped after repeated registry-level failures", e.GetName()))
+	}
+	return failed, errs, consecutiveBatchFailures, true
 }
 
 // isBatchLevelError reports whether err looks like a registry-wide failure

--- a/internal/state/replicator_test.go
+++ b/internal/state/replicator_test.go
@@ -47,7 +47,7 @@ func TestReplicate_NewImage(t *testing.T) {
 	r := NewBasicReplicator("", "", srcAddr, dstAddr, "", "", true)
 	ctx := testContext()
 
-	err := r.Replicate(ctx, []Entity{
+	_, err := r.Replicate(ctx, []Entity{
 		{Name: "alpine", Repository: "library", Tag: "latest"},
 	})
 	require.NoError(t, err)
@@ -74,7 +74,7 @@ func TestReplicate_SkipsExistingImage(t *testing.T) {
 	ctx := testContext()
 
 	// Should succeed without error and skip the image
-	err = r.Replicate(ctx, []Entity{
+	_, err = r.Replicate(ctx, []Entity{
 		{Name: "nginx", Repository: "library", Tag: "1.25"},
 	})
 	require.NoError(t, err)
@@ -93,7 +93,7 @@ func TestReplicate_UpdatesChangedImage(t *testing.T) {
 	r := NewBasicReplicator("", "", srcAddr, dstAddr, "", "", true)
 	ctx := testContext()
 
-	err := r.Replicate(ctx, []Entity{
+	_, err := r.Replicate(ctx, []Entity{
 		{Name: "redis", Repository: "library", Tag: "7"},
 	})
 	require.NoError(t, err)
@@ -124,7 +124,7 @@ func TestReplicate_MultipleEntities(t *testing.T) {
 	r := NewBasicReplicator("", "", srcAddr, dstAddr, "", "", true)
 	ctx := testContext()
 
-	err := r.Replicate(ctx, []Entity{
+	_, err := r.Replicate(ctx, []Entity{
 		{Name: "alpine", Repository: "library", Tag: "latest"},
 		{Name: "nginx", Repository: "library", Tag: "1.25"},
 	})
@@ -150,10 +150,12 @@ func TestReplicate_SourceNotFound(t *testing.T) {
 	r := NewBasicReplicator("", "", srcAddr, dstAddr, "", "", true)
 	ctx := testContext()
 
-	err := r.Replicate(ctx, []Entity{
+	failed, err := r.Replicate(ctx, []Entity{
 		{Name: "missing", Repository: "library", Tag: "latest"},
 	})
 	require.Error(t, err)
+	require.Len(t, failed, 1)
+	require.Equal(t, "missing", failed[0].Name)
 }
 
 func TestReplicate_EmptyEntities(t *testing.T) {
@@ -163,8 +165,53 @@ func TestReplicate_EmptyEntities(t *testing.T) {
 	r := NewBasicReplicator("", "", srcAddr, dstAddr, "", "", true)
 	ctx := testContext()
 
-	err := r.Replicate(ctx, []Entity{})
+	failed, err := r.Replicate(ctx, []Entity{})
 	require.NoError(t, err)
+	require.Empty(t, failed)
+}
+
+// TestReplicate_ContinuesAfterOneFailure verifies the core fix for issue #434:
+// a single unavailable image must not block replication of subsequent images.
+func TestReplicate_ContinuesAfterOneFailure(t *testing.T) {
+	_, srcAddr := newTestRegistry(t)
+	_, dstAddr := newTestRegistry(t)
+
+	// Push img1 and img3 — img2 is intentionally absent from source.
+	pushImage(t, srcAddr, "library", "img1", "v1", 1)
+	pushImage(t, srcAddr, "library", "img3", "v1", 1)
+
+	r := NewBasicReplicator("", "", srcAddr, dstAddr, "", "", true)
+	ctx := testContext()
+
+	failed, err := r.Replicate(ctx, []Entity{
+		{Name: "img1", Repository: "library", Tag: "v1"},
+		{Name: "img2", Repository: "library", Tag: "v1"}, // missing in source
+		{Name: "img3", Repository: "library", Tag: "v1"},
+	})
+
+	// Must return an error because img2 failed.
+	require.Error(t, err)
+
+	// Only img2 should be in the failed list.
+	require.Len(t, failed, 1)
+	require.Equal(t, "img2", failed[0].Name)
+
+	// img1 and img3 must exist at destination despite img2 failing.
+	for _, ref := range []string{
+		dstAddr + "/library/img1:v1",
+		dstAddr + "/library/img3:v1",
+	} {
+		parsed, parseErr := name.ParseReference(ref, name.Insecure)
+		require.NoError(t, parseErr)
+		_, headErr := remote.Head(parsed)
+		require.NoError(t, headErr, "image should be replicated: %s", ref)
+	}
+
+	// img2 must not exist at destination.
+	img2Ref, parseErr := name.ParseReference(dstAddr+"/library/img2:v1", name.Insecure)
+	require.NoError(t, parseErr)
+	_, headErr := remote.Head(img2Ref)
+	require.Error(t, headErr, "failed image must not exist at destination")
 }
 
 func TestCountMissingLayers_AllMissing(t *testing.T) {
@@ -293,7 +340,7 @@ func TestReplicate_LayerResume(t *testing.T) {
 	r := NewBasicReplicator("", "", srcAddr, dstAddr, "", "", true)
 	ctx := testContext()
 
-	err = r.Replicate(ctx, []Entity{
+	_, err = r.Replicate(ctx, []Entity{
 		{Name: "app", Repository: "library", Tag: "extended"},
 	})
 	require.NoError(t, err, "replication should succeed with layer-level resume")
@@ -331,7 +378,7 @@ func TestReplicate_CancelledContextStopsProcessing(t *testing.T) {
 	ctx, cancel := context.WithCancel(testContext())
 	cancel() // cancel immediately
 
-	err := r.Replicate(ctx, []Entity{
+	_, err := r.Replicate(ctx, []Entity{
 		{Name: "img1", Repository: "library", Tag: "v1"},
 		{Name: "img2", Repository: "library", Tag: "v1"},
 		{Name: "img3", Repository: "library", Tag: "v1"},

--- a/internal/state/replicator_test.go
+++ b/internal/state/replicator_test.go
@@ -2,17 +2,18 @@ package state
 
 import (
 	"context"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/types"
-	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -212,6 +213,43 @@ func TestReplicate_ContinuesAfterOneFailure(t *testing.T) {
 	require.NoError(t, parseErr)
 	_, headErr := remote.Head(img2Ref)
 	require.Error(t, headErr, "failed image must not exist at destination")
+}
+
+// TestReplicate_AbortsAfterConsecutiveBatchFailures verifies that once the
+// source registry starts failing every request with a registry-wide error
+// (here, 503s), replication gives up on the batch instead of retrying the
+// same failure for every remaining image.
+func TestReplicate_AbortsAfterConsecutiveBatchFailures(t *testing.T) {
+	var requestCount int
+	src := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(src.Close)
+	srcAddr := strings.TrimPrefix(src.URL, "http://")
+
+	_, dstAddr := newTestRegistry(t)
+
+	r := NewBasicReplicator("", "", srcAddr, dstAddr, "", "", true)
+	ctx := testContext()
+
+	entities := []Entity{
+		{Name: "img1", Repository: "library", Tag: "v1"},
+		{Name: "img2", Repository: "library", Tag: "v1"},
+		{Name: "img3", Repository: "library", Tag: "v1"},
+		{Name: "img4", Repository: "library", Tag: "v1"},
+		{Name: "img5", Repository: "library", Tag: "v1"},
+	}
+
+	failed, err := r.Replicate(ctx, entities)
+
+	require.Error(t, err)
+	require.Len(t, failed, len(entities), "every entity should be marked failed once the batch is aborted")
+
+	// Only the first maxConsecutiveBatchFailures entities should have actually
+	// hit the source; the rest are skipped without another request.
+	require.LessOrEqual(t, requestCount, maxConsecutiveBatchFailures,
+		"should stop calling the source once the consecutive-failure threshold is hit")
 }
 
 func TestCountMissingLayers_AllMissing(t *testing.T) {

--- a/internal/state/state_process.go
+++ b/internal/state/state_process.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -467,9 +468,12 @@ func (f *FetchAndReplicateStateProcess) processGroupState(
 		return result
 	}
 
-	if err := replicator.Replicate(ctx, replicateEntity); err != nil {
-		stateFetcherLog.Error().Err(err).Msg("Error replicating state")
-		result.Error = fmt.Errorf("failed to replicate entities for %s: %w", f.stateMap[index].url, err)
+	failedEntities, replicateErr := replicator.Replicate(ctx, replicateEntity)
+
+	// Context cancellation means nothing was completed — skip state update entirely.
+	if replicateErr != nil && (errors.Is(replicateErr, context.Canceled) || errors.Is(replicateErr, context.DeadlineExceeded)) {
+		result.Cancelled = true
+		result.Error = replicateErr
 		return result
 	}
 
@@ -483,9 +487,11 @@ func (f *FetchAndReplicateStateProcess) processGroupState(
 		}
 	}
 
+	// Update entity tracking for successfully replicated images only.
+	// Failed images are excluded so they will be retried on the next cycle.
 	mutex.Lock()
 	f.stateMap[index].State = newState
-	f.stateMap[index].Entities = FetchEntitiesFromState(newState)
+	f.stateMap[index].Entities = subtractEntities(FetchEntitiesFromState(newState), failedEntities)
 	if f.stateFilePath != "" {
 		if err := SaveState(f.stateFilePath, f.stateMap, f.currentConfigDigest); err != nil {
 			stateFetcherLog.Warn().Err(err).Msg("Failed to persist state to disk")
@@ -493,6 +499,10 @@ func (f *FetchAndReplicateStateProcess) processGroupState(
 	}
 	mutex.Unlock()
 
+	if replicateErr != nil {
+		stateFetcherLog.Error().Err(replicateErr).Msgf("%d image(s) failed to replicate for %s", len(failedEntities), f.stateMap[index].url)
+		result.Error = fmt.Errorf("%d image(s) failed to replicate for %s: %w", len(failedEntities), f.stateMap[index].url, replicateErr)
+	}
 	return result
 }
 
@@ -613,6 +623,25 @@ func FetchEntitiesFromState(state StateReader) []Entity {
 		}
 	}
 	return entities
+}
+
+// subtractEntities returns all entities in `all` that are not present in `failed`.
+// Used to track only successfully replicated images in the state map.
+func subtractEntities(all, failed []Entity) []Entity {
+	if len(failed) == 0 {
+		return all
+	}
+	failedKeys := make(map[string]struct{}, len(failed))
+	for _, e := range failed {
+		failedKeys[e.Name+"|"+e.Tag] = struct{}{}
+	}
+	result := make([]Entity, 0, len(all)-len(failed))
+	for _, e := range all {
+		if _, skip := failedKeys[e.Name+"|"+e.Tag]; !skip {
+			result = append(result, e)
+		}
+	}
+	return result
 }
 
 // contains takes in a slice and checks if the item is in the slice if preset it returns true else false

--- a/internal/state/state_process_test.go
+++ b/internal/state/state_process_test.go
@@ -206,6 +206,38 @@ func TestGetChanges(t *testing.T) {
 	})
 }
 
+func TestSubtractEntities(t *testing.T) {
+	t.Run("no failures returns all", func(t *testing.T) {
+		all := []Entity{
+			{Name: "img1", Tag: "v1"},
+			{Name: "img2", Tag: "v1"},
+		}
+		result := subtractEntities(all, nil)
+		require.Equal(t, all, result)
+	})
+
+	t.Run("removes failed entity", func(t *testing.T) {
+		all := []Entity{
+			{Name: "img1", Tag: "v1"},
+			{Name: "img2", Tag: "v1"},
+			{Name: "img3", Tag: "v1"},
+		}
+		failed := []Entity{{Name: "img2", Tag: "v1"}}
+		result := subtractEntities(all, failed)
+		require.Len(t, result, 2)
+		require.Equal(t, "img1", result[0].Name)
+		require.Equal(t, "img3", result[1].Name)
+	})
+
+	t.Run("all failed returns empty", func(t *testing.T) {
+		all := []Entity{
+			{Name: "img1", Tag: "v1"},
+		}
+		result := subtractEntities(all, all)
+		require.Empty(t, result)
+	})
+}
+
 func TestContains(t *testing.T) {
 	t.Run("item in slice returns true", func(t *testing.T) {
 		slice := []string{"a", "b", "c"}


### PR DESCRIPTION
Closes #434

## What this fixes

When any image in a group failed to replicate, `Replicate()` returned immediately and all subsequent images were skipped. Because `stateMap.Entities` was only updated on full success, the same images were permanently blocked on every future sync cycle.

## Changes

- `Replicate()` in `internal/state/replicator.go` now attempts every entity regardless of individual failures. Failed images are collected and returned alongside a joined error instead of aborting the batch. Per-image logic is extracted into a private `replicateOne()` method.
- `processGroupState()` in `internal/state/state_process.go` updates entity tracking even on partial failure, excluding only the images that actually failed so they are retried next cycle. A new `subtractEntities()` helper computes the succeeded set.
- Context cancellation still exits immediately without updating state.
- `DeleteReplicationEntity`, direct delivery, and the heartbeat/sync flow are unchanged.

## Tests

- Updated all existing `Replicate()` call sites to the new `([]Entity, error)` signature
- Added `TestReplicate_ContinuesAfterOneFailure`: pushes img1 and img3 to source, leaves img2 absent, verifies img1 and img3 are replicated and img2 is returned in the failed list
- Added `TestSubtractEntities` for the new helper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Replication now continues processing all entities even when individual entities fail, instead of stopping at the first failure
  * Failed entities are tracked and reported with detailed error information for better diagnostics
  * Improved handling of context cancellation during replication operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/container-registry/harbor-satellite/pull/435)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->