### PR TITLE
fix(ground-control): validate Harbor project existence during group sync

### DIFF
--- a/ground-control/internal/server/group_handlers.go
+++ b/ground-control/internal/server/group_handlers.go
@@ -22,6 +22,29 @@ func (s *Server) groupsSyncHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	projects := utils.GetProjectNames(&req.Artifacts)
+
+	// Validate that all projects exist in Harbor before opening a DB transaction
+	// to avoid holding DB connections open during external network calls.
+	for _, project := range projects {
+		exists, err := harbor.GetProject(r.Context(), project)
+		if err != nil {
+			log.Printf("Error checking project '%s' in Harbor: %v", project, err)
+			HandleAppError(w, &AppError{
+				Message: fmt.Sprintf("Error: failed to verify project '%s' in Harbor registry", project),
+				Code:    http.StatusBadGateway,
+			})
+			return
+		}
+		if !exists {
+			HandleAppError(w, &AppError{
+				Message: fmt.Sprintf("Error: project '%s' not found in Harbor registry", project),
+				Code:    http.StatusBadRequest,
+			})
+			return
+		}
+	}
+
 	tx, err := s.db.BeginTx(r.Context(), nil)
 	if err != nil {
 		log.Println("Could not begin transaction:", err)
@@ -46,7 +69,6 @@ func (s *Server) groupsSyncHandler(w http.ResponseWriter, r *http.Request) {
 
 	q := s.dbQueries.WithTx(tx)
 
-	projects := utils.GetProjectNames(&req.Artifacts)
 	params := database.CreateGroupParams{
 		GroupName:   req.Group,
 		RegistryUrl: os.Getenv("HARBOR_URL"),


### PR DESCRIPTION
Fixes: #442

## Description

`POST /api/groups/sync` stored group artifacts in the database without checking if the referenced Harbor projects actually exist. This caused a confusing `500` error during satellite registration, far removed from the actual problem.

This PR adds project existence validation in `groupsSyncHandler` before the database insert, using the already-available `harbor.GetProject` function. If a project is not found, the handler now returns a `400 Bad Request` immediately with a clear message naming the missing project.

## Change

```go
// Validate that all projects exist in Harbor before storing the group
for _, project := range projects {
    exists, err := harbor.GetProject(r.Context(), project)
    if err != nil {
        HandleAppError(w, &AppError{
            Message: fmt.Sprintf("Error: failed to verify project '%s' in Harbor registry", project),
            Code:    http.StatusBadGateway,
        })
        return
    }
    if !exists {
        HandleAppError(w, &AppError{
            Message: fmt.Sprintf("Error: project '%s' not found in Harbor registry", project),
            Code:    http.StatusBadRequest,
        })
        return
    }
}
```

Two error paths:
- `400 Bad Request` if the project does not exist in Harbor
- `502 Bad Gateway` if the Harbor API itself is unreachable during validation

## Testing

Tested on Harbor v2.10.0 with `goharbor/go-client` v0.210.0:

- `POST /api/groups/sync` with a non-existent project now returns `400` immediately with a clear message.
- `POST /api/groups/sync` with valid projects continues to work as before.
- Satellite registration for valid groups is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Groups now validate all associated projects exist in Harbor before creation to prevent database inconsistencies.
  * Enhanced error handling with appropriate responses for missing projects and Harbor connectivity issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/container-registry/harbor-satellite/pull/443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->