### PR TITLE
fix: validate satellite and config names in setSatelliteConfig handler

### DIFF
--- a/internal/groundcontrol/server/config_handlers.go
+++ b/internal/groundcontrol/server/config_handlers.go
@@ -461,6 +461,22 @@ func (s *Server) setSatelliteConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !utils.IsValidName(req.Satellite) {
+		HandleAppError(w, &AppError{
+			Message: fmt.Sprintf(invalidNameMessage, "satellite"),
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	if !utils.IsValidName(req.ConfigName) {
+		HandleAppError(w, &AppError{
+			Message: "invalid or empty config_name",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
 	tx, err := s.db.BeginTx(r.Context(), nil)
 	if err != nil {
 		log.Println("Could not begin transaction:", err)

--- a/internal/groundcontrol/server/config_handlers_test.go
+++ b/internal/groundcontrol/server/config_handlers_test.go
@@ -168,3 +168,47 @@ func TestDeleteConfigHandler_ConfigInUse(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, rr.Code)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
+
+func TestSetSatelliteConfig_InvalidBody(t *testing.T) {
+	server, _ := newMockServer(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/satellites/config", bytes.NewReader([]byte("not json")))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	server.setSatelliteConfig(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestSetSatelliteConfig_InvalidSatelliteName(t *testing.T) {
+	server, _ := newMockServer(t)
+
+	body, _ := json.Marshal(map[string]string{
+		"satellite":   "UPPERCASE_SAT",
+		"config_name": "valid-config",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/satellites/config", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	server.setSatelliteConfig(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestSetSatelliteConfig_EmptyConfigName(t *testing.T) {
+	server, _ := newMockServer(t)
+
+	body, _ := json.Marshal(map[string]string{
+		"satellite":   "valid-sat",
+		"config_name": "",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/satellites/config", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	server.setSatelliteConfig(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}


### PR DESCRIPTION
## Description

The `setSatelliteConfig` handler accepted `req.Satellite` and `req.ConfigName` without validating them via `utils.IsValidName()`. Every sibling handler already performs this check. This inconsistency allowed invalid names (uppercase, empty, special characters) to reach the database layer and downstream OCI artifact operations.

### Changes

1. **`internal/groundcontrol/server/config_handlers.go`** — Added two `utils.IsValidName()` guard blocks after `DecodeRequestBody` and before `BeginTx`. Invalid names are rejected with a clear 400 Bad Request before any database transaction is opened.

2. **`internal/groundcontrol/server/config_handlers_test.go`** — Added three test cases covering malformed body, uppercase satellite name, and empty config name. All are pure unit tests — no DB mocking needed since validation fires before any database call.

### Verification

- `task lint-report`: 0 issues
- Full test suite: 582 tests passed, 0 failures, 0 regressions
- `go vet`: No issues

## Additional context

**Sibling handlers with same validation:** `registerSatelliteHandler`, `createConfigHandler`, `updateConfigHandler`, `addSatelliteToGroup`, `removeSatelliteFromGroup`.

**Validator:** `IsValidName()` at `internal/groundcontrol/utils/helper.go:313` — 1-255 chars, lowercase + digits + ._-, must start with letter/digit.