### PR TITLE
fix: retry direct delivery for tarballs absent from digest map

### DIFF
--- a/internal/state/direct_delivery.go
+++ b/internal/state/direct_delivery.go
@@ -86,6 +86,8 @@ func (d *DirectDeliverer) Deliver(ctx context.Context, entities []Entity) error 
 			continue
 		}
 
+		log.Info().Str("file", filename).Msg("Direct delivery: tarball not in digest map, attempting write")
+
 		srcRef := fmt.Sprintf("%s/%s/%s:%s", d.srcRegistry, entity.Repository, entity.Name, entity.Tag)
 		ref, err := name.ParseReference(srcRef, nameOpts...)
 		if err != nil {

--- a/internal/state/direct_delivery_test.go
+++ b/internal/state/direct_delivery_test.go
@@ -140,3 +140,63 @@ func TestDeliverEmptyEntitiesIsNoop(t *testing.T) {
 		t.Fatalf("Deliver([]): %v", err)
 	}
 }
+
+// TestDeliverSkipsEntityAlreadyInDigestMap verifies that an entity whose
+// filename+digest already appears in the digest map is skipped without error.
+// This is the fast path for convergence: when Deliver is called with the full
+// desired state, previously written tarballs are not re-fetched or re-written.
+func TestDeliverSkipsEntityAlreadyInDigestMap(t *testing.T) {
+	dir := t.TempDir()
+	d := &DirectDeliverer{imageDir: dir}
+
+	entity := Entity{Repository: "lib", Name: "nginx", Tag: "v1", Digest: "sha256:abc123"}
+	filename := tarballFilename(entity)
+
+	// Simulate a prior successful write: file exists and digest map records it.
+	if err := os.WriteFile(filepath.Join(dir, filename), []byte("fake tar content"), 0o644); err != nil {
+		t.Fatalf("write fake tarball: %v", err)
+	}
+	if err := d.saveDigestMap(map[string]string{filename: entity.Digest}); err != nil {
+		t.Fatalf("save digest map: %v", err)
+	}
+
+	// Deliver should succeed and skip without touching the file.
+	ctx := testContext()
+	if err := d.Deliver(ctx, []Entity{entity}); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+
+	// Digest map must still contain the original entry unchanged.
+	loaded := d.loadDigestMap()
+	if got, ok := loaded[filename]; !ok || got != entity.Digest {
+		t.Errorf("digest map entry modified: got %v, want %v", loaded, map[string]string{filename: entity.Digest})
+	}
+}
+
+// TestDeliverAttemptsEntityMissingFromDigestMap verifies that an entity absent
+// from the digest map is attempted even when the caller considers it "unchanged".
+// This is the retry path: a failed delivery from a prior cycle leaves no digest
+// map entry, so the full-state Deliver call will attempt it again.
+func TestDeliverAttemptsEntityMissingFromDigestMap(t *testing.T) {
+	dir := t.TempDir()
+	d := &DirectDeliverer{imageDir: dir}
+
+	entity := Entity{Repository: "lib", Name: "redis", Tag: "v2", Digest: "sha256:def456"}
+
+	// Digest map is empty — simulates a prior cycle where delivery failed.
+	m := d.loadDigestMap()
+	if len(m) != 0 {
+		t.Fatalf("expected empty digest map, got %v", m)
+	}
+
+	// Deliver will attempt the entity (and fail pulling from a non-existent registry),
+	// but the key assertion is that it does NOT skip: the digest map stays empty
+	// (no phantom entry written for a failed delivery).
+	ctx := testContext()
+	_ = d.Deliver(ctx, []Entity{entity}) // error expected — no real registry
+
+	loaded := d.loadDigestMap()
+	if _, ok := loaded[tarballFilename(entity)]; ok {
+		t.Errorf("digest map must not record a failed delivery")
+	}
+}

--- a/internal/state/state_process.go
+++ b/internal/state/state_process.go
@@ -473,12 +473,15 @@ func (f *FetchAndReplicateStateProcess) processGroupState(
 		return result
 	}
 
-	// Direct delivery: write tarballs to k3s/RKE2 image dir after registry push
+	// Direct delivery: write tarballs to k3s/RKE2 image dir after registry push.
+	// Pass the full desired entity list so that any tarball that failed to write
+	// in a prior cycle is retried — the digest map inside DirectDeliverer skips
+	// entries that were already written successfully.
 	if f.directDeliverer != nil {
 		if err := f.directDeliverer.Delete(ctx, deleteEntity); err != nil {
 			stateFetcherLog.Warn().Err(err).Msg("Direct delivery: failed to remove old tarballs")
 		}
-		if err := f.directDeliverer.Deliver(ctx, replicateEntity); err != nil {
+		if err := f.directDeliverer.Deliver(ctx, FetchEntitiesFromState(newState)); err != nil {
 			stateFetcherLog.Warn().Err(err).Msg("Direct delivery: failed to write tarballs")
 		}
 	}


### PR DESCRIPTION
Fixes a silent non-convergence in the direct delivery path introduced in #356.

## What's broken

`processGroupState` computes a delta  `GetChanges()` returns only entities that are new or whose digest changed. Entities already tracked in the previous cycle are "unchanged" and never enter `replicateEntity`.

The original code passed `replicateEntity` to `Deliver()`. So if a tarball write fails mid-cycle (disk full, permission denied, transient I/O), and the image digest doesn't change between cycles, that entity is permanently stuck. The registry push already succeeded, so no error surfaces anywhere. The pod on the k3s node just stays in `ImagePullBackOff` with nothing in the logs pointing to why  the registry is healthy, replication looks fine, direct delivery just quietly gave up.

## The stuck loop

```mermaid
sequenceDiagram
    participant GC as Ground Control
    participant Sat as Satellite
    participant Zot as Local Zot Registry
    participant DD as DirectDeliverer
    participant FS as k3s image dir

    Note over Sat: Cycle N  redis:v2 is new
    Sat->>GC: fetch state
    GC-->>Sat: [nginx:v1, redis:v2]
    Sat->>Zot: push redis:v2 ✓
    Sat->>DD: Deliver(replicateEntity=[redis:v2])
    DD->>FS: write redis.tar ✗ (disk full / permission denied)
    Note over DD: digest map stays empty  no entry written

    Note over Sat: Cycle N+1  redis:v2 is "unchanged"
    Sat->>GC: fetch state
    GC-->>Sat: [nginx:v1, redis:v2]
    Note over Sat: GetChanges → replicateEntity=[] (delta is zero)
    Sat->>DD: Deliver([])
    Note over FS: redis.tar still missing stuck forever
```

## Fix

Pass the full desired state instead of the delta:

```go
// before
f.directDeliverer.Deliver(ctx, replicateEntity)

// after
f.directDeliverer.Deliver(ctx, FetchEntitiesFromState(newState))
```

`DirectDeliverer.Deliver()` already skips entities whose digest is recorded in `.satellite-digests.json` — so passing the full state is safe. Previously successful tarballs are skipped with a single map lookup. Anything absent from the map, whether never attempted or previously failed, gets retried every cycle until it lands.

## How Deliver() decides skip vs retry

```mermaid
flowchart TD
    A[Deliver full desired state] --> B{for each entity}
    B --> C{filename + digest\nin digest map?}
    C -->|yes| D[skip already written ✓]
    C -->|no| E[log: not in digest map, attempting write]
    E --> F[pull image from registry]
    F --> G{pull ok?}
    G -->|no| H[warn + skip\nno map entry written]
    G -->|yes| I[write tarball atomically to temp file]
    I --> J[rename to final path]
    J --> K{rename ok?}
    K -->|no| L[warn + skip\nno map entry written]
    K -->|yes| M[record filename → digest in map]
    M --> B
    D --> B
    H --> B
    L --> B
    B -->|all entities processed| N[flush digest map updates to disk]
```

Entries missing from the map failed writes from prior cycles fall through to the write path and get retried. The new `Info` log on that branch makes this observable: grep `"not in digest map"` in production logs to see exactly which images are being re-attempted and when.

## Before vs after

```
BEFORE (broken)
──────────────────────────────────────────────────────────────────
desired state:  { nginx:v1 ✓,  redis:v2 ✗,  app:v3 ✓ }
                                    ↑ tarball write failed cycle N

cycle N+1   replicateEntity = []   ← delta is zero, redis:v2 "unchanged"
Deliver([]):   redis:v2 never seen
k3s dir:    nginx.tar             app.tar     ← redis.tar missing, stuck

cycle N+2, N+3 ...   same result no recovery path

AFTER (fixed)
──────────────────────────────────────────────────────────────────
desired state:  { nginx:v1 ✓,  redis:v2 ✗,  app:v3 ✓ }

cycle N+1   full state = [nginx:v1, redis:v2, app:v3]
Deliver(full state):
  nginx:v1  →  in digest map  →  skip ✓
  redis:v2  →  not in map     →  retry fetch + write ✓
  app:v3    →  in digest map  →  skip ✓

k3s dir:    nginx.tar  redis.tar  app.tar     ← converged ✓
```

## Changes

| File | Description |
|------|-------------|
| `internal/state/state_process.go` | Pass `FetchEntitiesFromState(newState)` instead of `replicateEntity` to `Deliver()` |
| `internal/state/direct_delivery.go` | Log at `Info` when an entity is not in the digest map so retry attempts are visible in production |
| `internal/state/direct_delivery_test.go` | Two tests covering the skip path and the retry path |

## Tests added

| Test | What it covers |
|------|----------------|
| `TestDeliverSkipsEntityAlreadyInDigestMap` | Entity in map with matching digest → skipped without network call, map entry unchanged |
| `TestDeliverAttemptsEntityMissingFromDigestMap` | Entity absent from map → attempted; a failed pull writes no phantom entry to the map |

The second test specifically guards against a regression where a failed write could silently record the entity as delivered, which would suppress all future retries.

## Test plan

- [x] `go test -v -run 'TestDeliver|TestDigest|TestTarball|TestDelete' ./internal/state/...` all 7 tests pass on Linux CI
- [x] `go test ./... -count=1` full suite passes
- [x] `task lint-report` clean