### PR TITLE
tests: Add PARSEC hardware identity e2e verification

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -202,3 +202,26 @@ jobs:
 
       - name: Test SPIFFE Join Token E2E
         run: task e2e-spiffe
+
+  e2e-parsec-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26.3"
+          cache: false
+
+      - name: Install Task
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        with:
+          version: 3.x
+
+      - name: Test PARSEC Hardware Identity E2E
+        run: task e2e-parsec

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -93,6 +93,7 @@ tasks:
       - task: _e2e:test
       - task: _e2e:test-byo
       - task: _e2e:test-spiffe
+      - task: _e2e:test-parsec
 
   e2e-test:
     desc: Run main E2E test
@@ -108,6 +109,11 @@ tasks:
     desc: Run SPIFFE E2E test
     cmds:
       - task: _e2e:test-spiffe
+
+  e2e-parsec:
+    desc: Run PARSEC hardware identity E2E test
+    cmds:
+      - task: _e2e:test-parsec
 
   e2e-crash-recovery:
     desc: Run crash recovery E2E test

--- a/taskfiles/e2e.yml
+++ b/taskfiles/e2e.yml
@@ -65,9 +65,29 @@ tasks:
   start-parsec-daemon:
     desc: Start PARSEC Hardware Simulator
     cmds:
-      - echo "Starting PARSEC Daemon..."
-      - docker run -d --name parsec-daemon -u root --network harbor-e2e --privileged -v parsec-socket:/run/parsec ghcr.io/parallaxsecond/parsec-quickstart:latest bash -c "rm -f /run/parsec/parsec.sock && chmod 777 /run/parsec && sed -i 's|\"./parsec.sock\"|\"/run/parsec/parsec.sock\"|g' config.toml && parsec"
-      - sleep 5
+      - |
+        echo "Starting PARSEC Daemon..."
+        docker run -d --name parsec-daemon \
+          -u root \
+          --network harbor-e2e \
+          --privileged \
+          -v parsec-socket:/run/parsec \
+          ghcr.io/parallaxsecond/parsec-quickstart:latest \
+          bash -c "rm -f /run/parsec/parsec.sock && chmod 777 /run/parsec && sed -i 's|\"./parsec.sock\"|\"/run/parsec/parsec.sock\"|g' config.toml && parsec"
+
+        echo "Waiting for PARSEC socket..."
+        for i in $(seq 1 30); do
+          if docker run --rm -v parsec-socket:/run/parsec alpine:3.22 test -S /run/parsec/parsec.sock; then
+            echo "PARSEC socket is ready"
+            exit 0
+          fi
+          echo "Waiting for PARSEC socket... ($i/30)"
+          sleep 1
+        done
+
+        echo "ERROR: PARSEC daemon did not create /run/parsec/parsec.sock"
+        docker logs parsec-daemon
+        exit 1
 
   register-and-run-parsec-satellite:
     desc: Register satellite and run with PARSEC enabled
@@ -90,6 +110,11 @@ tasks:
             "config_name": "test-config"
           }')
         TOKEN=$(echo "$RESPONSE" | grep -o '"token":"[^"]*"' | cut -d'"' -f4)
+        if [ -z "$TOKEN" ]; then
+          echo "ERROR: Ground Control did not return a satellite token."
+          echo "$RESPONSE"
+          exit 1
+        fi
 
         echo "Building satellite with PARSEC tags..."
         docker build --build-arg GO_TAGS=parsec -t satellite:e2e -f Dockerfile .
@@ -109,33 +134,24 @@ tasks:
         sleep 5
 
   verify-parsec:
-    desc: Verify PARSEC hardware key generation
+    desc: Verify PARSEC hardware key generation and signing
     cmds:
       - |
-        # The earlier version of this check grepped the satellite logs for a
-        # `keyattributes: key_type:{rsa_key_pair` line emitted by a leftover
-        # `fmt.Printf` debug statement in parsec-client-go. That debug print
-        # is a bug (removed under PR #468 fixes) and the test should not
-        # depend on it. Instead, verify the key directly via parsec-tool:
-        # it lists the keys the daemon actually holds, which is the
-        # functional truth we care about.
-        echo "Verifying satellite-identity-key exists in PARSEC..."
-        if docker exec -e PARSEC_SERVICE_ENDPOINT="unix:///run/parsec/parsec.sock" parsec-daemon parsec-tool list-keys | grep -q "satellite-identity-key"; then
-          echo "SUCCESS: Key successfully verified in PARSEC secure memory!"
-          docker exec -e PARSEC_SERVICE_ENDPOINT="unix:///run/parsec/parsec.sock" parsec-daemon parsec-tool list-keys
-        else
-          echo "ERROR: satellite-identity-key not found in PARSEC."
-          docker logs satellite
-          exit 1
-        fi
-
         echo "Verifying satellite process is running (did not halt on startup)..."
         if ! docker ps --filter "name=^satellite$" --filter "status=running" --format '{{`{{.Names}}`}}' | grep -q satellite; then
           echo "ERROR: satellite container is not running."
           docker logs satellite
           exit 1
         fi
-        echo "SUCCESS: Satellite is running with PARSEC hardware identity."
+        echo "Verifying PARSEC identity key with sign/verify round-trip..."
+        docker run --rm \
+          --network harbor-e2e \
+          -v "$PWD:/workspace" \
+          -v parsec-socket:/run/parsec \
+          -w /workspace \
+          golang:1.26.3-alpine \
+          go run -tags parsec ./test/e2e/parsec/verify_parsec.go --socket /run/parsec/parsec.sock
+        echo "SUCCESS: Satellite is running with a PARSEC-backed hardware identity."
 
   cleanup-parsec:
     desc: Cleanup PARSEC E2E containers

--- a/test/e2e/parsec/doc.go
+++ b/test/e2e/parsec/doc.go
@@ -1,0 +1,2 @@
+// Package main contains PARSEC E2E verifier commands.
+package main

--- a/test/e2e/parsec/verify_parsec.go
+++ b/test/e2e/parsec/verify_parsec.go
@@ -1,0 +1,146 @@
+//go:build parsec
+
+package main
+
+import (
+	"crypto/sha256"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/parallaxsecond/parsec-client-go/interface/requests"
+	parsecclient "github.com/parallaxsecond/parsec-client-go/parsec"
+	"github.com/parallaxsecond/parsec-client-go/parsec/algorithm"
+)
+
+const identityKeyName = "satellite-identity-key"
+
+func main() {
+	socketPath := flag.String("socket", "/run/parsec/parsec.sock", "PARSEC daemon socket path")
+	wait := flag.Duration("wait", 30*time.Second, "maximum time to wait for the satellite identity key")
+	flag.Parse()
+
+	if err := verify(*socketPath, *wait); err != nil {
+		fmt.Fprintf(os.Stderr, "PARSEC E2E verification failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("PARSEC E2E verification passed: identity key signs, verifies, and remains non-exportable")
+}
+
+func verify(socketPath string, wait time.Duration) error {
+	if socketPath == "" {
+		return fmt.Errorf("socket path must not be empty")
+	}
+	if err := os.Setenv("PARSEC_SERVICE_ENDPOINT", "unix:"+socketPath); err != nil {
+		return fmt.Errorf("set PARSEC_SERVICE_ENDPOINT: %w", err)
+	}
+
+	client, err := parsecclient.CreateConfiguredClient(parsecclient.NewClientConfig())
+	if err != nil {
+		return fmt.Errorf("connect to parsec daemon at %s: %w", socketPath, err)
+	}
+	defer client.Close() //nolint:errcheck
+
+	if _, _, err := client.Ping(); err != nil {
+		return fmt.Errorf("ping parsec daemon: %w", err)
+	}
+
+	if err := waitForIdentityKey(client, wait); err != nil {
+		return err
+	}
+	if err := verifySignRoundTrip(client); err != nil {
+		return err
+	}
+	if err := verifyPrivateKeyNonExportable(client); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func waitForIdentityKey(client *parsecclient.BasicClient, wait time.Duration) error {
+	deadline := time.Now().Add(wait)
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		found, err := hasIdentityKey(client)
+		if err == nil && found {
+			return nil
+		}
+		lastErr = err
+		time.Sleep(time.Second)
+	}
+
+	if lastErr != nil {
+		return fmt.Errorf("wait for %q: %w", identityKeyName, lastErr)
+	}
+	return fmt.Errorf("wait for %q: key not found after %s", identityKeyName, wait)
+}
+
+func hasIdentityKey(client *parsecclient.BasicClient) (bool, error) {
+	keys, err := client.ListKeys()
+	if err != nil {
+		return false, fmt.Errorf("list parsec keys: %w", err)
+	}
+	for _, key := range keys {
+		if key.Name == identityKeyName {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func verifySignRoundTrip(client *parsecclient.BasicClient) error {
+	digest := sha256.Sum256([]byte("harbor-satellite-parsec-e2e"))
+	sigAlg := algorithm.NewAsymmetricSignature().
+		Ecdsa(algorithm.HashAlgorithmTypeSHA256).
+		GetAsymmetricSignature()
+
+	sig, err := client.PsaSignHash(identityKeyName, digest[:], sigAlg)
+	if err != nil {
+		return fmt.Errorf("sign with parsec identity key: %w", err)
+	}
+	if len(sig) == 0 {
+		return fmt.Errorf("sign with parsec identity key: empty signature")
+	}
+	if err := client.PsaVerifyHash(identityKeyName, digest[:], sig, sigAlg); err != nil {
+		return fmt.Errorf("verify parsec identity signature: %w", err)
+	}
+
+	tampered := sha256.Sum256([]byte("harbor-satellite-parsec-e2e-tampered"))
+	verifyErr := client.PsaVerifyHash(identityKeyName, tampered[:], sig, sigAlg)
+	if err := expectStatus(verifyErr, requests.StatusPsaErrorInvalidSignature, "verify parsec identity signature with tampered digest"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func verifyPrivateKeyNonExportable(client *parsecclient.BasicClient) error {
+	if _, err := client.PsaExportPublicKey(identityKeyName); err != nil {
+		return fmt.Errorf("export parsec identity public key: %w", err)
+	}
+	_, err := client.PsaExportKey(identityKeyName)
+	if err := expectStatus(err, requests.StatusPsaErrorNotPermitted, "export parsec identity private key"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func expectStatus(err error, status requests.StatusCode, action string) error {
+	expected := status.ToErr()
+	if expected == nil {
+		return fmt.Errorf("%s: expected non-success status %d", action, status)
+	}
+	if err == nil {
+		return fmt.Errorf("%s: unexpectedly succeeded", action)
+	}
+
+	// The client maps response statuses to untyped errors, so compare the canonical mapping.
+	if err.Error() != expected.Error() {
+		return fmt.Errorf("%s: got %v, want %v", action, err, expected)
+	}
+	return nil
+}


### PR DESCRIPTION
Adds PARSEC hardware identity E2E coverage for the satellite path introduced in #469. The test now exercises the real PARSEC-backed identity flow instead of relying on log output or key-list grepping.

### Why this matters

- Proves the satellite creates its identity key in PARSEC
- Verifies the PARSEC identity key can complete an ECDSA sign/verify round-trip
- Confirms a tampered digest is rejected with the expected PSA invalid-signature status
- Confirms public key export works while private key export is rejected with the expected PSA not-permitted status
- Runs this coverage as a dedicated CI job so PARSEC regressions are caught before merge

### Changes

- Adds `task e2e-parsec` and includes it in the aggregate `task e2e` flow
- Adds the `e2e-parsec-tests` job to the GitHub Actions test pipeline
- Replaces shell log/key-list checks with a Go verifier under `test/e2e/parsec`
- Hardens PARSEC daemon startup with bounded socket readiness polling and daemon logs on failure
- Fails fast when Ground Control does not return a satellite registration token

### Validation

Rebased onto `container-registry/harbor-satellite/main` and validated on commit `60bd7cd03d111c9be3251845d905919cf47f6ca7`.

- `go test -tags parsec ./...`
- CI `lint`
- CI `Unit Tests and Coverage`
- CI `build-satellite`
- CI `build-ground-control`
- CI `test-release`
- CI `vulnerability-check`
- CI `e2e-tests`
- CI `e2e-byo-registry-tests`
- CI `e2e-spiffe-join-token-tests`
- CI `e2e-parsec-tests`
- Codacy, CodeRabbit, Codecov, and DCO checks

All required checks are green, including the dedicated PARSEC E2E job.