### PR TITLE
fix: retry remote BuildKit publish failures

### DIFF
--- a/.github/actions/publish-and-sign/action.yaml
+++ b/.github/actions/publish-and-sign/action.yaml
@@ -38,8 +38,9 @@ runs:
     - name: Set up Docker Buildx with remote BuildKit
       shell: bash
       run: |
-        docker buildx inspect remote || docker buildx create --name remote --driver remote tcp://buildkitd.github-runners.svc:1234
-        docker buildx use remote
+        docker buildx rm remote >/dev/null 2>&1 || true
+        docker buildx create --name remote --driver remote tcp://buildkitd.github-runners.svc:1234 --use
+        docker buildx inspect remote --bootstrap
 
     - name: Provide envsubst for Cosign installer
       shell: bash
@@ -84,4 +85,29 @@ runs:
         REG_PASS: ${{ inputs.REGISTRY_PASSWORD }}
         PROJECT_NAME: ${{ inputs.PROJECT_NAME }}
         TAG: ${{ inputs.IMAGE_TAGS }}
-      run: task publish-and-sign
+      run: |
+        for attempt in 1 2 3; do
+          if task publish-and-sign; then
+            exit 0
+          else
+            status=$?
+          fi
+
+          if [ "$attempt" -eq 3 ]; then
+            exit "$status"
+          fi
+
+          echo "Publish attempt $attempt failed with status $status; resetting remote BuildKit builder before retry..."
+          docker buildx rm remote >/dev/null 2>&1 || true
+          if ! docker buildx create --name remote --driver remote tcp://buildkitd.github-runners.svc:1234 --use; then
+            echo "Remote BuildKit builder creation failed; retrying after backoff..."
+            sleep $((attempt * 20))
+            continue
+          fi
+          if ! docker buildx inspect remote --bootstrap; then
+            echo "Remote BuildKit builder bootstrap failed; retrying after backoff..."
+            sleep $((attempt * 20))
+            continue
+          fi
+          sleep $((attempt * 20))
+        done


### PR DESCRIPTION
- Fixes: # (no linked issue; fixes failing main workflow run 28849220022)

## Description

This resets the remote BuildKit buildx builder before publishing and retries `task publish-and-sign` up to three times when the remote BuildKit transport drops during multi-platform image publishing.

The failed main run hit this error in `push-latest-images`:

```text
failed to receive status: rpc error: code = Unavailable desc = closing transport due to: connection error: desc = \"error reading from server: EOF\", received prior goaway: code: NO_ERROR, debug data: \"graceful_stop\"
```

## Additional context

This is a targeted CI reliability fix for the publish path. It does not change application code. Validation: parsed `.github/actions/publish-and-sign/action.yaml` as YAML and ran `git diff --check`.