### PR TITLE
docs: fix ground control satellite API routes

### DIFF
--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -34,11 +34,14 @@ Ground Control is the central management component that orchestrates the Harbor 
 
 ### API Endpoints
 
-- `GET /api/v1/satellites` - List satellites
-- `POST /api/v1/satellites` - Register satellite
-- `GET /api/v1/satellites/{name}` - Get satellite details
-- `PUT /api/v1/satellites/{name}` - Update satellite configuration
-- `DELETE /api/v1/satellites/{name}` - Remove satellite
+- `GET /api/satellites` - List satellites
+- `POST /api/satellites` - Register satellite
+- `GET /api/satellites/active` - List active satellites
+- `GET /api/satellites/stale` - List stale satellites
+- `GET /api/satellites/{satellite}` - Get satellite details
+- `DELETE /api/satellites/{satellite}` - Remove satellite
+- `GET /api/satellites/{satellite}/status` - Get satellite status
+- `GET /api/satellites/{satellite}/images` - List cached satellite images
 
 ## Satellite
 


### PR DESCRIPTION
- Fixes: #488 

## Description
Updates the architecture components guide so the documented Ground Control satellite API endpoints match the routes currently registered in `ground-control/internal/server/routes.go`.

This replaces the stale `/api/v1/satellites` paths with the current `/api/satellites` routes, removes the undocumented `PUT /api/v1/satellites/{name}` endpoint, and adds the active, stale, status, and cached image satellite routes.

## Additional context

<!-- Add any other context about the PR here. -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated satellite API endpoint documentation to use streamlined paths.
  * Removed the documented satellite update endpoint.
  * Added documentation for listing active or stale satellites and retrieving satellite status and cached images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->