### PR TITLE
optimising ground-control satellite state reconciliation by centralis…

### DIFF
--- a/ground-control/internal/server/config_handlers.go
+++ b/ground-control/internal/server/config_handlers.go
@@ -318,35 +318,7 @@ func (s *Server) setSatelliteConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	groupList, err := q.SatelliteGroupList(r.Context(), sat.ID)
-	if err != nil {
-		log.Printf("Could not get satellite group list: %v", err)
-		err := &AppError{
-			Message: "Error: Failed to Add satellite to config",
-			Code:    http.StatusInternalServerError,
-		}
-		HandleAppError(w, err)
-		return
-	}
-
-    // TODO: Store the groupStates in memory to survive hot reloads
-	var groupStates []string
-	for _, group := range groupList {
-		grp, err := q.GetGroupByID(r.Context(), group.GroupID)
-		if err != nil {
-			log.Printf("Error: Failed: %v", err)
-			err := &AppError{
-				Message: "Error: Failed to Add satellite to config",
-				Code:    http.StatusInternalServerError,
-			}
-			HandleAppError(w, err)
-			return
-		}
-		groupStates = append(groupStates, utils.AssembleGroupState(grp.GroupName))
-	}
-
-	err = utils.CreateOrUpdateSatStateArtifact(r.Context(), sat.Name, groupStates, req.ConfigName)
-	if err != nil {
+	if err := reconcileSatelliteState(r.Context(), q, sat.ID); err != nil {
 		log.Printf("Could not update satellite state artifact: %v", err)
 		HandleAppError(w, err)
 		return

--- a/ground-control/internal/server/group_handlers.go
+++ b/ground-control/internal/server/group_handlers.go
@@ -221,38 +221,14 @@ func (s *Server) deleteGroupHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Get remaining groups for this satellite
-		groupList, err := q.SatelliteGroupList(r.Context(), satellite.SatelliteID)
+		details, err := buildSatelliteStateDetails(r.Context(), q, satellite.SatelliteID)
 		if err != nil {
-			log.Println(err)
-			err := &AppError{
-				Message: "Error: Failed to update satellite state",
-				Code:    http.StatusInternalServerError,
-			}
 			HandleAppError(w, err)
 			return
 		}
 
-		// Update projects and state artifacts
-		var projects []string
-		var groupStates []string
-		for _, g := range groupList {
-			grp, err := q.GetGroupByID(r.Context(), g.GroupID)
-			if err != nil {
-				log.Println(err)
-				err := &AppError{
-					Message: "Error: Failed to update satellite state",
-					Code:    http.StatusInternalServerError,
-				}
-				HandleAppError(w, err)
-				return
-			}
-			projects = append(projects, grp.Projects...)
-			groupStates = append(groupStates, utils.AssembleGroupState(grp.GroupName))
-		}
-
 		// Update robot permissions
-		_, err = utils.UpdateRobotProjects(r.Context(), projects, robotAcc.RobotID)
+		_, err = utils.UpdateRobotProjects(r.Context(), details.Projects, robotAcc.RobotID)
 		if err != nil {
 			log.Println(err)
 			err := &AppError{
@@ -263,32 +239,7 @@ func (s *Server) deleteGroupHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		sat, err := q.GetSatellite(r.Context(), satellite.SatelliteID)
-		if err != nil {
-			log.Println(err)
-			err := &AppError{
-				Message: "Error: Failed to update satellite state",
-				Code:    http.StatusInternalServerError,
-			}
-			HandleAppError(w, err)
-			return
-		}
-
-		configObject, err := fetchSatelliteConfig(r.Context(), q, sat.ID)
-		if err != nil {
-			log.Printf("Error: Failed to fetch Satellite config: %v", err)
-			HandleAppError(w, err)
-			return
-		}
-
-		// Update state artifact
-		err = utils.CreateOrUpdateSatStateArtifact(r.Context(), sat.Name, groupStates, configObject.ConfigName)
-		if err != nil {
-			log.Println(err)
-			err := &AppError{
-				Message: "Error: Failed to update satellite state",
-				Code:    http.StatusInternalServerError,
-			}
+		if err := reconcileSatelliteState(r.Context(), q, satellite.SatelliteID); err != nil {
 			HandleAppError(w, err)
 			return
 		}

--- a/ground-control/internal/server/helpers.go
+++ b/ground-control/internal/server/helpers.go
@@ -200,6 +200,80 @@ func getGroupStates(ctx context.Context, groups []database.SatelliteGroup, q *da
 	return states, nil
 }
 
+type satelliteStateDetails struct {
+	Satellite   database.Satellite
+	Config      database.Config
+	GroupStates []string
+	Projects    []string
+}
+
+func buildSatelliteStateDetails(ctx context.Context, q *database.Queries, satelliteID int32) (*satelliteStateDetails, error) {
+	sat, err := q.GetSatellite(ctx, satelliteID)
+	if err != nil {
+		log.Printf("failed to get satellite by ID: %v", err)
+		return nil, &AppError{
+			Message: "Error: Failed to update satellite state",
+			Code:    http.StatusInternalServerError,
+		}
+	}
+
+	groupList, err := q.SatelliteGroupList(ctx, satelliteID)
+	if err != nil {
+		log.Printf("failed to list groups for satellite %d: %v", satelliteID, err)
+		return nil, &AppError{
+			Message: "Error: Failed to update satellite state",
+			Code:    http.StatusInternalServerError,
+		}
+	}
+
+	groupStates, err := getGroupStates(ctx, groupList, q)
+	if err != nil {
+		return nil, err
+	}
+
+	var projects []string
+	for _, group := range groupList {
+		grp, err := q.GetGroupByID(ctx, group.GroupID)
+		if err != nil {
+			log.Printf("failed to get group by ID: %v, %v", group.GroupID, err)
+			return nil, &AppError{
+				Message: "Error: Failed to update satellite state",
+				Code:    http.StatusInternalServerError,
+			}
+		}
+		projects = append(projects, grp.Projects...)
+	}
+
+	configObject, err := fetchSatelliteConfig(ctx, q, satelliteID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &satelliteStateDetails{
+		Satellite:   sat,
+		Config:      configObject,
+		GroupStates: groupStates,
+		Projects:    projects,
+	}, nil
+}
+
+func reconcileSatelliteState(ctx context.Context, q *database.Queries, satelliteID int32) error {
+	details, err := buildSatelliteStateDetails(ctx, q, satelliteID)
+	if err != nil {
+		return err
+	}
+
+	if err := utils.CreateOrUpdateSatStateArtifact(ctx, details.Satellite.Name, details.GroupStates, details.Config.ConfigName); err != nil {
+		log.Printf("failed to update satellite state artifact for %s: %v", details.Satellite.Name, err)
+		return &AppError{
+			Message: "Error: Failed to update satellite state",
+			Code:    http.StatusInternalServerError,
+		}
+	}
+
+	return nil
+}
+
 func DecodeRequestBody(r *http.Request, v any) error {
 	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
 		return &AppError{

--- a/ground-control/internal/server/satellite_handlers.go
+++ b/ground-control/internal/server/satellite_handlers.go
@@ -152,7 +152,7 @@ func (s *Server) registerSatelliteHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	groupStates, err := addSatelliteToGroups(r.Context(), q, req.Groups, satellite.ID)
+	_, err = addSatelliteToGroups(r.Context(), q, req.Groups, satellite.ID)
 	if err != nil {
 		log.Println("Error adding satellite to groups:", err)
 		HandleAppError(w, err)
@@ -219,9 +219,7 @@ func (s *Server) registerSatelliteHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Create the satellite's state artifact
-	err = utils.CreateOrUpdateSatStateArtifact(r.Context(), req.Name, groupStates, req.ConfigName)
-	if err != nil {
+	if err := reconcileSatelliteState(r.Context(), q, satellite.ID); err != nil {
 		log.Println(err)
 		HandleAppError(w, err)
 		return
@@ -317,44 +315,13 @@ func (s *Server) ztrHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// groups attached to satellite
-	groups, err := q.SatelliteGroupList(r.Context(), satelliteID)
-	if err != nil {
-		log.Printf("failed to list groups for satellite: %v, %v", satelliteID, err)
-		log.Println(err)
-		err := &AppError{
-			Message: "Error: Satellite Groups List Failed",
-			Code:    http.StatusInternalServerError,
-		}
-		HandleAppError(w, err)
-		return
-	}
-
-	states, err := getGroupStates(r.Context(), groups, q)
-	if err != nil {
-		log.Println("Error retrieving group states:", err)
-		HandleAppError(w, &AppError{
-			Message: "Error: Get Group By ID Failed",
-			Code:    http.StatusInternalServerError,
-		})
-		return
-	}
-
 	satellite, err := q.GetSatellite(r.Context(), satelliteID)
 	if err != nil {
 		HandleAppError(w, &AppError{Message: "satellite not found", Code: http.StatusNotFound})
 		return
 	}
 
-	configObject, err := fetchSatelliteConfig(r.Context(), s.dbQueries, satelliteID)
-	if err != nil {
-		log.Printf("Error: Failed to fetch Satellite config: %v", err)
-		HandleAppError(w, err)
-		return
-	}
-
-	// For sanity, create (update) the state artifact during the registration process as well.
-	err = utils.CreateOrUpdateSatStateArtifact(r.Context(), satellite.Name, states, configObject.ConfigName)
-	if err != nil {
+	if err := reconcileSatelliteState(r.Context(), q, satelliteID); err != nil {
 		log.Println(err)
 		HandleAppError(w, err)
 		return
@@ -481,40 +448,12 @@ func (s *Server) spiffeZtrHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	groups, err := q.SatelliteGroupList(r.Context(), satellite.ID)
-	if err != nil {
-		log.Printf("SPIFFE ZTR: Failed to list groups for satellite %s: %v", satelliteName, err)
-		HandleAppError(w, &AppError{
-			Message: "Error: Satellite Groups List Failed",
-			Code:    http.StatusInternalServerError,
-		})
-		return
-	}
-
-	states, err := getGroupStates(r.Context(), groups, q)
-	if err != nil {
-		log.Printf("SPIFFE ZTR: Error retrieving group states: %v", err)
-		HandleAppError(w, &AppError{
-			Message: "Error: Get Group By ID Failed",
-			Code:    http.StatusInternalServerError,
-		})
-		return
-	}
-
 	// When Harbor is available, create state artifacts; otherwise just return credentials
 	skipHarborCheck := os.Getenv("SKIP_HARBOR_HEALTH_CHECK") == "true"
 	var satelliteState string
 
 	if !skipHarborCheck {
-		configObject, err := fetchSatelliteConfig(r.Context(), s.dbQueries, satellite.ID)
-		if err != nil {
-			log.Printf("SPIFFE ZTR: Failed to fetch satellite config: %v", err)
-			HandleAppError(w, err)
-			return
-		}
-
-		err = utils.CreateOrUpdateSatStateArtifact(r.Context(), satellite.Name, states, configObject.ConfigName)
-		if err != nil {
+		if err := reconcileSatelliteState(r.Context(), q, satellite.ID); err != nil {
 			log.Printf("SPIFFE ZTR: Failed to create state artifact: %v", err)
 			HandleAppError(w, err)
 			return
@@ -1137,38 +1076,8 @@ func (s *Server) addSatelliteToGroup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get updated group list after adding the new group
-	groupList, err := q.SatelliteGroupList(r.Context(), sat.ID)
+	details, err := buildSatelliteStateDetails(r.Context(), q, sat.ID)
 	if err != nil {
-		log.Printf("Error: Failed to get updated satellite group list: %v", err)
-		err := &AppError{
-			Message: "Error: Failed to get updated satellite group list",
-			Code:    http.StatusInternalServerError,
-		}
-		HandleAppError(w, err)
-		return
-	}
-
-	var projects []string
-	var groupStates []string
-
-	for _, group := range groupList {
-		grp, err := s.dbQueries.GetGroupByID(r.Context(), group.GroupID)
-		if err != nil {
-			log.Printf("Error: Failed to get group by ID %d: %v", group.GroupID, err)
-			err := &AppError{
-				Message: "Error: Failed to get group details",
-				Code:    http.StatusInternalServerError,
-			}
-			HandleAppError(w, err)
-			return
-		}
-		projects = append(projects, grp.Projects...)
-		groupStates = append(groupStates, utils.AssembleGroupState(grp.GroupName))
-	}
-
-	configObject, err := fetchSatelliteConfig(r.Context(), s.dbQueries, sat.ID)
-	if err != nil {
-		log.Printf("Error: Failed to fetch Satellite config: %v", err)
 		HandleAppError(w, err)
 		return
 	}
@@ -1186,7 +1095,7 @@ func (s *Server) addSatelliteToGroup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Update robot account permissions
-	_, err = utils.UpdateRobotProjects(r.Context(), projects, robotAcc.RobotID)
+	_, err = utils.UpdateRobotProjects(r.Context(), details.Projects, robotAcc.RobotID)
 	if err != nil {
 		log.Printf("Error: Failed to update robot account permissions: %v", err)
 		err := &AppError{
@@ -1197,9 +1106,7 @@ func (s *Server) addSatelliteToGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Update the state artifact to also track the new group state artifact
-	err = utils.CreateOrUpdateSatStateArtifact(r.Context(), sat.Name, groupStates, configObject.ConfigName)
-	if err != nil {
+	if err := reconcileSatelliteState(r.Context(), q, sat.ID); err != nil {
 		log.Printf("Error: Failed to update satellite state artifact: %v", err)
 		HandleAppError(w, err)
 		return
@@ -1300,39 +1207,16 @@ func (s *Server) removeSatelliteFromGroup(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	groupList, err := q.SatelliteGroupList(r.Context(), sat.ID)
+	details, err := buildSatelliteStateDetails(r.Context(), q, sat.ID)
 	if err != nil {
-		log.Printf("Error: Failed: %v", err)
-		err := &AppError{
-			Message: "Error: Failed to refresh satellite group list",
-			Code:    http.StatusInternalServerError,
-		}
 		HandleAppError(w, err)
 		return
-	}
-
-	var projects []string
-	var groupStates []string
-
-	for _, group := range groupList {
-		grp, err := q.GetGroupByID(r.Context(), group.GroupID)
-		if err != nil {
-			log.Printf("Error: Failed: %v", err)
-			err := &AppError{
-				Message: "Error: Failed to to refresh satellite group list",
-				Code:    http.StatusInternalServerError,
-			}
-			HandleAppError(w, err)
-			return
-		}
-		projects = append(projects, grp.Projects...)
-		groupStates = append(groupStates, utils.AssembleGroupState(grp.GroupName))
 	}
 
 	// 1. We need the list of state artifacts for the groups that satellite belongs to
 	// 2. Update the satellite state artifact accordingly
 
-	_, err = utils.UpdateRobotProjects(r.Context(), projects, robotAcc.RobotID)
+	_, err = utils.UpdateRobotProjects(r.Context(), details.Projects, robotAcc.RobotID)
 	if err != nil {
 		log.Printf("Error: Failed to Add permission to robot account: %v", err)
 		err := &AppError{
@@ -1343,16 +1227,7 @@ func (s *Server) removeSatelliteFromGroup(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	configObject, err := fetchSatelliteConfig(r.Context(), q, sat.ID)
-	if err != nil {
-		log.Printf("Error: Failed to fetch Satellite config: %v", err)
-		HandleAppError(w, err)
-		return
-	}
-
-	// Update the state artifact to also track the new group state artifact
-	err = utils.CreateOrUpdateSatStateArtifact(r.Context(), sat.Name, groupStates, configObject.ConfigName)
-	if err != nil {
+	if err := reconcileSatelliteState(r.Context(), q, sat.ID); err != nil {
 		log.Println(err)
 		HandleAppError(w, err)
 		return


### PR DESCRIPTION
- Fixes: #447 

## Description

Centralizes Ground Control satellite state reconciliation by moving repeated state rebuild/publish logic into a shared helper.

## Changes

- added a shared satellite state reconciliation path
- replaced duplicated inline state reconstruction in config, group, and satellite handlers
- kept existing API and behavior unchanged.

## Testing

- `go test ./internal/server/...`

## Additional context
- refer issue #447 , proposed solution is described over there only.
<!-- Add any other context about the PR here. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved satellite management by consolidating state-handling procedures across configuration updates, satellite registration, group associations, and maintenance operations. This centralization eliminates code duplication, ensures consistent state management practices throughout the system, and enhances overall code maintainability without changing any user-visible features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/container-registry/harbor-satellite/pull/449?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->