### PR TITLE
test(e2e): add crash mid-replication layer resume test

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -93,6 +93,11 @@ tasks:
     cmds:
       - task: _e2e:test-crash-recovery-byo
 
+  e2e-crash-mid-replication:
+    desc: Run crash mid-replication E2E test
+    cmds:
+      - task: _e2e:test-crash-mid-replication
+
   publish:
     desc: "Publish both components to registry"
     aliases: [p]

--- a/taskfiles/e2e.yml
+++ b/taskfiles/e2e.yml
@@ -977,7 +977,7 @@ tasks:
     desc: Test crash recovery during mid-replication with layer-level resume
     cmds:
       - task: setup
-      - defer: { task: cleanup }
+      - defer: { task: cleanup-crash-recovery }
       - task: wait-harbor
       - task: wait-gc
       - task: init-harbor-golang-image
@@ -1042,6 +1042,7 @@ tasks:
 
         echo "Restarting satellite with same volume..."
         docker run -d --name satellite --network harbor-e2e \
+          -u root \
           -v sat-state-vol:/satellite-state \
           -e TOKEN="$TOKEN" \
           -e GROUND_CONTROL_URL="http://gc:8080" \
@@ -1064,7 +1065,7 @@ tasks:
             sleep 3
             
             echo "Capturing blob state before crash..."
-            docker exec satellite find /satellite-state/zot -type f 2>/dev/null | sort > /tmp/blobs_before_crash.txt || true
+            docker exec satellite find /satellite-state/zot -type f 2>/dev/null | grep '/blobs/sha256/' | sort > /tmp/blobs_before_crash.txt || true
             BLOBS_BEFORE=$(wc -l < /tmp/blobs_before_crash.txt)
             echo "Blobs present before crash: $BLOBS_BEFORE"
             
@@ -1120,7 +1121,7 @@ tasks:
         done
         
         echo "Capturing blob state after restart and completion..."
-        docker exec satellite find /satellite-state/zot -type f 2>/dev/null | sort > /tmp/blobs_after_complete.txt || true
+        docker exec satellite find /satellite-state/zot -type f 2>/dev/null | grep '/blobs/sha256/' | sort > /tmp/blobs_after_complete.txt || true
         BLOBS_AFTER=$(wc -l < /tmp/blobs_after_complete.txt)
         BLOBS_BEFORE=$(wc -l < /tmp/blobs_before_crash.txt)
         

--- a/taskfiles/e2e.yml
+++ b/taskfiles/e2e.yml
@@ -1061,8 +1061,19 @@ tasks:
         echo "Waiting for replication to start..."
         for i in $(seq 1 30); do
           if docker logs satellite 2>&1 | grep -q "Replicating image golang"; then
-            echo "Replication started, waiting 3 seconds for partial completion..."
-            sleep 3
+            echo "Replication started, waiting for at least one blob to be written..."
+            for j in $(seq 1 30); do
+              if docker exec satellite sh -c 'find /satellite-state/zot -type f 2>/dev/null | grep -q "/blobs/sha256/"'; then
+                echo "Blob detected, proceeding with crash"
+                break
+              fi
+              if [ "$j" -eq 30 ]; then
+                echo "ERROR: No blobs detected after 30s (replication may not have started writing)"
+                docker logs satellite 2>&1 | tail -50
+                exit 1
+              fi
+              sleep 1
+            done
             
             echo "Capturing blob state before crash..."
             docker exec satellite find /satellite-state/zot -type f 2>/dev/null | grep '/blobs/sha256/' | sort > /tmp/blobs_before_crash.txt || true
@@ -1128,30 +1139,28 @@ tasks:
         echo "Blobs before crash: $BLOBS_BEFORE"
         echo "Blobs after completion: $BLOBS_AFTER"
         
-        if [ "$BLOBS_BEFORE" -eq 0 ]; then
-          echo "WARN: No blobs detected before crash, crash may have been too early"
-          echo "Test will rely on log verification only"
-        else
-          if [ "$BLOBS_AFTER" -le "$BLOBS_BEFORE" ]; then
-            echo "FAIL: Blob count did not increase (replication did not resume properly)"
+        if [ "$BLOBS_AFTER" -le "$BLOBS_BEFORE" ]; then
+          echo "FAIL: Blob count did not increase (replication did not resume properly)"
+          exit 1
+        fi
+        
+        echo "Verifying blobs from before crash still exist (not re-downloaded)..."
+        while IFS= read -r blob; do
+          if ! grep -Fxq "$blob" /tmp/blobs_after_complete.txt; then
+            echo "FAIL: Blob from before crash is missing after restart: $blob"
             exit 1
           fi
-          
-          echo "Verifying blobs from before crash still exist (not re-downloaded)..."
-          while IFS= read -r blob; do
-            if ! grep -Fxq "$blob" /tmp/blobs_after_complete.txt; then
-              echo "FAIL: Blob from before crash is missing after restart: $blob"
-              exit 1
-            fi
-          done < /tmp/blobs_before_crash.txt
-          echo "PASS: All pre-crash blobs still present (layer resume confirmed)"
-        fi
+        done < /tmp/blobs_before_crash.txt
+        echo "PASS: All pre-crash blobs still present (layer resume confirmed)"
         
         if docker logs satellite 2>&1 | tail -100 | grep -q "Old state has zero entities, replicating the complete state"; then
           echo "FAIL: Full re-replication occurred"
           exit 1
         fi
         echo "PASS: No full re-replication detected"
+        
+        echo "Cleaning up temporary files..."
+        rm -f /tmp/blobs_before_crash.txt /tmp/blobs_after_complete.txt 2>/dev/null || true
         
         echo "Crash mid-replication test passed"
 

--- a/taskfiles/e2e.yml
+++ b/taskfiles/e2e.yml
@@ -434,6 +434,74 @@ tasks:
 
         echo "Harbor initialized"
 
+  init-harbor-golang-image:
+    desc: Initialize Harbor with golang image (multi-layer, already cached from satellite build)
+    cmds:
+      - |
+        echo "Creating project..."
+        curl -sf -X POST {{.HARBOR_API}}/projects \
+          -u {{.HARBOR_ADMIN_USER}}:{{.HARBOR_ADMIN_PASSWORD}} \
+          -H "Content-Type: application/json" \
+          -d '{"project_name": "{{.PROJECT_NAME}}"}'
+
+        echo "Pulling golang:1.26.3-alpine (multi-layer image for crash test)..."
+        docker pull golang:1.26.3-alpine || { echo "Failed to pull golang:1.26.3-alpine"; exit 1; }
+
+        echo "Pushing image to Harbor..."
+        docker tag golang:1.26.3-alpine localhost:8080/{{.PROJECT_NAME}}/golang:1.26.3-alpine
+
+        if docker login localhost:8080 -u admin -p Harbor12345 2>/dev/null; then
+          docker push localhost:8080/{{.PROJECT_NAME}}/golang:1.26.3-alpine 2>/dev/null || \
+          docker push localhost:8080/{{.PROJECT_NAME}}/golang:1.26.3-alpine --tls-verify=false
+        else
+          docker login localhost:8080 -u admin -p Harbor12345 --tls-verify=false
+          docker push localhost:8080/{{.PROJECT_NAME}}/golang:1.26.3-alpine --tls-verify=false
+        fi
+
+        echo "Creating registry..."
+        curl -sf -X POST {{.HARBOR_API}}/registries \
+          -u {{.HARBOR_ADMIN_USER}}:{{.HARBOR_ADMIN_PASSWORD}} \
+          -H "Content-Type: application/json" \
+          -d '{
+            "credential": {"access_key": "", "access_secret": "", "type": "basic"},
+            "description": "",
+            "insecure": true,
+            "name": "{{.REGISTRY_NAME}}",
+            "type": "harbor-satellite",
+            "url": "http://gc:8080/groups/sync"
+          }'
+
+        echo "Creating replication policy..."
+        curl -sf -X POST {{.HARBOR_API}}/replication/policies \
+          -u {{.HARBOR_ADMIN_USER}}:{{.HARBOR_ADMIN_PASSWORD}} \
+          -H "Content-Type: application/json" \
+          -d '{
+            "name": "satellite-group",
+            "dest_registry": {
+              "id": 1,
+              "name": "{{.REGISTRY_NAME}}",
+              "status": "healthy",
+              "type": "harbor-satellite",
+              "url": "http://gc:8080/groups/sync"
+            },
+            "dest_namespace": "{{.DEST_NAMESPACE}}",
+            "dest_namespace_replace_count": 1,
+            "trigger": {"type": "manual", "trigger_settings": {"cron": ""}},
+            "filters": [{"type": "name", "value": "{{.PROJECT_NAME}}/**"}],
+            "enabled": true,
+            "deletion": false,
+            "override": true,
+            "speed": -1
+          }'
+
+        echo "Executing replication..."
+        curl -sf -X POST {{.HARBOR_API}}/replication/executions \
+          -u {{.HARBOR_ADMIN_USER}}:{{.HARBOR_ADMIN_PASSWORD}} \
+          -H "Content-Type: application/json" \
+          -d '{"policy_id": 1}'
+
+        echo "Harbor initialized with golang image"
+
   init-gc:
     desc: Initialize Ground Control with config and group
     vars:
@@ -482,6 +550,55 @@ tasks:
           }'
 
         echo "Ground Control initialized"
+
+  init-gc-golang:
+    desc: Initialize Ground Control with golang artifact
+    vars:
+      GC_TOKEN:
+        sh: |
+          curl -sf -X POST {{.GC_URL}}/login \
+            -H "Content-Type: application/json" \
+            -d '{"username":"{{.GC_ADMIN_USER}}","password":"{{.GC_ADMIN_PASSWORD}}"}' | \
+            grep -o '"token":"[^"]*"' | cut -d'"' -f4
+    cmds:
+      - |
+        echo "Creating config..."
+        curl -sf -X POST {{.GC_URL}}/api/configs \
+          -H "Authorization: Bearer {{.GC_TOKEN}}" \
+          -H "Content-Type: application/json" \
+          -d '{
+            "config_name": "test-config",
+            "registry": "{{.HARBOR_INTERNAL_URL}}",
+            "config": {
+              "app_config": {
+                "ground_control_url": "http://gc:8080",
+                "log_level": "info",
+                "use_unsecure": true,
+                "state_replication_interval": "@every 00h00m10s",
+                "register_satellite_interval": "@every 00h00m10s",
+                "bring_own_registry": false,
+                "local_registry": {"url": "http://127.0.0.1:8585"}
+              },
+              "zot_config": {
+                "distSpecVersion": "1.1.0",
+                "storage": {"rootDirectory": "./zot"},
+                "http": {"address": "0.0.0.0", "port": "8585"},
+                "log": {"level": "info"}
+              }
+            }
+          }'
+
+        echo "Creating group..."
+        curl -sf -X POST {{.GC_URL}}/api/groups/sync \
+          -H "Authorization: Bearer {{.GC_TOKEN}}" \
+          -H "Content-Type: application/json" \
+          -d '{
+            "group": "{{.DEST_NAMESPACE}}",
+            "registry": "{{.HARBOR_INTERNAL_URL}}",
+            "artifacts": [{"repository": "{{.PROJECT_NAME}}/golang", "tag": ["1.26.3-alpine"]}]
+          }'
+
+        echo "Ground Control initialized with golang artifact"
 
   register-satellite:
     desc: Register satellite and start it
@@ -856,6 +973,20 @@ tasks:
       - task: verify-crash-recovery-byo
       - echo "Crash recovery BYO E2E test passed"
 
+  test-crash-mid-replication:
+    desc: Test crash recovery during mid-replication with layer-level resume
+    cmds:
+      - task: setup
+      - defer: { task: cleanup }
+      - task: wait-harbor
+      - task: wait-gc
+      - task: init-harbor-golang-image
+      - task: init-gc-golang
+      - task: register-and-run-satellite-with-volume
+      - task: crash-mid-replication-and-restart
+      - task: verify-mid-replication-resume
+      - echo "Crash mid-replication E2E test passed"
+
   register-and-run-satellite-with-volume:
     desc: Register satellite and start it with a named volume for state persistence
     vars:
@@ -890,6 +1021,7 @@ tasks:
 
         echo "Starting satellite with named volume..."
         docker run -d --name satellite --network harbor-e2e \
+          -u root \
           -v sat-state-vol:/satellite-state \
           -e TOKEN="$TOKEN" \
           -e GROUND_CONTROL_URL="http://gc:8080" \
@@ -920,6 +1052,107 @@ tasks:
 
         echo "Waiting for satellite to start..."
         sleep 15
+
+  crash-mid-replication-and-restart:
+    desc: Kill satellite during replication and restart to test layer-level resume
+    cmds:
+      - |
+        echo "Waiting for replication to start..."
+        for i in $(seq 1 30); do
+          if docker logs satellite 2>&1 | grep -q "Replicating image golang"; then
+            echo "Replication started, waiting 3 seconds for partial completion..."
+            sleep 3
+            
+            echo "Capturing blob state before crash..."
+            docker exec satellite find /satellite-state/zot -type f 2>/dev/null | sort > /tmp/blobs_before_crash.txt || true
+            BLOBS_BEFORE=$(wc -l < /tmp/blobs_before_crash.txt)
+            echo "Blobs present before crash: $BLOBS_BEFORE"
+            
+            echo "Killing satellite mid-replication (SIGKILL)..."
+            docker kill satellite
+            docker rm satellite
+            echo "Satellite killed"
+            break
+          fi
+          if [ "$i" -eq 30 ]; then
+            echo "ERROR: Replication did not start"
+            docker logs satellite 2>&1 | tail -50
+            exit 1
+          fi
+          sleep 1
+        done
+        
+        TOKEN=$(cat /tmp/e2e_satellite_token)
+        
+        echo "Restarting satellite with same volume..."
+        docker run -d --name satellite --network harbor-e2e \
+          -u root \
+          -v sat-state-vol:/satellite-state \
+          -e TOKEN="$TOKEN" \
+          -e GROUND_CONTROL_URL="http://gc:8080" \
+          -e HARBOR_REGISTRY_URL="{{.HARBOR_INTERNAL_URL}}" \
+          -e CONFIG_DIR=/satellite-state \
+          -p 8585:8585 \
+          satellite:e2e
+        
+        echo "Waiting for satellite to start..."
+        sleep 15
+
+  verify-mid-replication-resume:
+    desc: Verify layer-level resume behavior after mid-replication crash
+    cmds:
+      - |
+        echo "Waiting for replication to complete after restart..."
+        for i in $(seq 1 20); do
+          if docker run --rm --network harbor-e2e alpine:latest sh -c "
+            apk add --no-cache crane > /dev/null 2>&1 &&
+            crane manifest satellite:8585/{{.PROJECT_NAME}}/golang:1.26.3-alpine --insecure > /dev/null 2>&1
+          "; then
+            echo "Image fully replicated after restart"
+            break
+          fi
+          if [ "$i" -eq 20 ]; then
+            echo "FAIL: Image not accessible after restart"
+            docker logs satellite 2>&1 | tail -50
+            exit 1
+          fi
+          sleep 3
+        done
+        
+        echo "Capturing blob state after restart and completion..."
+        docker exec satellite find /satellite-state/zot -type f 2>/dev/null | sort > /tmp/blobs_after_complete.txt || true
+        BLOBS_AFTER=$(wc -l < /tmp/blobs_after_complete.txt)
+        BLOBS_BEFORE=$(wc -l < /tmp/blobs_before_crash.txt)
+        
+        echo "Blobs before crash: $BLOBS_BEFORE"
+        echo "Blobs after completion: $BLOBS_AFTER"
+        
+        if [ "$BLOBS_BEFORE" -eq 0 ]; then
+          echo "WARN: No blobs detected before crash, crash may have been too early"
+          echo "Test will rely on log verification only"
+        else
+          if [ "$BLOBS_AFTER" -le "$BLOBS_BEFORE" ]; then
+            echo "FAIL: Blob count did not increase (replication did not resume properly)"
+            exit 1
+          fi
+          
+          echo "Verifying blobs from before crash still exist (not re-downloaded)..."
+          while IFS= read -r blob; do
+            if ! grep -Fxq "$blob" /tmp/blobs_after_complete.txt; then
+              echo "FAIL: Blob from before crash is missing after restart: $blob"
+              exit 1
+            fi
+          done < /tmp/blobs_before_crash.txt
+          echo "PASS: All pre-crash blobs still present (layer resume confirmed)"
+        fi
+        
+        if docker logs satellite 2>&1 | tail -100 | grep -q "Old state has zero entities, replicating the complete state"; then
+          echo "FAIL: Full re-replication occurred"
+          exit 1
+        fi
+        echo "PASS: No full re-replication detected"
+        
+        echo "Crash mid-replication test passed"
 
   verify-crash-recovery:
     desc: Verify satellite recovered from crash without full re-replication


### PR DESCRIPTION
## Summary

Adds E2E test for crash mid-replication scenario with layer-level resume verification (Zot mode only).

Implements testing for issue #323 row: "Crash mid-replication + verify layer-level resume"

## Changes

- Add `e2e-crash-mid-replication` task to root `Taskfile.yml`
- Add 5 new tasks to `taskfiles/e2e.yml`:
  1. `test-crash-mid-replication` - main test orchestrator
  2. `init-harbor-golang-image` - pushes `golang:1.26.3-alpine` (multi-layer, ~400MB) to Harbor
  3. `init-gc-golang` - configures Ground Control with golang artifact
  4. `crash-mid-replication-and-restart` - kills satellite mid-replication with SIGKILL, restarts with same volume
  5. `verify-mid-replication-resume` - verifies layer-level resume by comparing blob files before/after restart
- Modify `register-and-run-satellite-with-volume` to add `-u root` flag for volume permission handling

## Test Approach

- Uses `golang:1.26.3-alpine` as test image (already cached from satellite build, zero new external dependencies)
- Waits for replication to start, sleeps 3s for partial completion, kills with SIGKILL
- Captures blob file state before crash, verifies blobs are preserved after restart
- Direct filesystem verification (not log parsing) as primary proof of layer-level resume
- Follows existing `test-crash-recovery` task structure exactly

## Known Limitation

This test currently fails on macOS Docker Desktop due to issue #455: "bug: Zot config manager fails with cross-device link error (EXDEV)"

- **Root cause**: `internal/registry/manager.go` creates temp file in `/tmp`, attempts `os.Rename()` to Docker volume path (`/satellite-state/zot-hot.json`), fails cross-device on macOS Docker Desktop
- **Verified**: The existing `test-crash-recovery` test also fails locally with the same error, confirming this is a pre-existing environment-specific issue
- **Fix available**: PR #456 resolves this by creating temp file in same directory as target
- **Expected behavior**: Test will work on Linux (CI runs on `ubuntu-latest`)

## CI Status

This test is a **manual-only task** and does NOT run automatically in CI. The automatic CI pipeline (`e2e-tests`, `e2e-byo-registry-tests`, `e2e-spiffe-join-token-tests`) does not include crash recovery tests.

To run manually:
```bash
task e2e-crash-mid-replication
```

Testing
- go test ./... -v -count=1 (root module)
- cd ground-control && go test ./... -v -count=1
-  go vet ./...
- task build

 E2E execution blocked locally by issue #455 (manual test will work once #456 is merged, or on Linux CI)
Contributes to #323


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added an end-to-end crash-recovery scenario covering mid-replication resume behavior, including verification that previously persisted blobs remain present and that the expected manifest becomes available after restart.
  * Introduced a new named test flow to seed Harbor with a Go image, run replication to the satellite’s embedded Zot, crash during replication, and validate layer-level recovery on subsequent startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->