### PR TITLE
docs(ground-control): add ADMIN_PASSWORD to env example, compose, and quickstart

### DIFF
--- a/deploy/no-spiffe/quickstart.md
+++ b/deploy/no-spiffe/quickstart.md
@@ -9,6 +9,7 @@ For production deployments with cryptographic identity and mTLS, see the [SPIFFE
 - A Harbor registry instance with the satellite adapter installed. You can find the instance [here](https://github.com/container-registry/harbor-next/tree/satellite).
 - Credentials with permission to create robot accounts in the registry
 - [Task](https://taskfile.dev/installation/) installed.
+- [jq](https://jqlang.github.io/jq/download/) installed (used to parse JSON responses).
 - (Optional) Docker and Docker Compose. [Install Docker](https://docs.docker.com/get-docker/).
 
 ## Step 1: Configure Ground Control
@@ -46,6 +47,10 @@ Ground Control is the central service that manages satellite configurations.
    DB_DATABASE=groundcontrol
    DB_USERNAME=postgres
    DB_PASSWORD=password
+
+   # Ground Control admin (created on first run)
+   # Must be 8+ chars with uppercase, lowercase, and number
+   ADMIN_PASSWORD=Admin1234
    ```
 
    > Note: Ensure the database is running and accessible.
@@ -90,7 +95,23 @@ curl http://localhost:8080/health
 
 A `200 OK` response indicates Ground Control is healthy.
 
-## Step 4: Create a Group for Artifacts
+## Step 4: Login to Ground Control
+
+All `/api/*` endpoints require a Bearer token. Obtain one by logging in with the
+admin account you configured via `ADMIN_PASSWORD`:
+
+```bash
+AUTH_TOKEN=$(curl -s -X POST http://localhost:8080/login \
+  -H "Content-Type: application/json" \
+  -d '{"username": "admin", "password": "Admin1234"}' | jq -r '.token')
+
+echo $AUTH_TOKEN
+```
+
+> Note: Replace the password with whatever you set as `ADMIN_PASSWORD` in your `.env`.
+> The token is valid for 24 hours by default.
+
+## Step 5: Create a Group for Artifacts
 
 A group is a set of images that the satellite needs to replicate from the upstream registry. It also contains information about all the artifacts present in it.
 
@@ -117,7 +138,7 @@ curl -X POST http://localhost:8080/api/groups/sync \
 
 > Note: Replace `repository`, `tag`, and `digest` with your artifact details. Use `docker inspect` or Harbor's UI to find the digest.
 
-## Step 5: Configure the Satellite
+## Step 6: Configure the Satellite
 
 Create a config artifact for the satellite. See [config example](https://github.com/container-registry/harbor-satellite/blob/main/examples/config.json). This artifact tells the satellite where Ground Control is located and defines how and when to replicate artifacts. It also includes the local OCI-compliant registry configuration.
 
@@ -161,7 +182,7 @@ curl -i --location 'http://localhost:8080/api/configs' \
 
 > Tip: Adjust `ground_control_url` and `local_registry.url` if running on a different host or port.
 
-## Step 6: Register the Satellite
+## Step 7: Register the Satellite
 
 Register the satellite with the group and configuration created earlier. This request returns a token. Save it for the next step.
 
@@ -178,9 +199,9 @@ curl --location 'http://localhost:8080/api/satellites' \
 
 > Important: Copy the token from the response and store it securely.
 
-## Step 7: Start the Satellite
+## Step 8: Start the Satellite
 
-Use the token from Step 6 to start the satellite. See [.env.example](https://github.com/container-registry/harbor-satellite/blob/main/.env.example).
+Use the token from Step 7 to start the satellite. See [.env.example](https://github.com/container-registry/harbor-satellite/blob/main/.env.example).
 
 ### Option 1: Using Docker Compose (Recommended for End Users)
 

--- a/ground-control/.env.example
+++ b/ground-control/.env.example
@@ -19,6 +19,10 @@ DB_DATABASE=
 DB_USERNAME=
 DB_PASSWORD=
 
+# Ground Control system admin (bootstrapped on first run)
+# Must be 8+ chars with at least one uppercase, lowercase, and number
+ADMIN_PASSWORD=
+
 # TLS Configuration (optional)
 # If TLS_CERT_FILE and TLS_KEY_FILE are set, HTTPS will be enabled
 TLS_CERT_FILE=

--- a/ground-control/docker-compose.yml
+++ b/ground-control/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       HARBOR_PASSWORD: Harbor12345
       HARBOR_URL: http://harbor-sat.kube.bupd.xyz
       PORT: 8080
+      ADMIN_PASSWORD: "${ADMIN_PASSWORD:?ADMIN_PASSWORD must be set}"
       # Skip Harbor health check for local testing (set to false in production)
       SKIP_HARBOR_HEALTH_CHECK: "true"
       # SPIFFE Configuration (disabled by default)


### PR DESCRIPTION
Fixes: #437

## Description

While setting up Ground Control locally by following the [token-based ZTR quickstart](deploy/no-spiffe/quickstart.md), I ran into two blockers:

**1. First-run crash** - After `cp .env.example .env` and filling in the DB/Harbor credentials, `ground-control` exits immediately with:
```
Failed to bootstrap system admin: ADMIN_PASSWORD environment variable is required for initial setup
```
I had to trace through [`bootstrap.go:27-33`](ground-control/internal/server/bootstrap.go#L27-L33) and [`policy.go:20-29`](ground-control/internal/auth/policy.go#L20-L29) to figure out what `ADMIN_PASSWORD` needs to look like (8+ chars, uppercase, lowercase, number). The `.env.example` has no mention of it.

**2. No login step** - Once I got past the crash, the quickstart jumps from "verify health" (Step 3) straight into `curl` commands that use `${AUTH_TOKEN}` (Steps 4–6), but never shows how to get that token via `POST /login`. Every API call returns `401`.

The newer [`website/content/docs/quickstart.md`](website/content/docs/quickstart.md) already has `ADMIN_PASSWORD` and a login step, the older setup docs are just out of sync.

## Changes

### `ground-control/.env.example`
- Added `ADMIN_PASSWORD=` with a comment explaining the password policy requirements

### `ground-control/docker-compose.yml`
- Added `ADMIN_PASSWORD` to the `groundcontrol` service environment (defaults to `ChangeMe123` via `${ADMIN_PASSWORD:-ChangeMe123}`)

### `deploy/no-spiffe/quickstart.md`
- Added `ADMIN_PASSWORD=Admin1234` to the Step 1 `.env` example
- Inserted new **Step 4: Login to Ground Control** - shows how to obtain `AUTH_TOKEN` via `POST /login` before the first API call
- Renumbered subsequent steps (old 4→5, 5→6, 6→7, 7→8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added prerequisite for a JSON parser and a new step to obtain an API bearer token (curl + jq), plus renumbered tutorial steps and updated startup instructions to reference the token.
* **Chores**
  * Required an admin password for initial setup with complexity guidance in the example configuration.
  * Made orchestration configuration enforce providing the admin password at runtime.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/container-registry/harbor-satellite/pull/438?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->