### PR TITLE
docs(satellite): add missing HARBOR_REGISTRY_URL to env example, quickstart, and…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 GROUND_CONTROL_URL=***
 TOKEN=***
+# Harbor registry URL as reachable from this satellite (required)
+HARBOR_REGISTRY_URL=

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Satellite embeds a Zot registry by default. To use an external registry instead 
 
 | CLI Flag | Env Var | Description |
 |---|---|---|
+| `--harbor-registry-url` | `HARBOR_REGISTRY_URL` | Harbor registry URL as reachable from this satellite |
 | `--byo-registry` | `BYO_REGISTRY` | Enable BYO mode |
 | `--registry-url` | `REGISTRY_URL` | External registry URL (required if BYO) |
 | `--registry-username` | `REGISTRY_USERNAME` | External registry username (optional) |

--- a/deploy/no-spiffe/quickstart.md
+++ b/deploy/no-spiffe/quickstart.md
@@ -203,7 +203,7 @@ Use the token from Step 6 to start the satellite. See [.env.example](https://git
 2. Run the binary with the token:
 
    ```bash
-   ./bin --token "<your-token>" --ground-control-url "http://127.0.0.1:8080"
+   ./bin --token "<your-token>" --ground-control-url "http://127.0.0.1:8080" --harbor-registry-url "https://demo.goharbor.io"
    ```
 
 ### Option 3: Using Go
@@ -211,7 +211,7 @@ Use the token from Step 6 to start the satellite. See [.env.example](https://git
 1. Run the satellite directly:
 
    ```bash
-   go run cmd/main.go --token "<your token here>" --ground-control-url "<ground control url here>"
+   go run cmd/main.go --token "<your token here>" --ground-control-url "<ground control url here>" --harbor-registry-url "<harbor registry url here>"
    ```
 
    > Note: By default, JSON logging is enabled. To disable it, pass `--json-logging=false`.


### PR DESCRIPTION
Fixes: #439

## Description

After setting up Ground Control, creating a group, registering a satellite, and getting the bootstrap token, I ran the satellite binary exactly as shown in the quickstart Step 8:

```bash
./bin --token "<token>" --ground-control-url "http://127.0.0.1:8080"
```

It exited immediately with:

```
Missing required argument: --harbor-registry-url or HARBOR_REGISTRY_URL env var.
```

The `.env.example` only lists `GROUND_CONTROL_URL` and `TOKEN` - no mention of `HARBOR_REGISTRY_URL`. I had to trace through [`cmd/main.go:133-134`](cmd/main.go#L133-L134) to find the env var name and [`cmd/main.go:174-177`](cmd/main.go#L174-L177) to confirm it is required. The flag is already used in the root `docker-compose.yml` and `taskfiles/e2e.yml`, but none of the user-facing docs reference it.

## Changes

### `.env.example`
- Added `HARBOR_REGISTRY_URL=` with a comment clarifying it is the Harbor registry URL as reachable from the satellite's network

### `deploy/no-spiffe/quickstart.md`
- Added `--harbor-registry-url` to the binary start command (Option 2, Step 8)
- Added `--harbor-registry-url` to the `go run` command (Option 3, Step 8)

### `README.md`
- Added `--harbor-registry-url` / `HARBOR_REGISTRY_URL` row to the CLI flags table
