### PR TITLE
fix(ci): provide envsubst for cosign installer

### DIFF
--- a/.github/actions/publish-and-sign/action.yaml
+++ b/.github/actions/publish-and-sign/action.yaml
@@ -41,6 +41,31 @@ runs:
         docker buildx inspect remote || docker buildx create --name remote --driver remote tcp://buildkitd.github-runners.svc:1234
         docker buildx use remote
 
+    - name: Provide envsubst for Cosign installer
+      shell: bash
+      run: |
+        if command -v envsubst >/dev/null 2>&1; then
+          exit 0
+        fi
+
+        mkdir -p "$RUNNER_TEMP/bin"
+        cat > "$RUNNER_TEMP/bin/envsubst" <<'EOF'
+        #!/usr/bin/env python3
+        import os
+        import re
+        import sys
+
+        pattern = re.compile(r"\$(\w+)|\$\{([^}]+)\}")
+
+        def replace(match):
+            name = match.group(1) or match.group(2)
+            return os.environ.get(name, "")
+
+        sys.stdout.write(pattern.sub(replace, sys.stdin.read()))
+        EOF
+        chmod +x "$RUNNER_TEMP/bin/envsubst"
+        echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+
     - name: Install Cosign
       uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 

--- a/.github/actions/publish-and-sign/action.yaml
+++ b/.github/actions/publish-and-sign/action.yaml
@@ -55,7 +55,7 @@ runs:
         import re
         import sys
 
-        pattern = re.compile(r"\$(\w+)|\$\{([^}]+)\}")
+        pattern = re.compile(r"\$([A-Za-z_][A-Za-z0-9_]*)|\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
 
         def replace(match):
             name = match.group(1) or match.group(2)


### PR DESCRIPTION
## Summary
- add an envsubst fallback before running sigstore/cosign-installer
- keep the publish-and-sign action working on self-hosted runners without gettext installed

## Verification
- go test ./...
- go test ./... (ground-control)
- git diff --check
- verified the fallback expands `/var/home/bupd/.cosign`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the publish-and-sign action to automatically handle missing system dependencies, ensuring artifact publishing and signing operations work reliably across all build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->