### PR TITLE
feat: persist state to disk during graceful shutdown

### DIFF
--- a/cmd/harbor-satellite/main.go
+++ b/cmd/harbor-satellite/main.go
@@ -534,6 +534,13 @@ func gracefulShutdown(ctx context.Context, log *zerolog.Logger, s *satellite.Sat
 
 	select {
 	case <-shutdownDone:
+		// Persist state to disk before exit (reuses #228 SaveState logic)
+		log.Info().Msg("Persisting state to disk before exit")
+		if err := s.PersistState(); err != nil {
+			log.Warn().Err(err).Msg("Failed to persist state during shutdown")
+		} else {
+			log.Info().Msg("State persisted successfully")
+		}
 		log.Info().Msg("Graceful shutdown completed successfully")
 	case <-shutdownCtx.Done():
 		log.Warn().Msg("Shutdown timeout exceeded, forcing exit")

--- a/internal/satellite/satellite.go
+++ b/internal/satellite/satellite.go
@@ -15,6 +15,7 @@ type Satellite struct {
 	criResults    []runtime.CRIConfigResult
 	schedulers    []*scheduler.Scheduler
 	stateFilePath string
+	stateProcess  *state.FetchAndReplicateStateProcess
 }
 
 func NewSatellite(cm *config.ConfigManager, criResults []runtime.CRIConfigResult, stateFilePath string) *Satellite {
@@ -31,6 +32,7 @@ func (s *Satellite) Run(ctx context.Context) error {
 	log.Info().Msg("Starting Satellite")
 
 	fetchAndReplicateStateProcess := state.NewFetchAndReplicateStateProcess(s.cm, s.stateFilePath, log)
+	s.stateProcess = fetchAndReplicateStateProcess
 
 	// Create ZTR scheduler if not already done
 	if !s.cm.IsZTRDone() {
@@ -102,6 +104,15 @@ func (s *Satellite) Run(ctx context.Context) error {
 
 func (s *Satellite) GetSchedulers() []*scheduler.Scheduler {
 	return s.schedulers
+}
+
+// PersistState writes the current in-memory state to disk.
+// Called during graceful shutdown to ensure no state is lost.
+func (s *Satellite) PersistState() error {
+	if s.stateProcess == nil {
+		return nil
+	}
+	return s.stateProcess.PersistState()
 }
 
 // Stop gracefully stops all schedulers and logs the shutdown process.

--- a/internal/satellite/state/state_process.go
+++ b/internal/satellite/state/state_process.go
@@ -126,20 +126,17 @@ func (f *FetchAndReplicateStateProcess) Execute(ctx context.Context) error {
 	stateFetcherResults := make(chan StateFetcherResult, len(f.stateMap))
 	configFetcherResult := make(chan ConfigFetcherResult, 1)
 
-	// Mutex for concurrency safe access of the stateMap
-	mutex := &sync.Mutex{}
-
 	// Launch state fetcher goroutines
 	for i := range f.stateMap {
 		go func(index int) {
-			result := f.processGroupState(ctx, index, srcUsername, srcPassword, useUnsecure, replicator, mutex, &log)
+			result := f.processGroupState(ctx, index, srcUsername, srcPassword, useUnsecure, replicator, &log)
 			stateFetcherResults <- result
 		}(i)
 	}
 
 	// Launch config fetcher goroutine
 	go func() {
-		result := f.reconcileRemoteConfig(ctx, satelliteState.Config, srcUsername, srcPassword, useUnsecure, mutex, &log)
+		result := f.reconcileRemoteConfig(ctx, satelliteState.Config, srcUsername, srcPassword, useUnsecure, &log)
 		configFetcherResult <- result
 	}()
 
@@ -333,7 +330,6 @@ func (f *FetchAndReplicateStateProcess) reconcileRemoteConfig(
 	ctx context.Context,
 	configURL, srcUsername, srcPassword string,
 	useUnsecure bool,
-	mutex *sync.Mutex,
 	log *zerolog.Logger,
 ) ConfigFetcherResult {
 	configFetcherLog := log.With().
@@ -400,14 +396,14 @@ func (f *FetchAndReplicateStateProcess) reconcileRemoteConfig(
 			result.Error = fmt.Errorf("failed to write new config to disk: %w", err)
 			return result
 		}
-		mutex.Lock()
+		f.mu.Lock()
 		f.currentConfigDigest = configDigest
 		if f.stateFilePath != "" {
 			if err := SaveState(f.stateFilePath, f.stateMap, f.currentConfigDigest); err != nil {
 				configFetcherLog.Warn().Err(err).Msg("Failed to persist state to disk")
 			}
 		}
-		mutex.Unlock()
+		f.mu.Unlock()
 	}
 
 	result.ConfigDigest = configDigest
@@ -420,7 +416,6 @@ func (f *FetchAndReplicateStateProcess) processGroupState(
 	srcUsername, srcPassword string,
 	useUnsecure bool,
 	replicator Replicator,
-	mutex *sync.Mutex,
 	log *zerolog.Logger,
 ) StateFetcherResult {
 	stateFetcherLog := log.With().
@@ -483,7 +478,7 @@ func (f *FetchAndReplicateStateProcess) processGroupState(
 		}
 	}
 
-	mutex.Lock()
+	f.mu.Lock()
 	f.stateMap[index].State = newState
 	f.stateMap[index].Entities = FetchEntitiesFromState(newState)
 	if f.stateFilePath != "" {
@@ -491,7 +486,7 @@ func (f *FetchAndReplicateStateProcess) processGroupState(
 			stateFetcherLog.Warn().Err(err).Msg("Failed to persist state to disk")
 		}
 	}
-	mutex.Unlock()
+	f.mu.Unlock()
 
 	return result
 }

--- a/internal/satellite/state/state_process.go
+++ b/internal/satellite/state/state_process.go
@@ -560,6 +560,19 @@ func (f *FetchAndReplicateStateProcess) stop() {
 	f.isRunning = false
 }
 
+// PersistState writes the current in-memory state to disk.
+// This is safe to call concurrently and is used during graceful shutdown
+// to ensure no state is lost between the last sync and process exit.
+func (f *FetchAndReplicateStateProcess) PersistState() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.stateFilePath == "" {
+		return nil
+	}
+	return SaveState(f.stateFilePath, f.stateMap, f.currentConfigDigest)
+}
+
 func (f *FetchAndReplicateStateProcess) RemoveNullTagArtifacts(state StateReader) StateReader {
 	var artifactsWithoutNullTags []ArtifactReader
 	for _, artifact := range state.GetArtifacts() {

--- a/internal/satellite/state/state_process_test.go
+++ b/internal/satellite/state/state_process_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -250,6 +251,32 @@ func TestFetchEntitiesFromState(t *testing.T) {
 		entities := FetchEntitiesFromState(state)
 		require.Empty(t, entities)
 	})
+}
+
+func TestPersistState(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	process := &FetchAndReplicateStateProcess{
+		stateFilePath:       path,
+		currentConfigDigest: "sha256:config",
+		stateMap: []StateMap{
+			{
+				url: "http://registry.example.com/group1",
+				Entities: []Entity{
+					{Name: "alpine", Repository: "library", Tag: "latest", Digest: "sha256:abc123"},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, process.PersistState())
+
+	loaded, err := LoadState(path)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	require.Equal(t, "sha256:config", loaded.ConfigDigest)
+	require.Len(t, loaded.Groups, 1)
+	require.Equal(t, "http://registry.example.com/group1", loaded.Groups[0].URL)
+	require.Equal(t, process.stateMap[0].Entities, loaded.Groups[0].Entities)
 }
 
 func TestRemoveNullTagArtifacts(t *testing.T) {


### PR DESCRIPTION
- Fixes: #229

## Description

Adds state persistence to the graceful shutdown path so that the satellite's in-memory state (replicated artifacts, digests, config digest) is saved to disk before the process exits.

### Problem

When the satellite receives SIGTERM/SIGINT, the existing graceful shutdown logic correctly stops schedulers and waits for in progress replication to finish. However, it never persists the current state to disk before exiting. This means any state accumulated since the last successful sync cycle is lost, requiring redundant re-replication on restart.

### Solution

Three minimal changes, all reusing the `SaveState()` function from #228:

1. **`internal/state/state_process.go`**: Added `PersistState()` method to `FetchAndReplicateStateProcess`  thread-safe (mutex-protected) wrapper around `SaveState()`.

2. **`internal/satellite/satellite.go`**: Stored the state process reference in the `Satellite` struct and added a delegating `PersistState()` method.

3. **`cmd/main.go`**: Called `s.PersistState()` in `gracefulShutdown()` after all schedulers have stopped and goroutines have completed, but before final exit. Persistence failure is logged as a warning without blocking shutdown.

### Testing

- All existing unit tests pass (`go test ./... -v -count=1`)




<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now saves satellite state during a successful shutdown, helping preserve progress between runs.
  * State persistence is now available through the satellite runtime and replication process, improving shutdown reliability.
* **Bug Fixes**
  * Added logging for state-saving progress and failures during shutdown, making persistence issues easier to spot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->