### PR TITLE
fix(state): terminate collectResults loop using labeled break

### DIFF
--- a/internal/satellite/state/state_process.go
+++ b/internal/satellite/state/state_process.go
@@ -281,6 +281,7 @@ func (f *FetchAndReplicateStateProcess) collectResults(
 	receivedStateFetchers := 0
 	receivedConfigFetcher := false
 
+outer:
 	for {
 		select {
 		case <-ctx.Done():
@@ -315,7 +316,7 @@ func (f *FetchAndReplicateStateProcess) collectResults(
 		}
 
 		if receivedStateFetchers == expectedCount && receivedConfigFetcher {
-			break
+			break outer
 		}
 	}
 


### PR DESCRIPTION
- Fixes: #519 

## Description

This PR fixes a bug in `collectResults` where a bare `break` statement was used inside a loop containing a `select` block. In Go, a bare `break` only terminates the innermost `select` statement, rather than the enclosing `for` loop.

### What changed:
- Added a loop label `outer` to the `for` loop.
- Updated the break condition to use `break outer` to terminate the collection loop once all state and config fetcher results have been processed.
This allows the function to exit cleanly, execute the error-handling block, and return a clean success/failure status rather than blocking indefinitely until context cancellation.

## Additional context

- Confirmed all unit tests pass locally: `go test ./...`

<!-- Add any other context about the PR here. -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

