### PR TITLE
fix: default registry data dir to XDG-compliant paths

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -70,7 +70,10 @@ graph TB
 
 ## Registry Data Directory
 
-The satellite stores registry data in a configurable location. By default, it uses a `zot` subdirectory inside the configuration directory (`~/.config/satellite/zot`).
+The satellite stores registry data in a configurable location. The default follows XDG conventions:
+
+- **Root / system service:** `/var/lib/satellite/registry`
+- **Non-root users:** `$XDG_DATA_HOME/satellite/registry` if `XDG_DATA_HOME` is set, otherwise `~/.local/share/satellite/registry`
 
 You can override the storage location using:
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -75,7 +75,7 @@ func main() {
 	flag.StringVar(&opts.RegistryUsername, "registry-username", "", "External registry username")
 	flag.StringVar(&opts.RegistryPassword, "registry-password", "", "External registry password")
 	flag.StringVar(&opts.ConfigDir, "config-dir", "", "Configuration directory path (default: ~/.config/satellite)")
-	flag.StringVar(&opts.RegistryDataDir, "registry-data-dir", "", "Registry data directory (overrides default storage path derived from config-dir)")
+	flag.StringVar(&opts.RegistryDataDir, "registry-data-dir", "", "Registry data directory (overrides the XDG/system default; see QUICKSTART.md)")
 	flag.StringVar(&shutdownTimeout, "shutdown-timeout", "", "Graceful shutdown timeout (e.g., '30s'). Defaults to SHUTDOWN_TIMEOUT env var or 30s")
 	flag.BoolVar(&opts.NoRegistryFallback, "no-registry-fallback", false, "Disable all CRI registry fallback configuration")
 	flag.BoolVar(&opts.FallbackOnly, "fallback-only", false, "Apply CRI registry fallback configs and exit without starting satellite")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -156,12 +156,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	zotStorageDir, err := config.ResolveRegistryDataDir(opts.RegistryDataDir)
-	if err != nil {
-		fmt.Printf("Error resolving registry data directory: %v\n", err)
-		os.Exit(1)
+	// Skip when the embedded Zot won't run: --byo-registry uses an external
+	// registry, --fallback-only just applies CRI configs and exits.
+	if !opts.BYORegistry && !opts.FallbackOnly {
+		zotStorageDir, err := config.ResolveRegistryDataDir(opts.RegistryDataDir)
+		if err != nil {
+			fmt.Printf("Error resolving registry data directory: %v\n", err)
+			os.Exit(1)
+		}
+		pathConfig.ZotStorageDir = zotStorageDir
 	}
-	pathConfig.ZotStorageDir = zotStorageDir
 
 	// For --fallback-only mode, relax token/gc-url requirements
 	if !opts.FallbackOnly {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -156,10 +156,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Override ZotStorageDir if --registry-data-dir flag or env var is set
-	if opts.RegistryDataDir != "" {
-		pathConfig.ZotStorageDir = opts.RegistryDataDir
+	zotStorageDir, err := config.ResolveRegistryDataDir(opts.RegistryDataDir)
+	if err != nil {
+		fmt.Printf("Error resolving registry data directory: %v\n", err)
+		os.Exit(1)
 	}
+	pathConfig.ZotStorageDir = zotStorageDir
 
 	// For --fallback-only mode, relax token/gc-url requirements
 	if !opts.FallbackOnly {

--- a/config.example.json
+++ b/config.example.json
@@ -34,7 +34,7 @@
   "zot_config": {
     "distSpecVersion": "1.1.0",
     "storage": {
-      "rootDirectory": "./zot"
+      "rootDirectory": ""
     },
     "http": {
       "address": "0.0.0.0",

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -24,11 +24,7 @@ const DefaultHeartbeatCronExpr string = "@every 00h00m30s"
 
 const BringOwnRegistry bool = false
 
-// DefaultZotConfigJSON is the fallback Zot configuration used when none is
-// supplied. The storage.rootDirectory value here is a placeholder; at runtime
-// BuildZotConfigWithStoragePath replaces it with the path returned by
-// ResolveRegistryDataDir (honoring --registry-data-dir, REGISTRY_DATA_DIR, or
-// the XDG-compliant default).
+// storage.rootDirectory is a placeholder; overridden at runtime by BuildZotConfigWithStoragePath.
 const DefaultZotConfigJSON = `{
   "distSpecVersion": "1.1.0",
   "storage": {

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -24,6 +24,11 @@ const DefaultHeartbeatCronExpr string = "@every 00h00m30s"
 
 const BringOwnRegistry bool = false
 
+// DefaultZotConfigJSON is the fallback Zot configuration used when none is
+// supplied. The storage.rootDirectory value here is a placeholder; at runtime
+// BuildZotConfigWithStoragePath replaces it with the path returned by
+// ResolveRegistryDataDir (honoring --registry-data-dir, REGISTRY_DATA_DIR, or
+// the XDG-compliant default).
 const DefaultZotConfigJSON = `{
   "distSpecVersion": "1.1.0",
   "storage": {

--- a/pkg/config/paths.go
+++ b/pkg/config/paths.go
@@ -65,19 +65,15 @@ func DefaultConfigDir() (string, error) {
 	return filepath.Join(configDir, "satellite"), nil
 }
 
-// geteuid is a seam so tests can exercise the root branch without running as root.
+// Test seam for the root branch in DefaultRegistryDataDir.
 //
-//nolint:gochecknoglobals // function-typed test seam, not mutable state
+//nolint:gochecknoglobals // function-typed test seam
 var geteuid = os.Geteuid
 
-// rootRegistryDataDir is the default registry storage directory when running
-// as root or a system service.
 const rootRegistryDataDir = "/var/lib/satellite/registry"
 
-// DefaultRegistryDataDir returns the default registry storage directory:
-//   - /var/lib/satellite/registry when running as root (euid 0)
-//   - $XDG_DATA_HOME/satellite/registry when XDG_DATA_HOME is set
-//   - ~/.local/share/satellite/registry otherwise
+// DefaultRegistryDataDir returns /var/lib/satellite/registry for root,
+// $XDG_DATA_HOME/satellite/registry when set, else ~/.local/share/satellite/registry.
 func DefaultRegistryDataDir() (string, error) {
 	if geteuid() == 0 {
 		return rootRegistryDataDir, nil
@@ -95,10 +91,8 @@ func DefaultRegistryDataDir() (string, error) {
 	return filepath.Join(home, ".local", "share", "satellite", "registry"), nil
 }
 
-// ResolveRegistryDataDir returns the absolute, ensured-writable registry data
-// directory. If override is non-empty it wins; otherwise DefaultRegistryDataDir
-// is used. The chosen path is tilde-expanded, made absolute, and created if
-// missing.
+// ResolveRegistryDataDir picks override if non-empty, else DefaultRegistryDataDir,
+// then expands, absolutizes, and ensures the directory.
 func ResolveRegistryDataDir(override string) (string, error) {
 	dir := override
 	if dir == "" {

--- a/pkg/config/paths.go
+++ b/pkg/config/paths.go
@@ -65,6 +65,67 @@ func DefaultConfigDir() (string, error) {
 	return filepath.Join(configDir, "satellite"), nil
 }
 
+// geteuid is a seam so tests can exercise the root branch without running as root.
+//
+//nolint:gochecknoglobals // function-typed test seam, not mutable state
+var geteuid = os.Geteuid
+
+// rootRegistryDataDir is the default registry storage directory when running
+// as root or a system service.
+const rootRegistryDataDir = "/var/lib/satellite/registry"
+
+// DefaultRegistryDataDir returns the default registry storage directory:
+//   - /var/lib/satellite/registry when running as root (euid 0)
+//   - $XDG_DATA_HOME/satellite/registry when XDG_DATA_HOME is set
+//   - ~/.local/share/satellite/registry otherwise
+func DefaultRegistryDataDir() (string, error) {
+	if geteuid() == 0 {
+		return rootRegistryDataDir, nil
+	}
+
+	if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" {
+		return filepath.Join(xdg, "satellite", "registry"), nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("get home directory: %w", err)
+	}
+
+	return filepath.Join(home, ".local", "share", "satellite", "registry"), nil
+}
+
+// ResolveRegistryDataDir returns the absolute, ensured-writable registry data
+// directory. If override is non-empty it wins; otherwise DefaultRegistryDataDir
+// is used. The chosen path is tilde-expanded, made absolute, and created if
+// missing.
+func ResolveRegistryDataDir(override string) (string, error) {
+	dir := override
+	if dir == "" {
+		def, err := DefaultRegistryDataDir()
+		if err != nil {
+			return "", err
+		}
+		dir = def
+	}
+
+	expanded, err := expandPath(dir)
+	if err != nil {
+		return "", fmt.Errorf("expand registry data directory path: %w", err)
+	}
+
+	abs, err := filepath.Abs(expanded)
+	if err != nil {
+		return "", fmt.Errorf("resolve absolute registry data directory path: %w", err)
+	}
+
+	if err := ensureDir(abs); err != nil {
+		return "", err
+	}
+
+	return abs, nil
+}
+
 // ResolvePathConfig validates and resolves all storage paths.
 // It expands ~ in configDir, creates the directory structure,
 // and returns absolute paths for all configuration files.
@@ -88,7 +149,6 @@ func ResolvePathConfig(configDir string) (*PathConfig, error) {
 		ConfigFile:     filepath.Join(expanded, "config.json"),
 		PrevConfigFile: filepath.Join(expanded, "prev_config.json"),
 		ZotTempConfig:  filepath.Join(expanded, "zot-hot.json"),
-		ZotStorageDir:  filepath.Join(expanded, "zot"),
 		StateFile:      filepath.Join(expanded, "state.json"),
 	}, nil
 }

--- a/pkg/config/paths.go
+++ b/pkg/config/paths.go
@@ -65,21 +65,22 @@ func DefaultConfigDir() (string, error) {
 	return filepath.Join(configDir, "satellite"), nil
 }
 
-// Test seam for the root branch in DefaultRegistryDataDir.
-//
-//nolint:gochecknoglobals // function-typed test seam
-var geteuid = os.Geteuid
-
 const rootRegistryDataDir = "/var/lib/satellite/registry"
 
 // DefaultRegistryDataDir returns /var/lib/satellite/registry for root,
 // $XDG_DATA_HOME/satellite/registry when set, else ~/.local/share/satellite/registry.
 func DefaultRegistryDataDir() (string, error) {
-	if geteuid() == 0 {
+	return defaultRegistryDataDir(os.Geteuid)
+}
+
+func defaultRegistryDataDir(uidLookup func() int) (string, error) {
+	if uidLookup() == 0 {
 		return rootRegistryDataDir, nil
 	}
 
-	if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" {
+	// Per the XDG Base Directory Specification, relative XDG_DATA_HOME values
+	// are ignored.
+	if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" && filepath.IsAbs(xdg) {
 		return filepath.Join(xdg, "satellite", "registry"), nil
 	}
 

--- a/pkg/config/paths_test.go
+++ b/pkg/config/paths_test.go
@@ -230,6 +230,10 @@ func TestResolveRegistryDataDir(t *testing.T) {
 	})
 
 	t.Run("non-writable override returns error", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("root bypasses chmod permissions")
+		}
+
 		base := t.TempDir()
 		require.NoError(t, os.Chmod(base, 0500))
 		t.Cleanup(func() { _ = os.Chmod(base, 0700) })

--- a/pkg/config/paths_test.go
+++ b/pkg/config/paths_test.go
@@ -155,9 +155,88 @@ func TestResolvePathConfig(t *testing.T) {
 			require.Equal(t, filepath.Join(pathConfig.ConfigDir, "config.json"), pathConfig.ConfigFile)
 			require.Equal(t, filepath.Join(pathConfig.ConfigDir, "prev_config.json"), pathConfig.PrevConfigFile)
 			require.Equal(t, filepath.Join(pathConfig.ConfigDir, "zot-hot.json"), pathConfig.ZotTempConfig)
-			require.Equal(t, filepath.Join(pathConfig.ConfigDir, "zot"), pathConfig.ZotStorageDir)
+			require.Empty(t, pathConfig.ZotStorageDir, "ZotStorageDir is set by ResolveRegistryDataDir, not ResolvePathConfig")
 		})
 	}
+}
+
+func TestDefaultRegistryDataDir(t *testing.T) {
+	origGeteuid := geteuid
+	t.Cleanup(func() { geteuid = origGeteuid })
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	t.Run("root returns /var/lib path", func(t *testing.T) {
+		geteuid = func() int { return 0 }
+		t.Setenv("XDG_DATA_HOME", "/should/be/ignored")
+
+		got, err := DefaultRegistryDataDir()
+		require.NoError(t, err)
+		require.Equal(t, "/var/lib/satellite/registry", got)
+	})
+
+	t.Run("non-root with XDG_DATA_HOME set", func(t *testing.T) {
+		geteuid = func() int { return 1000 }
+		t.Setenv("XDG_DATA_HOME", "/tmp/xdg-data")
+
+		got, err := DefaultRegistryDataDir()
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join("/tmp/xdg-data", "satellite", "registry"), got)
+	})
+
+	t.Run("non-root without XDG_DATA_HOME falls back to ~/.local/share", func(t *testing.T) {
+		geteuid = func() int { return 1000 }
+		t.Setenv("XDG_DATA_HOME", "")
+
+		got, err := DefaultRegistryDataDir()
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(home, ".local", "share", "satellite", "registry"), got)
+	})
+}
+
+func TestResolveRegistryDataDir(t *testing.T) {
+	origGeteuid := geteuid
+	t.Cleanup(func() { geteuid = origGeteuid })
+	geteuid = func() int { return 1000 }
+
+	t.Run("override is used and created", func(t *testing.T) {
+		override := filepath.Join(t.TempDir(), "override-registry")
+
+		got, err := ResolveRegistryDataDir(override)
+		require.NoError(t, err)
+		require.Equal(t, override, got)
+		require.DirExists(t, override)
+	})
+
+	t.Run("empty override falls back to default and creates it", func(t *testing.T) {
+		xdg := t.TempDir()
+		t.Setenv("XDG_DATA_HOME", xdg)
+
+		got, err := ResolveRegistryDataDir("")
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(xdg, "satellite", "registry"), got)
+		require.DirExists(t, got)
+	})
+
+	t.Run("tilde override is expanded", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		got, err := ResolveRegistryDataDir("~/data/zot")
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(home, "data", "zot"), got)
+		require.DirExists(t, got)
+	})
+
+	t.Run("non-writable override returns error", func(t *testing.T) {
+		base := t.TempDir()
+		require.NoError(t, os.Chmod(base, 0500))
+		t.Cleanup(func() { _ = os.Chmod(base, 0700) })
+
+		_, err := ResolveRegistryDataDir(filepath.Join(base, "child"))
+		require.Error(t, err)
+	})
 }
 
 func TestBuildZotConfigWithStoragePath(t *testing.T) {

--- a/pkg/config/paths_test.go
+++ b/pkg/config/paths_test.go
@@ -161,45 +161,46 @@ func TestResolvePathConfig(t *testing.T) {
 }
 
 func TestDefaultRegistryDataDir(t *testing.T) {
-	origGeteuid := geteuid
-	t.Cleanup(func() { geteuid = origGeteuid })
-
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
 
+	asRoot := func() int { return 0 }
+	asUser := func() int { return 1000 }
+
 	t.Run("root returns /var/lib path", func(t *testing.T) {
-		geteuid = func() int { return 0 }
 		t.Setenv("XDG_DATA_HOME", "/should/be/ignored")
 
-		got, err := DefaultRegistryDataDir()
+		got, err := defaultRegistryDataDir(asRoot)
 		require.NoError(t, err)
 		require.Equal(t, "/var/lib/satellite/registry", got)
 	})
 
 	t.Run("non-root with XDG_DATA_HOME set", func(t *testing.T) {
-		geteuid = func() int { return 1000 }
 		t.Setenv("XDG_DATA_HOME", "/tmp/xdg-data")
 
-		got, err := DefaultRegistryDataDir()
+		got, err := defaultRegistryDataDir(asUser)
 		require.NoError(t, err)
 		require.Equal(t, filepath.Join("/tmp/xdg-data", "satellite", "registry"), got)
 	})
 
 	t.Run("non-root without XDG_DATA_HOME falls back to ~/.local/share", func(t *testing.T) {
-		geteuid = func() int { return 1000 }
 		t.Setenv("XDG_DATA_HOME", "")
 
-		got, err := DefaultRegistryDataDir()
+		got, err := defaultRegistryDataDir(asUser)
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(home, ".local", "share", "satellite", "registry"), got)
+	})
+
+	t.Run("relative XDG_DATA_HOME is ignored per XDG spec", func(t *testing.T) {
+		t.Setenv("XDG_DATA_HOME", "relative/path")
+
+		got, err := defaultRegistryDataDir(asUser)
 		require.NoError(t, err)
 		require.Equal(t, filepath.Join(home, ".local", "share", "satellite", "registry"), got)
 	})
 }
 
 func TestResolveRegistryDataDir(t *testing.T) {
-	origGeteuid := geteuid
-	t.Cleanup(func() { geteuid = origGeteuid })
-	geteuid = func() int { return 1000 }
-
 	t.Run("override is used and created", func(t *testing.T) {
 		override := filepath.Join(t.TempDir(), "override-registry")
 


### PR DESCRIPTION
- Fixes: #230 

## Description
PR #260 added --registry-data-dir and REGISTRY_DATA_DIR, but the default storage location still derived from the config dir (~/.config/satellite/zot). This PR finishes the remaining checklist items from issue #230 by replacing that default with
XDG-compliant paths:
  - Root / system service: `/var/lib/satellite/registry`
  - XDG_DATA_HOME set: `$XDG_DATA_HOME/satellite/registry`
  - Non-root fallback: `~/.local/share/satellite/registry`

Also updating docs.

<!-- Add any other context about the PR here. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Registry data storage now defaults to /var/lib/satellite/registry for root and $XDG_DATA_HOME/satellite/registry (or ~/.local/share/satellite/registry) for non-root; CLI flag and REGISTRY_DATA_DIR still override (flag > env > default).

* **Documentation**
  * Quickstart updated with new defaults and override instructions; CLI help text clarified to reflect the XDG/system default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/container-registry/harbor-satellite/pull/473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->