### PR TITLE
feat: add health and readiness endpoints to satellite server 

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -57,6 +57,7 @@ type SatelliteOptions struct {
 	HarborRegistryURL      string
 	DirectDelivery         bool
 	ImageDir               string
+	HealthPort             int
 }
 
 func main() {
@@ -83,6 +84,7 @@ func main() {
 	flag.StringVar(&opts.HarborRegistryURL, "harbor-registry-url", "", "Override Harbor registry URL from Ground Control (e.g., http://10.0.0.1:8080)")
 	flag.BoolVar(&opts.DirectDelivery, "direct-delivery", false, "[Experimental] Write image tarballs directly to k3s/RKE2 agent images directory")
 	flag.StringVar(&opts.ImageDir, "image-dir", "", "Override image directory for direct delivery (auto-detected if empty)")
+	flag.IntVar(&opts.HealthPort, "health-port", 9090, "Port for health and readiness HTTP server")
 
 	flag.Parse()
 
@@ -339,10 +341,14 @@ func run(opts SatelliteOptions, pathConfig *config.PathConfig, shutdownTimeout s
 	s := satellite.NewSatellite(cm, criResults, pathConfig.StateFile)
 	err = s.Run(ctx)
 
+	healthPort := opts.HealthPort
+	if healthPort == 0 {
+		healthPort = 9090
+	}
 	router := server.NewDefaultRouter("")
 	gcURL := cm.ResolveGroundControlURL()
 	headless := gcURL == ""
-	healthApp := server.NewApp(router, ctx, log, server.NewHealthRegistrar(
+	healthApp := server.NewApp(router, ctx, log, healthPort, server.NewHealthRegistrar(
 		"http://"+localRegistryEndpoint,
 		gcURL,
 		headless,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/container-registry/harbor-satellite/internal/logger"
 	"github.com/container-registry/harbor-satellite/internal/registry"
 	"github.com/container-registry/harbor-satellite/internal/satellite"
+	"github.com/container-registry/harbor-satellite/internal/server"
 	"github.com/container-registry/harbor-satellite/internal/utils"
 	"github.com/container-registry/harbor-satellite/internal/watcher"
 	"github.com/container-registry/harbor-satellite/pkg/config"
@@ -337,6 +338,19 @@ func run(opts SatelliteOptions, pathConfig *config.PathConfig, shutdownTimeout s
 
 	s := satellite.NewSatellite(cm, criResults, pathConfig.StateFile)
 	err = s.Run(ctx)
+
+	router := server.NewDefaultRouter("")
+	gcURL := cm.ResolveGroundControlURL()
+	headless := gcURL == ""
+	healthApp := server.NewApp(router, ctx, log, server.NewHealthRegistrar(
+		"http://"+localRegistryEndpoint,
+		gcURL,
+		headless,
+		s.SyncDone(),
+	))
+	healthApp.SetupRoutes()
+	healthApp.SetupServer(wg)
+
 	if err != nil {
 		return fmt.Errorf("unable to start satellite: %w", err)
 	}

--- a/internal/satellite/satellite.go
+++ b/internal/satellite/satellite.go
@@ -2,6 +2,7 @@ package satellite
 
 import (
 	"context"
+	"sync/atomic"
 
 	runtime "github.com/container-registry/harbor-satellite/internal/container_runtime"
 	"github.com/container-registry/harbor-satellite/internal/logger"
@@ -15,6 +16,7 @@ type Satellite struct {
 	criResults    []runtime.CRIConfigResult
 	schedulers    []*scheduler.Scheduler
 	stateFilePath string
+	syncDone      atomic.Bool
 }
 
 func NewSatellite(cm *config.ConfigManager, criResults []runtime.CRIConfigResult, stateFilePath string) *Satellite {
@@ -66,6 +68,10 @@ func (s *Satellite) Run(ctx context.Context) error {
 		s.schedulers = append(s.schedulers, ztrScheduler)
 		ztrScheduler.Start(ctx)
 	}
+
+	fetchAndReplicateStateProcess.SetOnFirstSync(func() {
+		s.syncDone.Store(true)
+	})
 
 	// Create state replication scheduler
 	stateScheduler, err := scheduler.NewSchedulerWithInterval(
@@ -127,4 +133,8 @@ func (s *Satellite) Stop(ctx context.Context) {
 	} else {
 		log.Info().Msg("All schedulers stopped")
 	}
+}
+
+func (s *Satellite) SyncDone() *atomic.Bool {
+	return &s.syncDone
 }

--- a/internal/server/health.go
+++ b/internal/server/health.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync/atomic"
+)
+
+type HealthRegistrar struct {
+	registryURL string
+	gcURL       string
+	headless    bool
+	syncDone    *atomic.Bool
+}
+
+func NewHealthRegistrar(registryURL, gcURL string, headless bool, syncDone *atomic.Bool) *HealthRegistrar {
+	return &HealthRegistrar{
+		registryURL: registryURL,
+		gcURL:       gcURL,
+		headless:    headless,
+		syncDone:    syncDone,
+	}
+}
+
+func (h *HealthRegistrar) RegisterRoutes(r Router) {
+	r.HandleFunc("GET /health", h.handleHealth)
+	r.HandleFunc("GET /ready", h.handleReady)
+}
+
+func (h *HealthRegistrar) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (h *HealthRegistrar) handleReady(w http.ResponseWriter, _ *http.Request) {
+	checks := map[string]string{}
+	allOK := true
+
+	resp, err := http.Get(h.registryURL + "/v2/")
+	if err != nil || (resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusUnauthorized) {
+		checks["registry"] = "unavailable"
+		allOK = false
+	} else {
+		checks["registry"] = "ok"
+	}
+
+	if h.headless {
+		checks["ground_control"] = "skipped"
+	} else {
+		resp, err := http.Get(h.gcURL + "/ping")
+		if err != nil || resp.StatusCode != http.StatusOK {
+			checks["ground_control"] = "unavailable"
+			allOK = false
+		} else {
+			checks["ground_control"] = "ok"
+		}
+	}
+
+	if h.syncDone.Load() {
+		checks["state_sync"] = "ok"
+	} else {
+		checks["state_sync"] = "pending"
+		allOK = false
+	}
+
+	status, code := "ready", http.StatusOK
+	if !allOK {
+		status, code = "not ready", http.StatusServiceUnavailable
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(map[string]any{"status": status, "checks": checks})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,13 +24,13 @@ type App struct {
 	Logger     *zerolog.Logger
 }
 
-func NewApp(router Router, ctx context.Context, logger *zerolog.Logger, registrars ...RouteRegistrar) *App {
+func NewApp(router Router, ctx context.Context, logger *zerolog.Logger, port int, registrars ...RouteRegistrar) *App {
 	return &App{
 		router:     router,
 		registrars: registrars,
 		ctx:        ctx,
 		Logger:     logger,
-		server:     &http.Server{Addr: ":9090", Handler: router, ReadHeaderTimeout: 10 * time.Second},
+		server:     &http.Server{Addr: fmt.Sprintf(":%d", port), Handler: router, ReadHeaderTimeout: 10 * time.Second},
 	}
 }
 
@@ -53,7 +53,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 
 func (a *App) SetupServer(g *errgroup.Group) {
 	g.Go(func() error {
-		a.Logger.Info().Msg("Starting server on :9090")
+		a.Logger.Info().Str("addr", a.server.Addr).Msg("Starting health server")
 		if err := a.Start(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			return err
 		}

--- a/internal/state/state_process.go
+++ b/internal/state/state_process.go
@@ -21,6 +21,7 @@ type FetchAndReplicateStateProcess struct {
 	mu                  sync.Mutex
 	stateFilePath       string
 	directDeliverer     *DirectDeliverer
+	onFirstSync         func()
 }
 
 // Define result types for channels
@@ -60,6 +61,11 @@ func NewFetchAndReplicateStateProcess(cm *config.ConfigManager, stateFilePath st
 	}
 
 	return p
+}
+
+// setter method
+func (f *FetchAndReplicateStateProcess) SetOnFirstSync(fn func()) {
+	f.onFirstSync = fn
 }
 
 type StateMap struct {
@@ -143,7 +149,13 @@ func (f *FetchAndReplicateStateProcess) Execute(ctx context.Context) error {
 		configFetcherResult <- result
 	}()
 
-	return f.collectResults(ctx, stateFetcherResults, configFetcherResult, len(f.stateMap), &log)
+	// return f.collectResults(ctx, stateFetcherResults, configFetcherResult, len(f.stateMap), &log)
+	err = f.collectResults(ctx, stateFetcherResults, configFetcherResult, len(f.stateMap), &log)
+	if err == nil && f.onFirstSync != nil {
+		f.onFirstSync()
+		f.onFirstSync = nil
+	}
+	return err
 }
 
 func (f *FetchAndReplicateStateProcess) updateStateMap(states []string) bool {


### PR DESCRIPTION
- Fixes: #
Closes #240 
## Description
Wires up the existing (but unused) `internal/server` scaffolding and adds `/health` and `/ready` HTTP endpoints. Port is configurable via a CLI flag (-health-port), defaulting to 9090.

## Additional context
Prevents Kubernetes from scheduling pods before satellite has proxied images, avoiding `ImagePullBackOff` errors.
<!-- Add any other context about the PR here. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `--health-port` CLI option to configure the health check server port (defaults to 9090).
  * Added `/health` endpoint returning operational status.
  * Added `/ready` endpoint performing readiness checks on registry connectivity, ground control availability, and state synchronization status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/container-registry/harbor-satellite/pull/452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->