### PR TITLE
chore(ci): Update the actions and workflows

### DIFF
--- a/.github/actions/publish-and-sign/action.yaml
+++ b/.github/actions/publish-and-sign/action.yaml
@@ -42,7 +42,7 @@ runs:
         docker buildx use remote
 
     - name: Install Cosign
-      uses: sigstore/cosign-installer@v4.1.0
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
     - name: Check Env Variables
       shell: bash

--- a/.github/actions/publish-and-sign/action.yaml
+++ b/.github/actions/publish-and-sign/action.yaml
@@ -25,7 +25,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: "1.26.3"
         cache: false

--- a/.github/actions/publish-and-sign/action.yaml
+++ b/.github/actions/publish-and-sign/action.yaml
@@ -41,7 +41,7 @@ runs:
         docker buildx use remote
 
     - name: Install Cosign
-      uses: sigstore/cosign-installer@v3.7.0
+      uses: sigstore/cosign-installer@v4.1.0
 
     - name: Check Env Variables
       shell: bash

--- a/.github/actions/publish-and-sign/action.yaml
+++ b/.github/actions/publish-and-sign/action.yaml
@@ -6,28 +6,28 @@ inputs:
     description: 'Tags for the image, e.g. "latest, v1.0.0"'
     required: true
   GITHUB_TOKEN:
-    description: 'GitHub token'
+    description: "GitHub token"
     required: true
   REGISTRY_PASSWORD:
-    description: 'Registry password'
+    description: "Registry password"
     required: true
   REGISTRY_ADDRESS:
-    description: 'Registry address'
+    description: "Registry address"
     required: true
   REGISTRY_USERNAME:
-    description: 'Registry username'
+    description: "Registry username"
     required: true
   PROJECT_NAME:
-    description: 'Project Name'
+    description: "Project Name"
     required: true
 
 runs:
   using: "composite"
   steps:
     - name: Setup Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
-        go-version: "1.24.11"
+        go-version: "1.26.3"
 
     - name: Install Task
       uses: arduino/setup-task@v2

--- a/.github/actions/publish-and-sign/action.yaml
+++ b/.github/actions/publish-and-sign/action.yaml
@@ -28,6 +28,7 @@ runs:
       uses: actions/setup-go@v6
       with:
         go-version: "1.26.3"
+        cache: false
 
     - name: Install Task
       uses: arduino/setup-task@v2

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -10,4 +10,4 @@ jobs:
     runs-on: container-registry
     steps:
       - name: Label PR
-        uses: actions/labeler@v6
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-- pull_request_target
+  - pull_request_target
 
 jobs:
   labeler:
@@ -9,5 +9,5 @@ jobs:
       pull-requests: write
     runs-on: container-registry
     steps:
-    - name: Label PR
-      uses: actions/labeler@v5
+      - name: Label PR
+        uses: actions/labeler@v6

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,12 +14,12 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.24.11"
+          go-version: "1.26.3"
           cache: false
 
       - name: Install Task
@@ -28,7 +28,10 @@ jobs:
           version: 3.x
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0.2
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: latest
+          install-only: true
 
       - name: Run golangci-lint
         run: task lint-report

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,16 +14,16 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26.3"
           cache: false
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,7 +28,7 @@ jobs:
           version: 3.x
 
       - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
         with:
           version: latest
           install-only: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,7 +28,7 @@ jobs:
           version: 3.x
 
       - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: v2.12
           install-only: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
         with:
-          version: latest
+          version: v2.12
           install-only: true
 
       - name: Run golangci-lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,6 +69,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.26.3"
+          cache: false
 
       - name: Install Task
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Install Syft
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
-        uses: anchore/sbom-action/download-syft@v0.24.0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610
 
       - name: Create Release
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Checkout repo
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main')
-        uses: actions/checkout@v6
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: Checkout repo
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
-        uses: actions/checkout@v6
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 
@@ -66,14 +66,14 @@ jobs:
 
       - name: Setup Go
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26.3"
           cache: false
 
       - name: Install Task
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,13 +79,13 @@ jobs:
 
       - name: Install GoReleaser
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           install-only: true
 
       - name: Install Syft
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
-        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - name: Create Release
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Checkout repo
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main')
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: Checkout repo
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -66,9 +66,9 @@ jobs:
 
       - name: Setup Go
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.24.11"
+          go-version: "1.26.3"
 
       - name: Install Task
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
@@ -78,14 +78,13 @@ jobs:
 
       - name: Install GoReleaser
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           install-only: true
-          version: v2.9.0
 
       - name: Install Syft
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
-        uses: anchore/sbom-action/download-syft@v0.22.2
+        uses: anchore/sbom-action/download-syft@v0.24.0
 
       - name: Create Release
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -97,6 +97,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           install-only: true
+          version: v2.16.0
 
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@v0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,7 @@ jobs:
           cache: false
 
       - name: Run govulncheck (report)
-        uses: golang/govulncheck-action@v1
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee
         continue-on-error: true
         with:
           repo-checkout: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.26.3"
-          cache: true
+          cache: false
 
       - name: Run unit tests for satellite (with coverage)
         run: |
@@ -156,6 +156,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.26.3"
+          cache: false
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -176,6 +177,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.26.3"
+          cache: false
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -196,6 +198,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.26.3"
+          cache: false
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,7 @@ jobs:
           cache: false
 
       - name: Run govulncheck (report)
-        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         continue-on-error: true
         with:
           repo-checkout: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,9 +17,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.24.11"
+          go-version: "1.26.3"
           cache: true
 
       - name: Run unit tests for satellite (with coverage)
@@ -44,26 +44,26 @@ jobs:
     runs-on: container-registry
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.24.11"
+          go-version: "1.26.3"
           cache: false
 
-      - name: Install Task
-        uses: arduino/setup-task@v2
+      - name: Run govulncheck (report)
+        uses: golang/govulncheck-action@v1
+        continue-on-error: true
         with:
-          version: 3.x
-
-      - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
-
-      - name: Run Vulnerability Check
-        run: task vuln-report
+          repo-checkout: false
+          go-version-input: "1.26.3"
+          go-package: ./...
+          output-format: text
+          output-file: vulnerability-check.report
+          cache: false
 
       - name: Generate vulnerability summary
         run: |
@@ -78,14 +78,14 @@ jobs:
     runs-on: container-registry
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.24.11"
+          go-version: "1.26.3"
           cache: false
 
       - name: Install Task
@@ -94,10 +94,9 @@ jobs:
           version: 3.x
 
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           install-only: true
-          version: v2.9.0
 
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@v0
@@ -109,12 +108,12 @@ jobs:
     runs-on: container-registry
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.24.11"
+          go-version: "1.26.3"
           cache: false
 
       - name: Install Task
@@ -129,12 +128,12 @@ jobs:
     runs-on: container-registry
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.24.11"
+          go-version: "1.26.3"
           cache: false
 
       - name: Install Task
@@ -150,12 +149,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.24.11"
+          go-version: "1.26.3"
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -170,12 +169,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.24.11"
+          go-version: "1.26.3"
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -190,12 +189,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.24.11"
+          go-version: "1.26.3"
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26.3"
           cache: false
@@ -44,12 +44,12 @@ jobs:
     runs-on: container-registry
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26.3"
           cache: false
@@ -78,29 +78,29 @@ jobs:
     runs-on: container-registry
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26.3"
           cache: false
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
 
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           install-only: true
           version: v2.16.0
 
       - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - name: Test Release
         run: task snapshot
@@ -109,16 +109,16 @@ jobs:
     runs-on: container-registry
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26.3"
           cache: false
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
 
@@ -129,16 +129,16 @@ jobs:
     runs-on: container-registry
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26.3"
           cache: false
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
 
@@ -150,16 +150,16 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26.3"
           cache: false
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
 
@@ -171,16 +171,16 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26.3"
           cache: false
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
 
@@ -192,16 +192,16 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26.3"
           cache: false
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
 


### PR DESCRIPTION
- Fixes: #477 

## Description

This PR updates the versions of the actions used in the workflows as suggested in the issue.

## Additional context

The actions in the workflows can be updated with the following versions.

| Action | Older Version | Newer Version | Full length SHA |
|--------|--------------|---------------|-|
| [`actions/labeler`](https://github.com/marketplace/actions/labeler) | `v5` | `v6.1.0` | `f27b608878404679385c85cfa523b85ccb86e213`
| [`actions/checkout`](https://github.com/marketplace/actions/checkout) | `v4` | `v5.0.1` | `93cb6efe18208431cddfb8368fd83d5badbf9bfd`
| [`actions/setup-go`](https://github.com/marketplace/actions/setup-go-environment) | `v5` | `v6.4.0` | `4a3601121dd01d1626a1e23e37211e3254c1c06c`
| [`arduino/setup-task`](https://github.com/marketplace/actions/arduino-setup-task) | `v2.0.0` | `v2.0.0` | `b91d5d2c96a56797b48ac1e0e89220bf64044611`
| [`goreleaser/goreleaser-action`](https://github.com/marketplace/actions/goreleaser-action) | `v6` | `v7.2.2` | `5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 `
| [`anchore/sbom-action/download-syft`](https://github.com/marketplace/actions/anchore-sbom-action) | `v0.22.2` | `v0.24.0` | `e22c389904149dbc22b58101806040fa8d37a610`
| [`sigstore/cosign-installer`](https://github.com/marketplace/actions/cosign-installer) | `v3.7.0` | `v4.1.0` | `6f9f17788090df1f26f669e9d70d6ae9567deba6`


Also the following actions are **added** to the workflows.

| Action | Version | Full length SHA |
|-|-|-|
[`golangci/golangci-lint-action`](https://github.com/golangci/golangci-lint-action) | `v9.2.1` | `82606bf257cbaff209d206a39f5134f0cfbfd2ee`
[`govulncheck-action`](https://github.com/golang/govulncheck-action) | `v1.0.4` | `b625fbe08f3bccbe446d94fbf87fcc875a4f50ee`

### Changes Made
1. `golangci-lint`
```diff
-      - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0.2
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
+        with:
+          version: v2.12
+          install-only: true
```
2. `govulncheck`
```diff
-      - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Run govulncheck (report)
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        continue-on-error: true
+        with:
+          repo-checkout: false
+          go-version-input: "1.26.3"
+          go-package: ./...
+          output-format: text
+          output-file: vulnerability-check.report
+          cache: false
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized Go toolchain to 1.26.3 and upgraded GitHub Actions across CI/CD workflows.
  * Updated lint, test, release, and labeler pipelines to newer action/tool versions and improved vulnerability scanning flows.
  * Refined tooling pins for signing, SBOM, linting, and release utilities.
  * Publish-and-sign pipeline now requires registry credentials, a project name, and an explicit token as inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->