### PR TITLE
fix: include GC binaries in release assets

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -102,12 +102,35 @@ builds:
   mod_timestamp: "{{ .CommitTimestamp }}"
 
 archives:
-  - format: tar.gz
+  - id: satellite
+    ids: [satellite]
+    formats: [tar.gz]
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
+  - id: ground-control
+    ids: [ground-control]
+    name_template: "ground-control_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
 nfpms:
-  -
+  - id: satellite
+    ids: [satellite]
+    package_name: harbor-satellite
+    homepage: https://github.com/container-registry/harbor-satellite
+    maintainer: Harbor Community
+    description: |-
+      Harbor Satellite is a lightweight, secure, and easy-to-use container registry that can be deployed in a few minutes on remote edge locations.
+    formats:
+      - rpm
+      - deb
+      - apk
+      - archlinux
+  - id: ground-control
+    ids: [ground-control]
+    package_name: ground-control
     homepage: https://github.com/container-registry/harbor-satellite
     maintainer: Harbor Community
     description: |-

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -121,8 +121,7 @@ nfpms:
     package_name: harbor-satellite
     homepage: https://github.com/container-registry/harbor-satellite
     maintainer: Harbor Community
-    description: |-
-      Harbor Satellite is a lightweight, secure, and easy-to-use container registry that can be deployed in a few minutes on remote edge locations.
+    description: "Harbor Satellite "
     formats:
       - rpm
       - deb
@@ -133,8 +132,7 @@ nfpms:
     package_name: ground-control
     homepage: https://github.com/container-registry/harbor-satellite
     maintainer: Harbor Community
-    description: |-
-      Harbor Satellite is a lightweight, secure, and easy-to-use container registry that can be deployed in a few minutes on remote edge locations.
+    description: "Ground Control"
     formats:
       - rpm
       - deb


### PR DESCRIPTION
## Description

This PR fixes goreleaser packaging conflicts that caused the GC binaries to be missing from release assets. The previous archive and nfpm configurations were shared between both builds which led to naming conflicts and duplicate package generation. The configuration is now split so each build has its own archive, package name, and IDs, preventing collisions during packaging. 

<img width="1025" height="542" alt="image" src="https://github.com/user-attachments/assets/9df48b24-583a-48c6-a5c5-4252e7d424ba" />

<img width="545" height="126" alt="image" src="https://github.com/user-attachments/assets/a21c4c5d-bd0d-48e9-ad35-d65a4e68b73a" />

<!-- Add any other context about the PR here. -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Packaging**
  * Updated release archives for Satellite and Ground Control with independent packaging formats.
  * Windows downloads are now provided as ZIP archives.
  * Added dedicated Linux package outputs for each application, including RPM, DEB, APK, and Arch Linux formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->