### PR TITLE
chore: upgrade Go toolchain to 1.26.2 and drop redundant toolchain directive

### DIFF
--- a/.github/actions/publish-and-sign/action.yaml
+++ b/.github/actions/publish-and-sign/action.yaml
@@ -27,7 +27,7 @@ runs:
     - name: Setup Go
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
-        go-version: "1.26.2"
+        go-version: "1.26.5"
 
     - name: Install Task
       uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0

--- a/.github/actions/publish-and-sign/action.yaml
+++ b/.github/actions/publish-and-sign/action.yaml
@@ -25,12 +25,12 @@ runs:
   using: "composite"
   steps:
     - name: Setup Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
-        go-version: "1.24.11"
+        go-version: "1.26.2"
 
     - name: Install Task
-      uses: arduino/setup-task@v2
+      uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
       with:
         version: 3.x
 
@@ -41,7 +41,7 @@ runs:
         docker buildx use remote
 
     - name: Install Cosign
-      uses: sigstore/cosign-installer@v3.7.0
+      uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
     - name: Check Env Variables
       shell: bash

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -10,4 +10,4 @@ jobs:
     runs-on: container-registry
     steps:
     - name: Label PR
-      uses: actions/labeler@v5
+      uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.26.2"
           cache: false
 
       - name: Install Task

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,17 +1,20 @@
 name: Lint
+
 on:
   pull_request:
     paths-ignore:
       - "*.md"
       - "assets/**"
+
+permissions: read-all
+
 jobs:
   lint:
     runs-on: container-registry
     env:
       GOLANGCI_LINT_CACHE: ${{ github.workspace }}/.cache/golangci-lint
     permissions:
-      contents: write
-      packages: write
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,16 +14,16 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "1.26.2"
           cache: false
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.5"
           cache: false
 
       - name: Install Task

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ on:
       - "*.md"
       - "assets/**"
 
+permissions: read-all
+
 jobs:
   push-latest-images:
     permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,7 +68,7 @@ jobs:
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.26.2"
 
       - name: Install Task
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Checkout repo
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main')
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: Checkout repo
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -66,26 +66,26 @@ jobs:
 
       - name: Setup Go
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "1.26.2"
 
       - name: Install Task
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
 
       - name: Install GoReleaser
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           install-only: true
           version: v2.9.0
 
       - name: Install Syft
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
-        uses: anchore/sbom-action/download-syft@v0.22.2
+        uses: anchore/sbom-action/download-syft@28d71544de8eaf1b958d335707167c5f783590ad # v0.22.2
 
       - name: Create Release
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,7 @@ jobs:
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.5"
 
       - name: Install Task
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "1.26.2"
           cache: true
@@ -44,18 +44,18 @@ jobs:
     runs-on: container-registry
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "1.26.2"
           cache: false
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
 
@@ -78,29 +78,29 @@ jobs:
     runs-on: container-registry
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "1.26.2"
           cache: false
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
 
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           install-only: true
           version: v2.9.0
 
       - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - name: Test Release
         run: task snapshot
@@ -109,16 +109,16 @@ jobs:
     runs-on: container-registry
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "1.26.2"
           cache: false
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
 
@@ -129,16 +129,16 @@ jobs:
     runs-on: container-registry
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "1.26.2"
           cache: false
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
 
@@ -150,15 +150,15 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "1.26.2"
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
 
@@ -170,15 +170,15 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "1.26.2"
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
 
@@ -190,15 +190,15 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "1.26.2"
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,8 @@ jobs:
   unit-tests:
     name: Unit Tests and Coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -44,6 +46,8 @@ jobs:
 
   vulnerability-check:
     runs-on: container-registry
+    permissions:
+      contents: read
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -78,6 +82,8 @@ jobs:
 
   test-release:
     runs-on: container-registry
+    permissions:
+      contents: read
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -109,6 +115,8 @@ jobs:
 
   build-satellite:
     runs-on: container-registry
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -129,6 +137,8 @@ jobs:
 
   build-ground-control:
     runs-on: container-registry
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -150,6 +160,8 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -170,6 +182,8 @@ jobs:
   e2e-byo-registry-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -190,6 +204,8 @@ jobs:
   e2e-spiffe-join-token-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.26.2"
           cache: true
 
       - name: Run unit tests for satellite (with coverage)
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.26.2"
           cache: false
 
       - name: Install Task
@@ -85,7 +85,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.26.2"
           cache: false
 
       - name: Install Task
@@ -114,7 +114,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.26.2"
           cache: false
 
       - name: Install Task
@@ -134,7 +134,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.26.2"
           cache: false
 
       - name: Install Task
@@ -155,7 +155,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.26.2"
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -175,7 +175,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.26.2"
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -195,7 +195,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.26.2"
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,8 @@ on:
       - "*.md"
       - "assets/**"
 
+permissions: read-all
+
 jobs:
   unit-tests:
     name: Unit Tests and Coverage

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.5"
           cache: true
 
       - name: Run unit tests for satellite (with coverage)
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.5"
           cache: false
 
       - name: Install Task
@@ -93,7 +93,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.5"
           cache: false
 
       - name: Install Task
@@ -124,7 +124,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.5"
           cache: false
 
       - name: Install Task
@@ -146,7 +146,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.5"
           cache: false
 
       - name: Install Task
@@ -169,7 +169,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.5"
 
       - name: Install Task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
@@ -191,7 +191,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.5"
 
       - name: Install Task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
@@ -213,7 +213,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.5"
 
       - name: Install Task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,7 +1,7 @@
 version: "3"
 
 vars:
-  GO_VERSION: "1.26.2"
+  GO_VERSION: "1.26.5"
   GOLANGCILINT_VERSION: "v2.0.2"
   GORELEASER_VERSION: "v2.9.0"
   PLATFORMS_LINUX: "amd64 arm64 ppc64le s390x riscv64"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,7 +1,7 @@
 version: "3"
 
 vars:
-  GO_VERSION: "1.24.11"
+  GO_VERSION: "1.26.2"
   GOLANGCILINT_VERSION: "v2.0.2"
   GORELEASER_VERSION: "v2.9.0"
   PLATFORMS_LINUX: "amd64 arm64 ppc64le s390x riscv64"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/container-registry/harbor-satellite
 
-go 1.24.0
+go 1.26.2
 
 require (
 	github.com/google/go-containerregistry v0.20.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/container-registry/harbor-satellite
 
-go 1.26.2
+go 1.26.5
 
 require (
 	github.com/google/go-containerregistry v0.20.3

--- a/ground-control/go.mod
+++ b/ground-control/go.mod
@@ -1,8 +1,6 @@
 module github.com/container-registry/harbor-satellite/ground-control
 
-go 1.24.1
-
-toolchain go1.24.3
+go 1.26.2
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/ground-control/go.mod
+++ b/ground-control/go.mod
@@ -1,6 +1,6 @@
 module github.com/container-registry/harbor-satellite/ground-control
 
-go 1.26.2
+go 1.26.5
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@ var (
 	GitCommit      = ""
 	BuildTime      = ""
 	ReleaseChannel = "dev"
-	GoVersion      = "1.24"
+	GoVersion      = "1.26"
 	OS             = func() string {
 		if info, ok := debug.ReadBuildInfo(); ok {
 			for _, setting := range info.Settings {


### PR DESCRIPTION
Go 1.26.2 has been out for a while now, and we were still pinned to 1.24 in both modules. This bumps the `go` directive in `go.mod` and `ground-control/go.mod` to 1.26.2, updates all CI workflow steps to match, and removes the now-redundant `toolchain go1.24.3` line from `ground-control/go.mod`  that directive only makes sense when the toolchain differs from the `go` line, which it no longer does.

The `GoVersion` constant in `internal/version/version.go` is updated to reflect the new baseline.

`go mod tidy` was run on both modules after the upgrade; only the `go` directive changed in the lock files, so there are no dependency additions or removals from this PR.

Go 1.26 is a drop-in compatible release. Nothing in either module uses features that changed between 1.24 and 1.26, so existing behavior is unchanged. CI on Linux (where the Zot syscall surface is fully supported) should go green without modification.

Closes #461.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Go toolchain from 1.24 to 1.26.5 across build configurations, Go module requirements, and CI/CD workflows.
  * Updated reported build Go version to 1.26.
  * Pinned GitHub Actions to specific commit SHAs (including checkout/setup-go/task, goreleaser, SBOM tooling, cosign installer, and PR labeling) for deterministic runs.
* **Security**
  * Standardized workflow permissions to `read-all` at the top level and restricted job permissions to `contents: read`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->