### PR TITLE
feat: add health and readiness endpoints to satellite

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	runtime "github.com/container-registry/harbor-satellite/internal/container_runtime"
@@ -376,6 +377,14 @@ func run(opts SatelliteOptions, pathConfig *config.PathConfig, shutdownTimeout s
 			return fmt.Errorf("create SPIFFE client for health checks: %w", scErr)
 		}
 		defer func() { _ = sc.Close() }()
+		// The http.Client is built once and reused across probes so connections
+		// can keep-alive between calls. The *tls.Config returned by
+		// sc.GetTLSConfig is bound to the X509Source, so SVID rotation keeps
+		// working transparently with the cached Transport.
+		var (
+			cachedClientMu sync.Mutex
+			cachedClient   *http.Client
+		)
 		gcClient = func(ctx context.Context) (*http.Client, error) {
 			// workloadapi.NewX509Source (called by Connect) blocks until it
 			// receives the first SVID. If SPIRE is unreachable, only the
@@ -386,14 +395,22 @@ func run(opts SatelliteOptions, pathConfig *config.PathConfig, shutdownTimeout s
 			if err := sc.Connect(cctx); err != nil {
 				return nil, err
 			}
+
+			cachedClientMu.Lock()
+			defer cachedClientMu.Unlock()
+			if cachedClient != nil {
+				return cachedClient, nil
+			}
+
 			tlsCfg, err := sc.GetTLSConfig()
 			if err != nil {
 				return nil, err
 			}
-			return &http.Client{
+			cachedClient = &http.Client{
 				Timeout:   2 * time.Second,
 				Transport: &http.Transport{TLSClientConfig: tlsCfg},
-			}, nil
+			}
+			return cachedClient, nil
 		}
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/container-registry/harbor-satellite/internal/logger"
 	"github.com/container-registry/harbor-satellite/internal/registry"
 	"github.com/container-registry/harbor-satellite/internal/satellite"
+	"github.com/container-registry/harbor-satellite/internal/server"
 	"github.com/container-registry/harbor-satellite/internal/utils"
 	"github.com/container-registry/harbor-satellite/internal/watcher"
 	"github.com/container-registry/harbor-satellite/pkg/config"
@@ -334,6 +335,23 @@ func run(opts SatelliteOptions, pathConfig *config.PathConfig, shutdownTimeout s
 			}
 		}
 	})
+
+	observabilityPort := os.Getenv("OBSERVABILITY_PORT")
+	if observabilityPort == "" {
+		observabilityPort = "9090"
+	}
+
+	// Start observability server.
+	observabilityServer := server.NewApp(
+		server.NewDefaultRouter(""),
+		ctx,
+		log,
+		":"+observabilityPort,
+		&server.DebugRegistrar{},
+		&server.MetricsRegistrar{},
+		&server.HealthRegistrar{},
+	)
+	observabilityServer.SetupServer(wg)
 
 	s := satellite.NewSatellite(cm, criResults, pathConfig.StateFile)
 	err = s.Run(ctx)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -57,6 +57,7 @@ type SatelliteOptions struct {
 	HarborRegistryURL      string
 	DirectDelivery         bool
 	ImageDir               string
+	Headless               bool
 }
 
 func main() {
@@ -83,6 +84,7 @@ func main() {
 	flag.StringVar(&opts.HarborRegistryURL, "harbor-registry-url", "", "Override Harbor registry URL from Ground Control (e.g., http://10.0.0.1:8080)")
 	flag.BoolVar(&opts.DirectDelivery, "direct-delivery", false, "[Experimental] Write image tarballs directly to k3s/RKE2 agent images directory")
 	flag.StringVar(&opts.ImageDir, "image-dir", "", "Override image directory for direct delivery (auto-detected if empty)")
+	flag.BoolVar(&opts.Headless, "headless", false, "Run without Ground Control; skips the Ground Control reachability check in the /ready probe")
 
 	flag.Parse()
 
@@ -139,6 +141,9 @@ func main() {
 	}
 	if opts.ImageDir == "" {
 		opts.ImageDir = os.Getenv("IMAGE_DIR")
+	}
+	if !opts.Headless && os.Getenv("HEADLESS") == "true" {
+		opts.Headless = true
 	}
 
 	// Resolve config directory path
@@ -338,8 +343,18 @@ func run(opts SatelliteOptions, pathConfig *config.PathConfig, shutdownTimeout s
 
 	observabilityPort := os.Getenv("OBSERVABILITY_PORT")
 	if observabilityPort == "" {
-		observabilityPort = "9090"
+		observabilityPort = "9091"
 	}
+
+	registryScheme := "https"
+	if cm.UseUnsecure() {
+		registryScheme = "http"
+	}
+	healthRegistrar := server.NewHealthRegistrar(
+		fmt.Sprintf("%s://%s", registryScheme, localRegistryEndpoint),
+		cm.ResolveGroundControlURL(),
+		opts.Headless,
+	)
 
 	// Start observability server.
 	observabilityServer := server.NewApp(
@@ -349,11 +364,11 @@ func run(opts SatelliteOptions, pathConfig *config.PathConfig, shutdownTimeout s
 		":"+observabilityPort,
 		&server.DebugRegistrar{},
 		&server.MetricsRegistrar{},
-		&server.HealthRegistrar{},
+		healthRegistrar,
 	)
 	observabilityServer.SetupServer(wg)
 
-	s := satellite.NewSatellite(cm, criResults, pathConfig.StateFile)
+	s := satellite.NewSatellite(cm, criResults, pathConfig.StateFile, healthRegistrar.MarkStateSynced)
 	err = s.Run(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to start satellite: %w", err)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"time"
 
@@ -14,6 +15,8 @@ import (
 	"github.com/container-registry/harbor-satellite/internal/registry"
 	"github.com/container-registry/harbor-satellite/internal/satellite"
 	"github.com/container-registry/harbor-satellite/internal/server"
+	"github.com/container-registry/harbor-satellite/internal/spiffe"
+	"github.com/container-registry/harbor-satellite/internal/state"
 	"github.com/container-registry/harbor-satellite/internal/utils"
 	"github.com/container-registry/harbor-satellite/internal/watcher"
 	"github.com/container-registry/harbor-satellite/pkg/config"
@@ -350,10 +353,47 @@ func run(opts SatelliteOptions, pathConfig *config.PathConfig, shutdownTimeout s
 	if cm.UseUnsecure() {
 		registryScheme = "http"
 	}
+	healthClient, err := state.CreateHTTPClient(cm.GetTLSConfig(), cm.UseUnsecure(), 2*time.Second)
+	if err != nil {
+		return fmt.Errorf("build health check HTTP client: %w", err)
+	}
+
+	// In SPIFFE mode the satellite reaches Ground Control via SPIFFE mTLS, so the
+	// readiness GC check must use the same path. Build the client lazily per probe
+	// (Connect is idempotent and the X509Source is reused) so an unreachable SPIRE
+	var gcClient func(context.Context) (*http.Client, error)
+	if cm.IsSPIFFEEnabled() {
+		spiffeCfg := cm.GetSPIFFEConfig()
+		sc, scErr := spiffe.NewClient(spiffe.Config{
+			Enabled:          spiffeCfg.Enabled,
+			EndpointSocket:   spiffeCfg.EndpointSocket,
+			ExpectedServerID: spiffeCfg.ExpectedServerID,
+		})
+		if scErr != nil {
+			return fmt.Errorf("create SPIFFE client for health checks: %w", scErr)
+		}
+		defer func() { _ = sc.Close() }()
+		gcClient = func(ctx context.Context) (*http.Client, error) {
+			if err := sc.Connect(ctx); err != nil {
+				return nil, err
+			}
+			tlsCfg, err := sc.GetTLSConfig()
+			if err != nil {
+				return nil, err
+			}
+			return &http.Client{
+				Timeout:   2 * time.Second,
+				Transport: &http.Transport{TLSClientConfig: tlsCfg},
+			}, nil
+		}
+	}
+
 	healthRegistrar := server.NewHealthRegistrar(
 		fmt.Sprintf("%s://%s", registryScheme, localRegistryEndpoint),
 		cm.ResolveGroundControlURL(),
 		opts.Headless,
+		healthClient,
+		gcClient,
 	)
 
 	// Start observability server.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,10 +3,14 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	runtime "github.com/container-registry/harbor-satellite/internal/container_runtime"
@@ -349,9 +353,8 @@ func run(opts SatelliteOptions, pathConfig *config.PathConfig, shutdownTimeout s
 		observabilityPort = "9091"
 	}
 
-	registryScheme := "https"
-	if cm.UseUnsecure() {
-		registryScheme = "http"
+	registryURLProvider := func() (string, error) {
+		return resolveRegistryURLForHealth(cm)
 	}
 	healthClient, err := state.CreateHTTPClient(cm.GetTLSConfig(), cm.UseUnsecure(), 2*time.Second)
 	if err != nil {
@@ -395,7 +398,7 @@ func run(opts SatelliteOptions, pathConfig *config.PathConfig, shutdownTimeout s
 	}
 
 	healthRegistrar := server.NewHealthRegistrar(
-		fmt.Sprintf("%s://%s", registryScheme, localRegistryEndpoint),
+		registryURLProvider,
 		cm.ResolveGroundControlURL(),
 		opts.Headless,
 		healthClient,
@@ -528,6 +531,104 @@ func resolveLocalRegistryEndpoint(cm *config.ConfigManager) (string, error) {
 		return "", fmt.Errorf("missing 'address' or 'port' in zot http config")
 	}
 	return addr + ":" + port, nil
+}
+
+// resolveRegistryURLForHealth returns the local registry URL the readiness probe
+// should use. It is called on every /ready request so hot-reloads of zot config
+// (address, port, or tls block) take effect without restarting the satellite.
+// Wildcard listen addresses (0.0.0.0, ::) are rewritten to localhost because a
+// probe should dial a routable address. TLS is inferred from zot's own http.tls
+// field for the embedded path; for BYO it follows the configured URL scheme,
+// falling back to UseUnsecure.
+func resolveRegistryURLForHealth(cm *config.ConfigManager) (string, error) {
+	if cm.GetOwnRegistry() {
+		return resolveBYORegistryURLForHealth(cm), nil
+	}
+	return resolveEmbeddedZotURLForHealth(cm.GetRawZotConfig())
+}
+
+func resolveBYORegistryURLForHealth(cm *config.ConfigManager) string {
+	raw := cm.GetLocalRegistryURL()
+	scheme := "https"
+	switch {
+	case strings.HasPrefix(raw, "http://"):
+		scheme = "http"
+	case strings.HasPrefix(raw, "https://"):
+		scheme = "https"
+	case cm.UseUnsecure():
+		scheme = "http"
+	}
+	return fmt.Sprintf("%s://%s", scheme, rewriteProbeHostPort(utils.FormatRegistryURL(raw)))
+}
+
+func resolveEmbeddedZotURLForHealth(rawZotConfig []byte) (string, error) {
+	var data map[string]any
+	if err := json.Unmarshal(rawZotConfig, &data); err != nil {
+		return "", fmt.Errorf("unmarshalling zot config: %w", err)
+	}
+	httpData, ok := data["http"].(map[string]any)
+	if !ok {
+		return "", errors.New("missing 'http' section in zot config")
+	}
+	addr := strings.TrimSpace(stringField(httpData["address"]))
+	port := stringField(httpData["port"])
+	if addr == "" || port == "" {
+		return "", errors.New("missing 'address' or 'port' in zot http config")
+	}
+	if addr == "0.0.0.0" || addr == "::" {
+		addr = "localhost"
+	}
+	return fmt.Sprintf("%s://%s:%s", detectZotScheme(httpData), addr, port), nil
+}
+
+// rewriteProbeHostPort returns its input with a wildcard host (0.0.0.0 or ::)
+// rewritten to "localhost". The input is expected to be "host" or "host:port".
+func rewriteProbeHostPort(hostport string) string {
+	hostport = strings.TrimSpace(hostport)
+	host, port, err := net.SplitHostPort(hostport)
+	if err != nil {
+		// No port — treat the whole thing as host.
+		if hostport == "0.0.0.0" || hostport == "::" {
+			return "localhost"
+		}
+		return hostport
+	}
+	if host == "0.0.0.0" || host == "::" {
+		host = "localhost"
+	}
+	return net.JoinHostPort(host, port)
+}
+
+// detectZotScheme returns "https" when zot's http config carries a tls block
+// (boolean true or a non-empty object), and "http" otherwise.
+func detectZotScheme(httpData map[string]any) string {
+	v, ok := httpData["tls"]
+	if !ok {
+		return "http"
+	}
+	switch t := v.(type) {
+	case bool:
+		if t {
+			return "https"
+		}
+	case map[string]any:
+		if len(t) > 0 {
+			return "https"
+		}
+	}
+	return "http"
+}
+
+// stringField returns v as a string, accepting JSON's "string" or "number"
+// (json.Unmarshal decodes numbers into float64 when targeting map[string]any).
+func stringField(v any) string {
+	switch s := v.(type) {
+	case string:
+		return s
+	case float64:
+		return strconv.FormatInt(int64(s), 10)
+	}
+	return ""
 }
 
 func handleRegistrySetup(ctx context.Context, log *zerolog.Logger, cm *config.ConfigManager, pathConfig *config.PathConfig) error {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -374,7 +374,13 @@ func run(opts SatelliteOptions, pathConfig *config.PathConfig, shutdownTimeout s
 		}
 		defer func() { _ = sc.Close() }()
 		gcClient = func(ctx context.Context) (*http.Client, error) {
-			if err := sc.Connect(ctx); err != nil {
+			// workloadapi.NewX509Source (called by Connect) blocks until it
+			// receives the first SVID. If SPIRE is unreachable, only the
+			// context deadline ends that wait — the http.Client timeout
+			// applies only to the eventual outbound HTTPS call.
+			cctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+			defer cancel()
+			if err := sc.Connect(cctx); err != nil {
 				return nil, err
 			}
 			tlsCfg, err := sc.GetTLSConfig()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -362,9 +362,7 @@ func run(opts SatelliteOptions, pathConfig *config.PathConfig, shutdownTimeout s
 		return fmt.Errorf("build health check HTTP client: %w", err)
 	}
 
-	// In SPIFFE mode the satellite reaches Ground Control via SPIFFE mTLS, so the
-	// readiness GC check must use the same path. Build the client lazily per probe
-	// (Connect is idempotent and the X509Source is reused) so an unreachable SPIRE
+	// In SPIFFE mode the /ready GC check must mTLS through the SPIFFE source too.
 	var gcClient func(context.Context) (*http.Client, error)
 	if cm.IsSPIFFEEnabled() {
 		spiffeCfg := cm.GetSPIFFEConfig()
@@ -377,19 +375,15 @@ func run(opts SatelliteOptions, pathConfig *config.PathConfig, shutdownTimeout s
 			return fmt.Errorf("create SPIFFE client for health checks: %w", scErr)
 		}
 		defer func() { _ = sc.Close() }()
-		// The http.Client is built once and reused across probes so connections
-		// can keep-alive between calls. The *tls.Config returned by
-		// sc.GetTLSConfig is bound to the X509Source, so SVID rotation keeps
-		// working transparently with the cached Transport.
+		// Cache the Client so probes reuse keep-alive connections; the tls.Config
+		// is bound to the X509Source, so SVID rotation works with one Transport.
 		var (
 			cachedClientMu sync.Mutex
 			cachedClient   *http.Client
 		)
 		gcClient = func(ctx context.Context) (*http.Client, error) {
-			// workloadapi.NewX509Source (called by Connect) blocks until it
-			// receives the first SVID. If SPIRE is unreachable, only the
-			// context deadline ends that wait — the http.Client timeout
-			// applies only to the eventual outbound HTTPS call.
+			// Bound Connect — NewX509Source blocks for the first SVID and only
+			// the ctx deadline ends that wait if SPIRE is unreachable.
 			cctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 			defer cancel()
 			if err := sc.Connect(cctx); err != nil {
@@ -550,13 +544,9 @@ func resolveLocalRegistryEndpoint(cm *config.ConfigManager) (string, error) {
 	return addr + ":" + port, nil
 }
 
-// resolveRegistryURLForHealth returns the local registry URL the readiness probe
-// should use. It is called on every /ready request so hot-reloads of zot config
-// (address, port, or tls block) take effect without restarting the satellite.
-// Wildcard listen addresses (0.0.0.0, ::) are rewritten to localhost because a
-// probe should dial a routable address. TLS is inferred from zot's own http.tls
-// field for the embedded path; for BYO it follows the configured URL scheme,
-// falling back to UseUnsecure.
+// resolveRegistryURLForHealth returns the URL the /ready probe should dial.
+// Re-resolved per probe to pick up hot-reloads; wildcard hosts (0.0.0.0, ::) are
+// rewritten to localhost so the probe targets a routable address.
 func resolveRegistryURLForHealth(cm *config.ConfigManager) (string, error) {
 	if cm.GetOwnRegistry() {
 		return resolveBYORegistryURLForHealth(cm), nil

--- a/internal/satellite/satellite.go
+++ b/internal/satellite/satellite.go
@@ -15,14 +15,16 @@ type Satellite struct {
 	criResults    []runtime.CRIConfigResult
 	schedulers    []*scheduler.Scheduler
 	stateFilePath string
+	onStateSync   func()
 }
 
-func NewSatellite(cm *config.ConfigManager, criResults []runtime.CRIConfigResult, stateFilePath string) *Satellite {
+func NewSatellite(cm *config.ConfigManager, criResults []runtime.CRIConfigResult, stateFilePath string, onStateSync func()) *Satellite {
 	return &Satellite{
 		cm:            cm,
 		criResults:    criResults,
 		schedulers:    make([]*scheduler.Scheduler, 0),
 		stateFilePath: stateFilePath,
+		onStateSync:   onStateSync,
 	}
 }
 
@@ -30,7 +32,7 @@ func (s *Satellite) Run(ctx context.Context) error {
 	log := logger.FromContext(ctx)
 	log.Info().Msg("Starting Satellite")
 
-	fetchAndReplicateStateProcess := state.NewFetchAndReplicateStateProcess(s.cm, s.stateFilePath, log)
+	fetchAndReplicateStateProcess := state.NewFetchAndReplicateStateProcess(s.cm, s.stateFilePath, s.onStateSync, log)
 
 	// Create ZTR scheduler if not already done
 	if !s.cm.IsZTRDone() {

--- a/internal/server/health.go
+++ b/internal/server/health.go
@@ -15,17 +15,29 @@ type HealthRegistrar struct {
 	gcURL       string
 	headless    bool
 	client      *http.Client
+	gcClient    func(context.Context) (*http.Client, error)
 	stateSynced atomic.Bool
 }
 
-func NewHealthRegistrar(registryURL, gcURL string, headless bool) *HealthRegistrar {
+// NewHealthRegistrar builds the registrar. client is used for the registry check
+// (and the Ground Control check when gcClient is nil); pass nil for a bare
+// default client. gcClient, when non-nil, supplies the client for the Ground
+// Control check — used to honor SPIFFE mTLS, which differs from the static client.
+func NewHealthRegistrar(
+	registryURL, gcURL string,
+	headless bool,
+	client *http.Client,
+	gcClient func(context.Context) (*http.Client, error),
+) *HealthRegistrar {
+	if client == nil {
+		client = &http.Client{Timeout: 2 * time.Second}
+	}
 	return &HealthRegistrar{
 		registryURL: strings.TrimRight(registryURL, "/"),
 		gcURL:       strings.TrimRight(gcURL, "/"),
 		headless:    headless,
-		client: &http.Client{
-			Timeout: 2 * time.Second,
-		},
+		client:      client,
+		gcClient:    gcClient,
 	}
 }
 
@@ -138,12 +150,21 @@ func (hr *HealthRegistrar) checkGroundControl(ctx context.Context) error {
 		return fmt.Errorf("ground control URL is empty")
 	}
 
+	client := hr.client
+	if hr.gcClient != nil {
+		c, err := hr.gcClient(ctx)
+		if err != nil {
+			return fmt.Errorf("build ground control client: %w", err)
+		}
+		client = c
+	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, hr.gcURL+"/health", nil)
 	if err != nil {
 		return fmt.Errorf("create ground control health request: %w", err)
 	}
 
-	resp, err := hr.client.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("send ground control health request: %w", err)
 	}

--- a/internal/server/health.go
+++ b/internal/server/health.go
@@ -1,0 +1,16 @@
+package server
+
+import "net/http"
+
+type HealthRegistrar struct{}
+
+func (hr *HealthRegistrar) RegisterRoutes(router Router) {
+	router.HandleFunc("GET /health", hr.healthHandler)
+}
+
+func (hr *HealthRegistrar) healthHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	_, _ = w.Write([]byte(`{"status":"ok"}`))
+}

--- a/internal/server/health.go
+++ b/internal/server/health.go
@@ -11,9 +11,8 @@ import (
 	"time"
 )
 
-// RegistryURLFunc returns the current local registry URL each time the readiness
-// probe runs. A function (rather than a captured string) lets the probe pick up
-// hot-reloaded zot config without restarting the satellite.
+// RegistryURLFunc returns the local registry URL, resolved per probe so
+// hot-reloads of zot config are picked up without a restart.
 type RegistryURLFunc func() (string, error)
 
 type HealthRegistrar struct {
@@ -25,12 +24,9 @@ type HealthRegistrar struct {
 	stateSynced atomic.Bool
 }
 
-// NewHealthRegistrar builds the registrar. registryURL is resolved per probe so
-// the check tracks hot-reloads of zot config. client is used for the registry
-// check (and the Ground Control check when gcClient is nil); pass nil for a
-// bare default client. gcClient, when non-nil, supplies the client for the
-// Ground Control check — used to honor SPIFFE mTLS, which differs from the
-// static client.
+// NewHealthRegistrar builds the registrar. client is the static client (registry
+// check, and Ground Control when gcClient is nil); pass nil for a bare default
+// gcClient, when set, supplies the Ground Control client — used for SPIFFE mTLS
 func NewHealthRegistrar(
 	registryURL RegistryURLFunc,
 	gcURL string,
@@ -50,8 +46,8 @@ func NewHealthRegistrar(
 	}
 }
 
-// MarkStateSynced records that the initial state sync has completed successfully.
-// Safe to call from the state replication goroutine while readyHandler reads it.
+// MarkStateSynced records a successful initial state sync. Safe to call
+// concurrently with readyHandler reads (backed by atomic.Bool).
 func (hr *HealthRegistrar) MarkStateSynced() {
 	hr.stateSynced.Store(true)
 }
@@ -72,8 +68,7 @@ func (hr *HealthRegistrar) RegisterRoutes(router Router) {
 	router.HandleFunc("/ready", hr.readyHandler)
 }
 
-// healthHandler is a liveness probe: it reports the process is running and must
-// not depend on any external dependency.
+// healthHandler is the liveness probe — always 200, no dependency checks.
 func (hr *HealthRegistrar) healthHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -81,9 +76,8 @@ func (hr *HealthRegistrar) healthHandler(w http.ResponseWriter, r *http.Request)
 	_, _ = w.Write([]byte(`{"status":"ok"}`))
 }
 
-// readyHandler is a readiness probe: it reports whether the satellite can serve
-// its purpose. Registry must be reachable, Ground Control must be reachable
-// (unless headless), and the initial state sync must have completed.
+// readyHandler is the readiness probe — 200 only if registry is up, GC is up
+// (or headless), and the initial state sync has completed.
 func (hr *HealthRegistrar) readyHandler(w http.ResponseWriter, r *http.Request) {
 	var checks readyChecks
 	ready := true
@@ -127,10 +121,7 @@ func (hr *HealthRegistrar) readyHandler(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
-// checkRegistry pings the local registry's OCI Distribution base endpoint.
-// A reachable registry answers /v2/ with 200 (open) or 401 (auth required).
-// The URL is re-resolved on every probe so hot-reloads of zot config are
-// picked up without restarting the satellite.
+// checkRegistry pings the local registry's /v2/ endpoint; 200 or 401 means up.
 func (hr *HealthRegistrar) checkRegistry(ctx context.Context) error {
 	if hr.registryURL == nil {
 		return errors.New("registry URL provider is not configured")
@@ -162,8 +153,7 @@ func (hr *HealthRegistrar) checkRegistry(ctx context.Context) error {
 	return fmt.Errorf("registry returned status %d", resp.StatusCode)
 }
 
-// checkGroundControl pings Ground Control's /health endpoint, which also
-// verifies GC's database. HTTP 200 means GC is reachable and healthy.
+// checkGroundControl pings GC's /health (which also covers GC's DB); 200 = up.
 func (hr *HealthRegistrar) checkGroundControl(ctx context.Context) error {
 	if hr.gcURL == "" {
 		return errors.New("ground control URL is empty")

--- a/internal/server/health.go
+++ b/internal/server/health.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -10,8 +11,13 @@ import (
 	"time"
 )
 
+// RegistryURLFunc returns the current local registry URL each time the readiness
+// probe runs. A function (rather than a captured string) lets the probe pick up
+// hot-reloaded zot config without restarting the satellite.
+type RegistryURLFunc func() (string, error)
+
 type HealthRegistrar struct {
-	registryURL string
+	registryURL RegistryURLFunc
 	gcURL       string
 	headless    bool
 	client      *http.Client
@@ -19,12 +25,15 @@ type HealthRegistrar struct {
 	stateSynced atomic.Bool
 }
 
-// NewHealthRegistrar builds the registrar. client is used for the registry check
-// (and the Ground Control check when gcClient is nil); pass nil for a bare
-// default client. gcClient, when non-nil, supplies the client for the Ground
-// Control check — used to honor SPIFFE mTLS, which differs from the static client.
+// NewHealthRegistrar builds the registrar. registryURL is resolved per probe so
+// the check tracks hot-reloads of zot config. client is used for the registry
+// check (and the Ground Control check when gcClient is nil); pass nil for a
+// bare default client. gcClient, when non-nil, supplies the client for the
+// Ground Control check — used to honor SPIFFE mTLS, which differs from the
+// static client.
 func NewHealthRegistrar(
-	registryURL, gcURL string,
+	registryURL RegistryURLFunc,
+	gcURL string,
 	headless bool,
 	client *http.Client,
 	gcClient func(context.Context) (*http.Client, error),
@@ -33,7 +42,7 @@ func NewHealthRegistrar(
 		client = &http.Client{Timeout: 2 * time.Second}
 	}
 	return &HealthRegistrar{
-		registryURL: strings.TrimRight(registryURL, "/"),
+		registryURL: registryURL,
 		gcURL:       strings.TrimRight(gcURL, "/"),
 		headless:    headless,
 		client:      client,
@@ -120,12 +129,22 @@ func (hr *HealthRegistrar) readyHandler(w http.ResponseWriter, r *http.Request) 
 
 // checkRegistry pings the local registry's OCI Distribution base endpoint.
 // A reachable registry answers /v2/ with 200 (open) or 401 (auth required).
+// The URL is re-resolved on every probe so hot-reloads of zot config are
+// picked up without restarting the satellite.
 func (hr *HealthRegistrar) checkRegistry(ctx context.Context) error {
-	if hr.registryURL == "" {
-		return fmt.Errorf("registry URL is empty")
+	if hr.registryURL == nil {
+		return errors.New("registry URL provider is not configured")
 	}
+	url, err := hr.registryURL()
+	if err != nil {
+		return fmt.Errorf("resolve registry URL: %w", err)
+	}
+	if url == "" {
+		return errors.New("registry URL is empty")
+	}
+	url = strings.TrimRight(url, "/")
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, hr.registryURL+"/v2/", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url+"/v2/", nil)
 	if err != nil {
 		return fmt.Errorf("create registry health request: %w", err)
 	}
@@ -147,7 +166,7 @@ func (hr *HealthRegistrar) checkRegistry(ctx context.Context) error {
 // verifies GC's database. HTTP 200 means GC is reachable and healthy.
 func (hr *HealthRegistrar) checkGroundControl(ctx context.Context) error {
 	if hr.gcURL == "" {
-		return fmt.Errorf("ground control URL is empty")
+		return errors.New("ground control URL is empty")
 	}
 
 	client := hr.client
@@ -155,6 +174,9 @@ func (hr *HealthRegistrar) checkGroundControl(ctx context.Context) error {
 		c, err := hr.gcClient(ctx)
 		if err != nil {
 			return fmt.Errorf("build ground control client: %w", err)
+		}
+		if c == nil {
+			return errors.New("ground control client provider returned nil client without error")
 		}
 		client = c
 	}

--- a/internal/server/health.go
+++ b/internal/server/health.go
@@ -1,16 +1,157 @@
 package server
 
-import "net/http"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+)
 
-type HealthRegistrar struct{}
-
-func (hr *HealthRegistrar) RegisterRoutes(router Router) {
-	router.HandleFunc("GET /health", hr.healthHandler)
+type HealthRegistrar struct {
+	registryURL string
+	gcURL       string
+	headless    bool
+	client      *http.Client
+	stateSynced atomic.Bool
 }
 
+func NewHealthRegistrar(registryURL, gcURL string, headless bool) *HealthRegistrar {
+	return &HealthRegistrar{
+		registryURL: strings.TrimRight(registryURL, "/"),
+		gcURL:       strings.TrimRight(gcURL, "/"),
+		headless:    headless,
+		client: &http.Client{
+			Timeout: 2 * time.Second,
+		},
+	}
+}
+
+// MarkStateSynced records that the initial state sync has completed successfully.
+// Safe to call from the state replication goroutine while readyHandler reads it.
+func (hr *HealthRegistrar) MarkStateSynced() {
+	hr.stateSynced.Store(true)
+}
+
+type readyChecks struct {
+	Registry      string `json:"registry"`
+	GroundControl string `json:"ground_control"`
+	StateSync     string `json:"state_sync"`
+}
+
+type readyResponse struct {
+	Status string      `json:"status"`
+	Checks readyChecks `json:"checks"`
+}
+
+func (hr *HealthRegistrar) RegisterRoutes(router Router) {
+	router.HandleFunc("/health", hr.healthHandler)
+	router.HandleFunc("/ready", hr.readyHandler)
+}
+
+// healthHandler is a liveness probe: it reports the process is running and must
+// not depend on any external dependency.
 func (hr *HealthRegistrar) healthHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
 	_, _ = w.Write([]byte(`{"status":"ok"}`))
+}
+
+// readyHandler is a readiness probe: it reports whether the satellite can serve
+// its purpose. Registry must be reachable, Ground Control must be reachable
+// (unless headless), and the initial state sync must have completed.
+func (hr *HealthRegistrar) readyHandler(w http.ResponseWriter, r *http.Request) {
+	var checks readyChecks
+	ready := true
+
+	if err := hr.checkRegistry(r.Context()); err != nil {
+		checks.Registry = "unavailable"
+		ready = false
+	} else {
+		checks.Registry = "ok"
+	}
+
+	switch {
+	case hr.headless:
+		checks.GroundControl = "skipped"
+	case hr.checkGroundControl(r.Context()) != nil:
+		checks.GroundControl = "unavailable"
+		ready = false
+	default:
+		checks.GroundControl = "ok"
+	}
+
+	if hr.stateSynced.Load() {
+		checks.StateSync = "ok"
+	} else {
+		checks.StateSync = "pending"
+		ready = false
+	}
+
+	status := "ready"
+	code := http.StatusOK
+	if !ready {
+		status = "not_ready"
+		code = http.StatusServiceUnavailable
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(readyResponse{
+		Status: status,
+		Checks: checks,
+	})
+}
+
+// checkRegistry pings the local registry's OCI Distribution base endpoint.
+// A reachable registry answers /v2/ with 200 (open) or 401 (auth required).
+func (hr *HealthRegistrar) checkRegistry(ctx context.Context) error {
+	if hr.registryURL == "" {
+		return fmt.Errorf("registry URL is empty")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, hr.registryURL+"/v2/", nil)
+	if err != nil {
+		return fmt.Errorf("create registry health request: %w", err)
+	}
+
+	resp, err := hr.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send registry health request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusUnauthorized {
+		return nil
+	}
+
+	return fmt.Errorf("registry returned status %d", resp.StatusCode)
+}
+
+// checkGroundControl pings Ground Control's /health endpoint, which also
+// verifies GC's database. HTTP 200 means GC is reachable and healthy.
+func (hr *HealthRegistrar) checkGroundControl(ctx context.Context) error {
+	if hr.gcURL == "" {
+		return fmt.Errorf("ground control URL is empty")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, hr.gcURL+"/health", nil)
+	if err != nil {
+		return fmt.Errorf("create ground control health request: %w", err)
+	}
+
+	resp, err := hr.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send ground control health request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+
+	return fmt.Errorf("ground control returned status %d", resp.StatusCode)
 }

--- a/internal/server/health_test.go
+++ b/internal/server/health_test.go
@@ -9,6 +9,71 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const unreachableURL = "http://127.0.0.1:0"
+
+// newStubRegistry returns a test server answering the OCI base endpoint with 401.
+func newStubRegistry(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newStubGroundControl returns a test server answering /health with 200.
+func newStubGroundControl(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+type readyTestCase struct {
+	name        string
+	registryURL string
+	gcURL       string
+	headless    bool
+	synced      bool
+	wantCode    int
+	wantChecks  readyChecks
+}
+
+// runReadyCase issues a /ready request for the case and asserts the result.
+// The expected status string is derived from wantCode (200 -> ready).
+func runReadyCase(t *testing.T, tc readyTestCase) {
+	t.Helper()
+
+	hr := NewHealthRegistrar(tc.registryURL, tc.gcURL, tc.headless)
+	if tc.synced {
+		hr.MarkStateSynced()
+	}
+
+	rec := httptest.NewRecorder()
+	hr.readyHandler(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	require.Equal(t, tc.wantCode, rec.Code)
+
+	wantStatus := "ready"
+	if tc.wantCode != http.StatusOK {
+		wantStatus = "not_ready"
+	}
+
+	var resp readyResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, wantStatus, resp.Status)
+	require.Equal(t, tc.wantChecks, resp.Checks)
+}
+
 func TestHealthHandlerAlwaysOK(t *testing.T) {
 	hr := NewHealthRegistrar("", "", false)
 
@@ -20,100 +85,25 @@ func TestHealthHandlerAlwaysOK(t *testing.T) {
 }
 
 func TestReadyHandler(t *testing.T) {
-	registry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v2/" {
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer registry.Close()
+	registry := newStubRegistry(t)
+	gc := newStubGroundControl(t)
 
-	gc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/health" {
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer gc.Close()
-
-	unreachable := "http://127.0.0.1:0"
-
-	tests := []struct {
-		name        string
-		registryURL string
-		gcURL       string
-		headless    bool
-		synced      bool
-		wantCode    int
-		wantStatus  string
-		wantChecks  readyChecks
-	}{
-		{
-			name:        "all checks pass",
-			registryURL: registry.URL,
-			gcURL:       gc.URL,
-			synced:      true,
-			wantCode:    http.StatusOK,
-			wantStatus:  "ready",
-			wantChecks:  readyChecks{Registry: "ok", GroundControl: "ok", StateSync: "ok"},
-		},
-		{
-			name:        "state sync pending",
-			registryURL: registry.URL,
-			gcURL:       gc.URL,
-			synced:      false,
-			wantCode:    http.StatusServiceUnavailable,
-			wantStatus:  "not_ready",
-			wantChecks:  readyChecks{Registry: "ok", GroundControl: "ok", StateSync: "pending"},
-		},
-		{
-			name:        "ground control unavailable",
-			registryURL: registry.URL,
-			gcURL:       unreachable,
-			synced:      true,
-			wantCode:    http.StatusServiceUnavailable,
-			wantStatus:  "not_ready",
-			wantChecks:  readyChecks{Registry: "ok", GroundControl: "unavailable", StateSync: "ok"},
-		},
-		{
-			name:        "registry unavailable",
-			registryURL: unreachable,
-			gcURL:       gc.URL,
-			synced:      true,
-			wantCode:    http.StatusServiceUnavailable,
-			wantStatus:  "not_ready",
-			wantChecks:  readyChecks{Registry: "unavailable", GroundControl: "ok", StateSync: "ok"},
-		},
-		{
-			name:        "headless skips ground control",
-			registryURL: registry.URL,
-			gcURL:       unreachable,
-			headless:    true,
-			synced:      true,
-			wantCode:    http.StatusOK,
-			wantStatus:  "ready",
-			wantChecks:  readyChecks{Registry: "ok", GroundControl: "skipped", StateSync: "ok"},
-		},
+	tests := []readyTestCase{
+		{"all checks pass", registry.URL, gc.URL, false, true,
+			http.StatusOK, readyChecks{Registry: "ok", GroundControl: "ok", StateSync: "ok"}},
+		{"state sync pending", registry.URL, gc.URL, false, false,
+			http.StatusServiceUnavailable, readyChecks{Registry: "ok", GroundControl: "ok", StateSync: "pending"}},
+		{"ground control unavailable", registry.URL, unreachableURL, false, true,
+			http.StatusServiceUnavailable, readyChecks{Registry: "ok", GroundControl: "unavailable", StateSync: "ok"}},
+		{"registry unavailable", unreachableURL, gc.URL, false, true,
+			http.StatusServiceUnavailable, readyChecks{Registry: "unavailable", GroundControl: "ok", StateSync: "ok"}},
+		{"headless skips ground control", registry.URL, unreachableURL, true, true,
+			http.StatusOK, readyChecks{Registry: "ok", GroundControl: "skipped", StateSync: "ok"}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hr := NewHealthRegistrar(tt.registryURL, tt.gcURL, tt.headless)
-			if tt.synced {
-				hr.MarkStateSynced()
-			}
-
-			rec := httptest.NewRecorder()
-			hr.readyHandler(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
-
-			require.Equal(t, tt.wantCode, rec.Code)
-
-			var resp readyResponse
-			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-			require.Equal(t, tt.wantStatus, resp.Status)
-			require.Equal(t, tt.wantChecks, resp.Checks)
+			runReadyCase(t, tt)
 		})
 	}
 }
@@ -126,10 +116,7 @@ func TestReadyHandlerHeadlessDoesNotContactGroundControl(t *testing.T) {
 	}))
 	defer gc.Close()
 
-	registry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer registry.Close()
+	registry := newStubRegistry(t)
 
 	hr := NewHealthRegistrar(registry.URL, gc.URL, true)
 	hr.MarkStateSynced()
@@ -139,3 +126,7 @@ func TestReadyHandlerHeadlessDoesNotContactGroundControl(t *testing.T) {
 
 	require.False(t, gcHit, "ground control should not be contacted in headless mode")
 }
+
+I've opened #463 for #240, adding /health and /ready for the satellite so Kubernetes can gate workloads on the satellite being ready, keeping pods from pulling before images are proxied and avoiding ImagePullBackOff churn. Two things I'd like your input on: 
+1. TLS — the readiness checks hit local Zot and GC with a bare http.Client, unlike the rest of the code which uses createHTTPClient(cm.GetTLSConfig(), cm.UseUnsecure()), so it honors neither UseUnsecure nor a custom CA; if a registry or GC is served over HTTPS with a self-signed/custom-CA cert the check fails verification and /ready falsely reports "unavailable" — is the observability port meant to stay internal-only (bare client fine), or should these checks honor the satellite's TLS config?
+2. Headless — the issue mentions skipping the GC check in headless mode, but no headless concept exists today and I've only made /ready skip the GC check; should we add a real mode to run the satellite without GC, and is "headless" meant to describe the satellite running standalone or just GC being absent?

--- a/internal/server/health_test.go
+++ b/internal/server/health_test.go
@@ -5,19 +5,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-)
 
-func decodeReady(t *testing.T, body []byte) (string, map[string]string) {
-	t.Helper()
-	var resp struct {
-		Status string            `json:"status"`
-		Checks map[string]string `json:"checks"`
-	}
-	if err := json.Unmarshal(body, &resp); err != nil {
-		t.Fatalf("invalid JSON response %q: %v", body, err)
-	}
-	return resp.Status, resp.Checks
-}
+	"github.com/stretchr/testify/require"
+)
 
 func TestHealthHandlerAlwaysOK(t *testing.T) {
 	hr := NewHealthRegistrar("", "", false)
@@ -25,9 +15,8 @@ func TestHealthHandlerAlwaysOK(t *testing.T) {
 	rec := httptest.NewRecorder()
 	hr.healthHandler(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", rec.Code)
-	}
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.JSONEq(t, `{"status":"ok"}`, rec.Body.String())
 }
 
 func TestReadyHandler(t *testing.T) {
@@ -59,16 +48,16 @@ func TestReadyHandler(t *testing.T) {
 		synced      bool
 		wantCode    int
 		wantStatus  string
-		wantChecks  map[string]string
+		wantChecks  readyChecks
 	}{
 		{
-			name:        "all ok",
+			name:        "all checks pass",
 			registryURL: registry.URL,
 			gcURL:       gc.URL,
 			synced:      true,
 			wantCode:    http.StatusOK,
 			wantStatus:  "ready",
-			wantChecks:  map[string]string{"registry": "ok", "ground_control": "ok", "state_sync": "ok"},
+			wantChecks:  readyChecks{Registry: "ok", GroundControl: "ok", StateSync: "ok"},
 		},
 		{
 			name:        "state sync pending",
@@ -77,7 +66,7 @@ func TestReadyHandler(t *testing.T) {
 			synced:      false,
 			wantCode:    http.StatusServiceUnavailable,
 			wantStatus:  "not_ready",
-			wantChecks:  map[string]string{"registry": "ok", "ground_control": "ok", "state_sync": "pending"},
+			wantChecks:  readyChecks{Registry: "ok", GroundControl: "ok", StateSync: "pending"},
 		},
 		{
 			name:        "ground control unavailable",
@@ -86,7 +75,7 @@ func TestReadyHandler(t *testing.T) {
 			synced:      true,
 			wantCode:    http.StatusServiceUnavailable,
 			wantStatus:  "not_ready",
-			wantChecks:  map[string]string{"registry": "ok", "ground_control": "unavailable", "state_sync": "ok"},
+			wantChecks:  readyChecks{Registry: "ok", GroundControl: "unavailable", StateSync: "ok"},
 		},
 		{
 			name:        "registry unavailable",
@@ -95,7 +84,7 @@ func TestReadyHandler(t *testing.T) {
 			synced:      true,
 			wantCode:    http.StatusServiceUnavailable,
 			wantStatus:  "not_ready",
-			wantChecks:  map[string]string{"registry": "unavailable", "ground_control": "ok", "state_sync": "ok"},
+			wantChecks:  readyChecks{Registry: "unavailable", GroundControl: "ok", StateSync: "ok"},
 		},
 		{
 			name:        "headless skips ground control",
@@ -105,7 +94,7 @@ func TestReadyHandler(t *testing.T) {
 			synced:      true,
 			wantCode:    http.StatusOK,
 			wantStatus:  "ready",
-			wantChecks:  map[string]string{"registry": "ok", "ground_control": "skipped", "state_sync": "ok"},
+			wantChecks:  readyChecks{Registry: "ok", GroundControl: "skipped", StateSync: "ok"},
 		},
 	}
 
@@ -119,25 +108,18 @@ func TestReadyHandler(t *testing.T) {
 			rec := httptest.NewRecorder()
 			hr.readyHandler(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
 
-			if rec.Code != tt.wantCode {
-				t.Fatalf("status code: got %d, want %d", rec.Code, tt.wantCode)
-			}
+			require.Equal(t, tt.wantCode, rec.Code)
 
-			status, checks := decodeReady(t, rec.Body.Bytes())
-			if status != tt.wantStatus {
-				t.Errorf("status: got %q, want %q", status, tt.wantStatus)
-			}
-			for k, want := range tt.wantChecks {
-				if checks[k] != want {
-					t.Errorf("check %q: got %q, want %q", k, checks[k], want)
-				}
-			}
+			var resp readyResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			require.Equal(t, tt.wantStatus, resp.Status)
+			require.Equal(t, tt.wantChecks, resp.Checks)
 		})
 	}
 }
 
-func TestHeadlessDoesNotContactGroundControl(t *testing.T) {
-	var gcHit bool
+func TestReadyHandlerHeadlessDoesNotContactGroundControl(t *testing.T) {
+	gcHit := false
 	gc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gcHit = true
 		w.WriteHeader(http.StatusOK)
@@ -155,7 +137,5 @@ func TestHeadlessDoesNotContactGroundControl(t *testing.T) {
 	rec := httptest.NewRecorder()
 	hr.readyHandler(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
 
-	if gcHit {
-		t.Error("ground control should not be contacted in headless mode")
-	}
+	require.False(t, gcHit, "ground control should not be contacted in headless mode")
 }

--- a/internal/server/health_test.go
+++ b/internal/server/health_test.go
@@ -1,0 +1,161 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func decodeReady(t *testing.T, body []byte) (string, map[string]string) {
+	t.Helper()
+	var resp struct {
+		Status string            `json:"status"`
+		Checks map[string]string `json:"checks"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("invalid JSON response %q: %v", body, err)
+	}
+	return resp.Status, resp.Checks
+}
+
+func TestHealthHandlerAlwaysOK(t *testing.T) {
+	hr := NewHealthRegistrar("", "", false)
+
+	rec := httptest.NewRecorder()
+	hr.healthHandler(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestReadyHandler(t *testing.T) {
+	registry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer registry.Close()
+
+	gc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer gc.Close()
+
+	unreachable := "http://127.0.0.1:0"
+
+	tests := []struct {
+		name        string
+		registryURL string
+		gcURL       string
+		headless    bool
+		synced      bool
+		wantCode    int
+		wantStatus  string
+		wantChecks  map[string]string
+	}{
+		{
+			name:        "all ok",
+			registryURL: registry.URL,
+			gcURL:       gc.URL,
+			synced:      true,
+			wantCode:    http.StatusOK,
+			wantStatus:  "ready",
+			wantChecks:  map[string]string{"registry": "ok", "ground_control": "ok", "state_sync": "ok"},
+		},
+		{
+			name:        "state sync pending",
+			registryURL: registry.URL,
+			gcURL:       gc.URL,
+			synced:      false,
+			wantCode:    http.StatusServiceUnavailable,
+			wantStatus:  "not_ready",
+			wantChecks:  map[string]string{"registry": "ok", "ground_control": "ok", "state_sync": "pending"},
+		},
+		{
+			name:        "ground control unavailable",
+			registryURL: registry.URL,
+			gcURL:       unreachable,
+			synced:      true,
+			wantCode:    http.StatusServiceUnavailable,
+			wantStatus:  "not_ready",
+			wantChecks:  map[string]string{"registry": "ok", "ground_control": "unavailable", "state_sync": "ok"},
+		},
+		{
+			name:        "registry unavailable",
+			registryURL: unreachable,
+			gcURL:       gc.URL,
+			synced:      true,
+			wantCode:    http.StatusServiceUnavailable,
+			wantStatus:  "not_ready",
+			wantChecks:  map[string]string{"registry": "unavailable", "ground_control": "ok", "state_sync": "ok"},
+		},
+		{
+			name:        "headless skips ground control",
+			registryURL: registry.URL,
+			gcURL:       unreachable,
+			headless:    true,
+			synced:      true,
+			wantCode:    http.StatusOK,
+			wantStatus:  "ready",
+			wantChecks:  map[string]string{"registry": "ok", "ground_control": "skipped", "state_sync": "ok"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hr := NewHealthRegistrar(tt.registryURL, tt.gcURL, tt.headless)
+			if tt.synced {
+				hr.MarkStateSynced()
+			}
+
+			rec := httptest.NewRecorder()
+			hr.readyHandler(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+
+			if rec.Code != tt.wantCode {
+				t.Fatalf("status code: got %d, want %d", rec.Code, tt.wantCode)
+			}
+
+			status, checks := decodeReady(t, rec.Body.Bytes())
+			if status != tt.wantStatus {
+				t.Errorf("status: got %q, want %q", status, tt.wantStatus)
+			}
+			for k, want := range tt.wantChecks {
+				if checks[k] != want {
+					t.Errorf("check %q: got %q, want %q", k, checks[k], want)
+				}
+			}
+		})
+	}
+}
+
+func TestHeadlessDoesNotContactGroundControl(t *testing.T) {
+	var gcHit bool
+	gc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gcHit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer gc.Close()
+
+	registry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer registry.Close()
+
+	hr := NewHealthRegistrar(registry.URL, gc.URL, true)
+	hr.MarkStateSynced()
+
+	rec := httptest.NewRecorder()
+	hr.readyHandler(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+
+	if gcHit {
+		t.Error("ground control should not be contacted in headless mode")
+	}
+}

--- a/internal/server/health_test.go
+++ b/internal/server/health_test.go
@@ -1,10 +1,13 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -54,7 +57,7 @@ type readyTestCase struct {
 func runReadyCase(t *testing.T, tc readyTestCase) {
 	t.Helper()
 
-	hr := NewHealthRegistrar(tc.registryURL, tc.gcURL, tc.headless)
+	hr := NewHealthRegistrar(tc.registryURL, tc.gcURL, tc.headless, nil, nil)
 	if tc.synced {
 		hr.MarkStateSynced()
 	}
@@ -75,7 +78,7 @@ func runReadyCase(t *testing.T, tc readyTestCase) {
 }
 
 func TestHealthHandlerAlwaysOK(t *testing.T) {
-	hr := NewHealthRegistrar("", "", false)
+	hr := NewHealthRegistrar("", "", false, nil, nil)
 
 	rec := httptest.NewRecorder()
 	hr.healthHandler(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
@@ -89,16 +92,31 @@ func TestReadyHandler(t *testing.T) {
 	gc := newStubGroundControl(t)
 
 	tests := []readyTestCase{
-		{"all checks pass", registry.URL, gc.URL, false, true,
-			http.StatusOK, readyChecks{Registry: "ok", GroundControl: "ok", StateSync: "ok"}},
-		{"state sync pending", registry.URL, gc.URL, false, false,
-			http.StatusServiceUnavailable, readyChecks{Registry: "ok", GroundControl: "ok", StateSync: "pending"}},
-		{"ground control unavailable", registry.URL, unreachableURL, false, true,
-			http.StatusServiceUnavailable, readyChecks{Registry: "ok", GroundControl: "unavailable", StateSync: "ok"}},
-		{"registry unavailable", unreachableURL, gc.URL, false, true,
-			http.StatusServiceUnavailable, readyChecks{Registry: "unavailable", GroundControl: "ok", StateSync: "ok"}},
-		{"headless skips ground control", registry.URL, unreachableURL, true, true,
-			http.StatusOK, readyChecks{Registry: "ok", GroundControl: "skipped", StateSync: "ok"}},
+		{
+			"all checks pass", registry.URL, gc.URL, false, true,
+			http.StatusOK,
+			readyChecks{Registry: "ok", GroundControl: "ok", StateSync: "ok"},
+		},
+		{
+			"state sync pending", registry.URL, gc.URL, false, false,
+			http.StatusServiceUnavailable,
+			readyChecks{Registry: "ok", GroundControl: "ok", StateSync: "pending"},
+		},
+		{
+			"ground control unavailable", registry.URL, unreachableURL, false, true,
+			http.StatusServiceUnavailable,
+			readyChecks{Registry: "ok", GroundControl: "unavailable", StateSync: "ok"},
+		},
+		{
+			"registry unavailable", unreachableURL, gc.URL, false, true,
+			http.StatusServiceUnavailable,
+			readyChecks{Registry: "unavailable", GroundControl: "ok", StateSync: "ok"},
+		},
+		{
+			"headless skips ground control", registry.URL, unreachableURL, true, true,
+			http.StatusOK,
+			readyChecks{Registry: "ok", GroundControl: "skipped", StateSync: "ok"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -110,7 +128,7 @@ func TestReadyHandler(t *testing.T) {
 
 func TestReadyHandlerHeadlessDoesNotContactGroundControl(t *testing.T) {
 	gcHit := false
-	gc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	gc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		gcHit = true
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -118,7 +136,7 @@ func TestReadyHandlerHeadlessDoesNotContactGroundControl(t *testing.T) {
 
 	registry := newStubRegistry(t)
 
-	hr := NewHealthRegistrar(registry.URL, gc.URL, true)
+	hr := NewHealthRegistrar(registry.URL, gc.URL, true, nil, nil)
 	hr.MarkStateSynced()
 
 	rec := httptest.NewRecorder()
@@ -127,6 +145,83 @@ func TestReadyHandlerHeadlessDoesNotContactGroundControl(t *testing.T) {
 	require.False(t, gcHit, "ground control should not be contacted in headless mode")
 }
 
-I've opened #463 for #240, adding /health and /ready for the satellite so Kubernetes can gate workloads on the satellite being ready, keeping pods from pulling before images are proxied and avoiding ImagePullBackOff churn. Two things I'd like your input on: 
-1. TLS — the readiness checks hit local Zot and GC with a bare http.Client, unlike the rest of the code which uses createHTTPClient(cm.GetTLSConfig(), cm.UseUnsecure()), so it honors neither UseUnsecure nor a custom CA; if a registry or GC is served over HTTPS with a self-signed/custom-CA cert the check fails verification and /ready falsely reports "unavailable" — is the observability port meant to stay internal-only (bare client fine), or should these checks honor the satellite's TLS config?
-2. Headless — the issue mentions skipping the GC check in headless mode, but no headless concept exists today and I've only made /ready skip the GC check; should we add a real mode to run the satellite without GC, and is "headless" meant to describe the satellite running standalone or just GC being absent?
+// TestReadyHandlerRegistryTLS proves the injected client governs TLS trust: a
+// bare client rejects the self-signed registry cert, but a client that trusts
+// the test server's CA succeeds. Headless skips GC so only the registry matters.
+func TestReadyHandlerRegistryTLS(t *testing.T) {
+	registry := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer registry.Close()
+
+	t.Run("bare client rejects self-signed cert", func(t *testing.T) {
+		hr := NewHealthRegistrar(registry.URL, "", true, nil, nil)
+		hr.MarkStateSynced()
+
+		rec := httptest.NewRecorder()
+		hr.readyHandler(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+
+		require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+		var resp readyResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		require.Equal(t, "unavailable", resp.Checks.Registry)
+	})
+
+	t.Run("client trusting the CA succeeds", func(t *testing.T) {
+		hr := NewHealthRegistrar(registry.URL, "", true, registry.Client(), nil)
+		hr.MarkStateSynced()
+
+		rec := httptest.NewRecorder()
+		hr.readyHandler(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		var resp readyResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		require.Equal(t, "ok", resp.Checks.Registry)
+	})
+}
+
+// TestReadyHandlerGCClientProvider proves the gcClient provider governs the GC
+// check (and only the GC check): the registry uses the static client while the
+// provider supplies the GC client, and a provider error surfaces as GC unavailable.
+func TestReadyHandlerGCClientProvider(t *testing.T) {
+	registry := newStubRegistry(t)
+	gc := newStubGroundControl(t)
+
+	t.Run("provider client is used for GC", func(t *testing.T) {
+		provider := func(context.Context) (*http.Client, error) {
+			return &http.Client{Timeout: 2 * time.Second}, nil
+		}
+		hr := NewHealthRegistrar(registry.URL, gc.URL, false, nil, provider)
+		hr.MarkStateSynced()
+
+		rec := httptest.NewRecorder()
+		hr.readyHandler(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		var resp readyResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		require.Equal(t, "ok", resp.Checks.GroundControl)
+	})
+
+	t.Run("provider error marks GC unavailable", func(t *testing.T) {
+		provider := func(context.Context) (*http.Client, error) {
+			return nil, errors.New("spire unavailable")
+		}
+		hr := NewHealthRegistrar(registry.URL, gc.URL, false, nil, provider)
+		hr.MarkStateSynced()
+
+		rec := httptest.NewRecorder()
+		hr.readyHandler(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+
+		require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+		var resp readyResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		require.Equal(t, "ok", resp.Checks.Registry)
+		require.Equal(t, "unavailable", resp.Checks.GroundControl)
+	})
+}

--- a/internal/server/health_test.go
+++ b/internal/server/health_test.go
@@ -14,6 +14,12 @@ import (
 
 const unreachableURL = "http://127.0.0.1:0"
 
+// staticURL wraps a literal URL string in the RegistryURLFunc shape required by
+// NewHealthRegistrar, so tests don't have to write the closure every time.
+func staticURL(s string) RegistryURLFunc {
+	return func() (string, error) { return s, nil }
+}
+
 // newStubRegistry returns a test server answering the OCI base endpoint with 401.
 func newStubRegistry(t *testing.T) *httptest.Server {
 	t.Helper()
@@ -57,7 +63,7 @@ type readyTestCase struct {
 func runReadyCase(t *testing.T, tc readyTestCase) {
 	t.Helper()
 
-	hr := NewHealthRegistrar(tc.registryURL, tc.gcURL, tc.headless, nil, nil)
+	hr := NewHealthRegistrar(staticURL(tc.registryURL), tc.gcURL, tc.headless, nil, nil)
 	if tc.synced {
 		hr.MarkStateSynced()
 	}
@@ -78,7 +84,7 @@ func runReadyCase(t *testing.T, tc readyTestCase) {
 }
 
 func TestHealthHandlerAlwaysOK(t *testing.T) {
-	hr := NewHealthRegistrar("", "", false, nil, nil)
+	hr := NewHealthRegistrar(staticURL(""), "", false, nil, nil)
 
 	rec := httptest.NewRecorder()
 	hr.healthHandler(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
@@ -136,7 +142,7 @@ func TestReadyHandlerHeadlessDoesNotContactGroundControl(t *testing.T) {
 
 	registry := newStubRegistry(t)
 
-	hr := NewHealthRegistrar(registry.URL, gc.URL, true, nil, nil)
+	hr := NewHealthRegistrar(staticURL(registry.URL), gc.URL, true, nil, nil)
 	hr.MarkStateSynced()
 
 	rec := httptest.NewRecorder()
@@ -159,7 +165,7 @@ func TestReadyHandlerRegistryTLS(t *testing.T) {
 	defer registry.Close()
 
 	t.Run("bare client rejects self-signed cert", func(t *testing.T) {
-		hr := NewHealthRegistrar(registry.URL, "", true, nil, nil)
+		hr := NewHealthRegistrar(staticURL(registry.URL), "", true, nil, nil)
 		hr.MarkStateSynced()
 
 		rec := httptest.NewRecorder()
@@ -172,7 +178,7 @@ func TestReadyHandlerRegistryTLS(t *testing.T) {
 	})
 
 	t.Run("client trusting the CA succeeds", func(t *testing.T) {
-		hr := NewHealthRegistrar(registry.URL, "", true, registry.Client(), nil)
+		hr := NewHealthRegistrar(staticURL(registry.URL), "", true, registry.Client(), nil)
 		hr.MarkStateSynced()
 
 		rec := httptest.NewRecorder()
@@ -196,7 +202,7 @@ func TestReadyHandlerGCClientProvider(t *testing.T) {
 		provider := func(context.Context) (*http.Client, error) {
 			return &http.Client{Timeout: 2 * time.Second}, nil
 		}
-		hr := NewHealthRegistrar(registry.URL, gc.URL, false, nil, provider)
+		hr := NewHealthRegistrar(staticURL(registry.URL), gc.URL, false, nil, provider)
 		hr.MarkStateSynced()
 
 		rec := httptest.NewRecorder()
@@ -212,7 +218,7 @@ func TestReadyHandlerGCClientProvider(t *testing.T) {
 		provider := func(context.Context) (*http.Client, error) {
 			return nil, errors.New("spire unavailable")
 		}
-		hr := NewHealthRegistrar(registry.URL, gc.URL, false, nil, provider)
+		hr := NewHealthRegistrar(staticURL(registry.URL), gc.URL, false, nil, provider)
 		hr.MarkStateSynced()
 
 		rec := httptest.NewRecorder()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,13 +24,13 @@ type App struct {
 	Logger     *zerolog.Logger
 }
 
-func NewApp(router Router, ctx context.Context, logger *zerolog.Logger, registrars ...RouteRegistrar) *App {
+func NewApp(router Router, ctx context.Context, logger *zerolog.Logger, port string, registrars ...RouteRegistrar) *App {
 	return &App{
 		router:     router,
 		registrars: registrars,
 		ctx:        ctx,
 		Logger:     logger,
-		server:     &http.Server{Addr: ":9090", Handler: router, ReadHeaderTimeout: 10 * time.Second},
+		server:     &http.Server{Addr: port, Handler: router, ReadHeaderTimeout: 10 * time.Second},
 	}
 }
 
@@ -43,6 +43,7 @@ func (a *App) SetupRoutes() {
 func (a *App) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	a.router.ServeHTTP(w, r)
 }
+
 func (a *App) Start() error {
 	return a.server.ListenAndServe()
 }
@@ -52,8 +53,11 @@ func (a *App) Shutdown(ctx context.Context) error {
 }
 
 func (a *App) SetupServer(g *errgroup.Group) {
+	a.SetupRoutes()
+
 	g.Go(func() error {
-		a.Logger.Info().Msg("Starting server on :9090")
+		a.Logger.Info().Msgf("Starting server on %s", a.server.Addr)
+
 		if err := a.Start(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			return err
 		}

--- a/internal/state/registration_process.go
+++ b/internal/state/registration_process.go
@@ -16,8 +16,10 @@ import (
 	"github.com/rs/zerolog"
 )
 
-const ZeroTouchRegistrationRoute = "satellites/ztr"
-const ZeroTouchRegistrationEventName = "zero-touch-registration-event"
+const (
+	ZeroTouchRegistrationRoute     = "satellites/ztr"
+	ZeroTouchRegistrationEventName = "zero-touch-registration-event"
+)
 
 type ZtrProcess struct {
 	// Name is the name of the process
@@ -154,7 +156,7 @@ func (z *ZtrProcess) stop() {
 func registerSatellite(groundControlURL, path, token string, tlsCfg config.TLSConfig, useUnsecure bool, ctx context.Context) (config.StateConfig, error) {
 	ztrURL := fmt.Sprintf("%s/%s/%s", groundControlURL, path, token)
 
-	client, err := createHTTPClient(tlsCfg, useUnsecure)
+	client, err := CreateHTTPClient(tlsCfg, useUnsecure, 30*time.Second)
 	if err != nil {
 		return config.StateConfig{}, fmt.Errorf("failed to create HTTP client: %w", err)
 	}
@@ -185,11 +187,12 @@ func registerSatellite(groundControlURL, path, token string, tlsCfg config.TLSCo
 	return authResponse, nil
 }
 
-func createHTTPClient(tlsCfg config.TLSConfig, useUnsecure bool) (*http.Client, error) {
+// CreateHTTPClient builds an HTTP client honoring the satellite's TLS config.
+func CreateHTTPClient(tlsCfg config.TLSConfig, useUnsecure bool, timeout time.Duration) (*http.Client, error) {
 	transport := &http.Transport{
-		MaxIdleConns:        10,
-		IdleConnTimeout:     30 * time.Second,
-		DisableCompression:  true,
+		MaxIdleConns:       10,
+		IdleConnTimeout:    30 * time.Second,
+		DisableCompression: true,
 	}
 
 	if useUnsecure {
@@ -205,7 +208,6 @@ func createHTTPClient(tlsCfg config.TLSConfig, useUnsecure bool) (*http.Client, 
 			SkipVerify: tlsCfg.SkipVerify,
 			MinVersion: tls.VersionTLS12,
 		}
-
 		tlsConfig, err := satTLS.LoadClientTLSConfig(cfg)
 		if err != nil {
 			return nil, fmt.Errorf("load TLS config: %w", err)
@@ -215,6 +217,6 @@ func createHTTPClient(tlsCfg config.TLSConfig, useUnsecure bool) (*http.Client, 
 
 	return &http.Client{
 		Transport: transport,
-		Timeout:   30 * time.Second,
+		Timeout:   timeout,
 	}, nil
 }

--- a/internal/state/reporting_process.go
+++ b/internal/state/reporting_process.go
@@ -158,7 +158,7 @@ func (s *StatusReportingProcess) sendStatusReport(ctx context.Context, groundCon
 			return fmt.Errorf("create SPIFFE HTTP client: %w", err)
 		}
 	} else {
-		client, err = createHTTPClient(s.cm.GetTLSConfig(), s.cm.UseUnsecure())
+		client, err = CreateHTTPClient(s.cm.GetTLSConfig(), s.cm.UseUnsecure(), 30*time.Second)
 		if err != nil {
 			return fmt.Errorf("create HTTP client: %w", err)
 		}

--- a/internal/state/state_process.go
+++ b/internal/state/state_process.go
@@ -21,6 +21,7 @@ type FetchAndReplicateStateProcess struct {
 	mu                  sync.Mutex
 	stateFilePath       string
 	directDeliverer     *DirectDeliverer
+	onSyncSuccess       func()
 }
 
 // Define result types for channels
@@ -37,11 +38,12 @@ type ConfigFetcherResult struct {
 	Cancelled    bool
 }
 
-func NewFetchAndReplicateStateProcess(cm *config.ConfigManager, stateFilePath string, log *zerolog.Logger) *FetchAndReplicateStateProcess {
+func NewFetchAndReplicateStateProcess(cm *config.ConfigManager, stateFilePath string, onSyncSuccess func(), log *zerolog.Logger) *FetchAndReplicateStateProcess {
 	p := &FetchAndReplicateStateProcess{
 		name:          config.ReplicateStateJobName,
 		cm:            cm,
 		stateFilePath: stateFilePath,
+		onSyncSuccess: onSyncSuccess,
 	}
 
 	if stateFilePath != "" {
@@ -143,7 +145,15 @@ func (f *FetchAndReplicateStateProcess) Execute(ctx context.Context) error {
 		configFetcherResult <- result
 	}()
 
-	return f.collectResults(ctx, stateFetcherResults, configFetcherResult, len(f.stateMap), &log)
+	if err := f.collectResults(ctx, stateFetcherResults, configFetcherResult, len(f.stateMap), &log); err != nil {
+		return err
+	}
+
+	if f.onSyncSuccess != nil {
+		f.onSyncSuccess()
+	}
+
+	return nil
 }
 
 func (f *FetchAndReplicateStateProcess) updateStateMap(states []string) bool {


### PR DESCRIPTION
- Fixes: #240 

## Description
 Adds Kubernetes-style health probes to the satellite by wiring the previously scaffolded observability server (`internal/server/`) into satellite startup and implementing `/health` and `/ready`.

Started the observability HTTP server in `cmd/main.go` (it was scaffolded but never run) and added two health endpoints:

  - `GET /health` — liveness. Always returns `200`; just reports the process is running, with no dependency checks.
  - `GET /ready` — readiness. Returns `200` only when the local Zot registry is reachable, Ground Control is reachable (skipped in     headless mode), and the initial state sync has completed; otherwise `503`. Response:
    ```json
    {
      "status": "ready",
      "checks": {
        "registry": "ok",
        "ground_control": "ok",
        "state_sync": "ok"
      }
    }

-   added a --headless flag (HEADLESS env) that skips the Ground Control check in /ready.

## Check
### GC  unavailable
<img width="1536" height="103" alt="image" src="https://github.com/user-attachments/assets/96489c1d-46bf-4a31-9a4b-9c26031712ea" />

### Zot unavailable
<img width="1568" height="104" alt="image" src="https://github.com/user-attachments/assets/a1a14521-3e9f-40e5-b30e-0a11e764d685" />

## With SPIFFE enabled
### SPIRE up + GC reachable + first sync done
<img width="1309" height="78" alt="image" src="https://github.com/user-attachments/assets/3e0a2064-6aa6-4200-97ac-e8ed5b36c84d" />

### SPIRE agent stopped before the satellite started
<img width="1500" height="77" alt="image" src="https://github.com/user-attachments/assets/1b93374e-4e42-417f-9e9e-8be340ca087f" />



<!-- Add any other context about the PR here. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Headless mode via CLI flag or env var.
  * Health (/health) and readiness (/ready) endpoints reporting registry, ground-control, and initial state-sync; readiness skips ground-control when headless.
  * Observability server (debug, metrics, health) on a configurable port (default 9091).
  * State-sync now signals readiness once initial replication completes.

* **Tests**
  * Expanded unit tests for health/readiness scenarios, TLS handling, and headless behavior.

* **Chores**
  * HTTP client creation made configurable (timeout/behavior) for registration and reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/container-registry/harbor-satellite/pull/463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->