### PR TITLE
fix (#475): delete Harbor artifact before database transaction in deleteGroupHandler

### DIFF
--- a/ground-control/internal/server/group_handlers.go
+++ b/ground-control/internal/server/group_handlers.go
@@ -144,6 +144,31 @@ func (s *Server) deleteGroupHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	groupName := vars["group"]
 
+	q := s.dbQueries
+
+	group, err := q.GetGroupByName(r.Context(), groupName)
+	if err != nil {
+		log.Println(err)
+		err := &AppError{
+			Message: "Error: Group Not Found",
+			Code:    http.StatusNotFound,
+		}
+		HandleAppError(w, err)
+		return
+	}
+
+	// Delete Harbor artifact before modifying database
+	err = utils.DeleteArtifact(utils.ConstructHarborDeleteURL(groupName, "group"))
+	if err != nil {
+		log.Println(err)
+		err := &AppError{
+			Message: "Error: Failed to delete group state artifact",
+			Code:    http.StatusInternalServerError,
+		}
+		HandleAppError(w, err)
+		return
+	}
+
 	tx, err := s.db.BeginTx(r.Context(), nil)
 	if err != nil {
 		log.Printf("Error starting transaction: %v", err)
@@ -155,7 +180,7 @@ func (s *Server) deleteGroupHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	q := s.dbQueries.WithTx(tx)
+	q = s.dbQueries.WithTx(tx)
 
 	committed := false
 	defer func() {
@@ -171,17 +196,6 @@ func (s *Server) deleteGroupHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}()
-
-	group, err := q.GetGroupByName(r.Context(), groupName)
-	if err != nil {
-		log.Println(err)
-		err := &AppError{
-			Message: "Error: Group Not Found",
-			Code:    http.StatusNotFound,
-		}
-		HandleAppError(w, err)
-		return
-	}
 
 	// Remove the group from all associated satellites
 	satellites, err := q.GroupSatelliteList(r.Context(), group.ID)
@@ -314,17 +328,6 @@ func (s *Server) deleteGroupHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	committed = true
-
-	err = utils.DeleteArtifact(utils.ConstructHarborDeleteURL(groupName, "group"))
-	if err != nil {
-		log.Println(err)
-		err := &AppError{
-			Message: "Error: Failed to delete group state",
-			Code:    http.StatusInternalServerError,
-		}
-		HandleAppError(w, err)
-		return
-	}
 
 	WriteJSONResponse(w, http.StatusOK, map[string]string{})
 }

--- a/ground-control/internal/utils/helper.go
+++ b/ground-control/internal/utils/helper.go
@@ -265,7 +265,7 @@ func DeleteArtifact(deleteURL string) error {
 		}
 	}()
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusNoContent {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
 		return fmt.Errorf("failed to delete repository, received status: %d", resp.StatusCode)
 	}
 


### PR DESCRIPTION
Fixes #475

## Summary

`deleteGroupHandler` was calling `utils.DeleteArtifact` after `tx.Commit`. If the Harbor API call failed (network timeout, Harbor downtime), the group was permanently removed from the database but its OCI artifact remained in Harbor with no way to clean it up, since the group no longer existed in the database to retry against.

## Changes

Moved the Harbor artifact deletion to before the transaction begins, following the same pattern already used in `deleteConfigHandler`:

1. Verify group exists
2. Delete Harbor artifact — if this fails, database is unchanged
3. Begin transaction, update satellite states, delete group from DB, commit

If Harbor deletion succeeds but the database transaction fails, the client receives an error and can retry. Harbor artifact deletion is idempotent (404 is acceptable on retry).

## Testing

- All existing unit tests pass
- golangci-lint clean (0 issues)
- Build successful

## Notes

PostgreSQL's `ON DELETE CASCADE` on `satellite_groups.group_id` handles junction table cleanup automatically when the group is deleted, so no changes to the satellite association logic were needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved group deletion handling to reduce the chance of partial cleanup when removing a group.
  * Updated error messaging during deletion to be clearer and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->