### PR TITLE
feat :- implement headless satellite mode to run standalone without ground control

### DIFF
--- a/cmd/harbor-satellite/main.go
+++ b/cmd/harbor-satellite/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/container-registry/harbor-satellite/internal/satellite/parsec"
 	"github.com/container-registry/harbor-satellite/internal/satellite/registry"
 	"github.com/container-registry/harbor-satellite/internal/satellite/watcher"
+	"github.com/container-registry/harbor-satellite/internal/satellite/state"
 	"github.com/container-registry/harbor-satellite/internal/utils"
 	"github.com/container-registry/harbor-satellite/pkg/config"
 
@@ -63,6 +64,7 @@ type SatelliteOptions struct {
 	// PARSEC hardware-backed identity (optional; requires parsec build tag and running daemon)
 	ParsecEnabled    bool
 	ParsecSocketPath string
+	Headless         bool
 }
 
 func main() {
@@ -90,6 +92,7 @@ func main() {
 		ImageDir:               envCfg.ImageDir,
 		ParsecEnabled:          envCfg.ParsecEnabled,
 		ParsecSocketPath:       envCfg.ParsecSocketPath,
+		Headless:               envCfg.Headless,
 	}
 	shutdownTimeout := envCfg.ShutdownTimeout
 
@@ -115,6 +118,7 @@ func main() {
 	flag.StringVar(&opts.ImageDir, "image-dir", opts.ImageDir, "Override image directory for direct delivery (auto-detected if empty)")
 	flag.BoolVar(&opts.ParsecEnabled, "parsec-enabled", opts.ParsecEnabled, "Enable hardware-backed identity via PARSEC (requires parsec build tag and running PARSEC daemon)")
 	flag.StringVar(&opts.ParsecSocketPath, "parsec-socket", opts.ParsecSocketPath, "PARSEC daemon socket path")
+	flag.BoolVar(&opts.Headless, "headless", opts.Headless, "Run satellite in headless mode (without ground control)")
 
 	flag.Parse()
 	if opts.Token == "" {
@@ -151,8 +155,8 @@ func main() {
 		pathConfig.ZotStorageDir = opts.RegistryDataDir
 	}
 
-	// For --fallback-only mode, relax token/gc-url requirements
-	if !opts.FallbackOnly {
+	// For --fallback-only and --headless modes, relax token/gc-url/harbor-registry-url requirements
+	if !opts.FallbackOnly && !opts.Headless {
 		if !opts.SPIFFEEnabled && (opts.Token == "" || opts.GroundControlURL == "") {
 			fmt.Println("Missing required arguments: --token and --ground-control-url or matching env vars (or enable SPIFFE with --spiffe-enabled).")
 			os.Exit(1)
@@ -287,10 +291,17 @@ func run(opts SatelliteOptions, pathConfig *config.PathConfig, shutdownTimeout s
 		cryptoProvider = crypto.NewAESProvider()
 	}
 
-	cm, warnings, err := config.InitConfigManager(opts.Token, opts.GroundControlURL, pathConfig.ConfigFile, pathConfig.PrevConfigFile, opts.JSONLogging, opts.UseUnsecure, cryptoProvider)
+	cm, warnings, err := config.InitConfigManager(opts.Token, opts.GroundControlURL, pathConfig.ConfigFile, pathConfig.PrevConfigFile, opts.JSONLogging, opts.UseUnsecure, cryptoProvider, opts.Headless)
 	if err != nil {
 		fmt.Printf("Error initiating the config manager: %v\n", err)
 		return err
+	}
+
+	if opts.Headless {
+		if err := state.ValidateStateFile(pathConfig.StateFile); err != nil {
+			fmt.Printf("Error validating local state file on startup: %v\n", err)
+			return err
+		}
 	}
 
 	// Apply SPIFFE config from CLI flags

--- a/internal/env/harbor-satellite.go
+++ b/internal/env/harbor-satellite.go
@@ -25,6 +25,7 @@ type HarborSatellite struct {
 	ImageDir               string `env:"IMAGE_DIR"`
 	ParsecEnabled          bool   `env:"PARSEC_ENABLED"            envDefault:"false"`
 	ParsecSocketPath       string `env:"PARSEC_SOCKET"             envDefault:"/run/parsec/parsec.sock"`
+	Headless               bool   `env:"HEADLESS"                  envDefault:"false"`
 }
 
 func (h HarborSatellite) ApplyDefaults() HarborSatellite {

--- a/internal/satellite/satellite.go
+++ b/internal/satellite/satellite.go
@@ -31,6 +31,11 @@ func (s *Satellite) Run(ctx context.Context) error {
 	log := logger.FromContext(ctx)
 	log.Info().Msg("Starting Satellite")
 
+	if s.cm.IsHeadless() {
+		log.Info().Msg("Satellite is running in HEADLESS mode (Ground Control communication is disabled)")
+		return nil
+	}
+
 	fetchAndReplicateStateProcess := state.NewFetchAndReplicateStateProcess(s.cm, s.stateFilePath, log)
 	s.stateProcess = fetchAndReplicateStateProcess
 

--- a/internal/satellite/state/state_persistence.go
+++ b/internal/satellite/state/state_persistence.go
@@ -91,3 +91,32 @@ func LoadState(path string) (*PersistedState, error) {
 
 	return &persisted, nil
 }
+
+// ValidateStateFile reads and validates the state file for headless mode.
+func ValidateStateFile(path string) error {
+	persisted, err := LoadState(path)
+	if err != nil {
+		return fmt.Errorf("invalid or corrupted state file: %w", err)
+	}
+	if persisted == nil {
+		return fmt.Errorf("state file not found at %s", path)
+	}
+	for i, g := range persisted.Groups {
+		if g.URL == "" {
+			return fmt.Errorf("group %d has empty URL", i)
+		}
+		for j, e := range g.Entities {
+			if e.Name == "" {
+				return fmt.Errorf("entity %d in group %s has empty name", j, g.URL)
+			}
+			if e.Tag == "" {
+				return fmt.Errorf("entity %d in group %s has empty tag", j, g.URL)
+			}
+			if e.Digest == "" {
+				return fmt.Errorf("entity %d in group %s has empty digest", j, g.URL)
+			}
+		}
+	}
+	return nil
+}
+

--- a/internal/satellite/state/state_persistence_test.go
+++ b/internal/satellite/state/state_persistence_test.go
@@ -101,3 +101,72 @@ func TestSaveEmptyState(t *testing.T) {
 		t.Errorf("state file should exist: %v", err)
 	}
 }
+
+func TestValidateStateFile_ErrorCases(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	// 1. Missing file
+	err := ValidateStateFile(path)
+	if err == nil {
+		t.Fatal("expected error for missing state file")
+	}
+
+	// 2. Corrupted JSON
+	if err := os.WriteFile(path, []byte("invalid-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err = ValidateStateFile(path)
+	if err == nil {
+		t.Fatal("expected error for invalid json state file")
+	}
+
+	// 3. Invalid entity (missing digest)
+	stateMapInvalid := []StateMap{
+		{
+			url: "http://registry.example.com/group1",
+			Entities: []Entity{
+				{Name: "alpine", Repository: "library", Tag: "latest", Digest: ""},
+			},
+		},
+	}
+	if err := SaveState(path, stateMapInvalid, "sha256:config123"); err != nil {
+		t.Fatal(err)
+	}
+	err = ValidateStateFile(path)
+	if err == nil {
+		t.Fatal("expected error for entity with missing digest")
+	}
+}
+
+func TestValidateStateFile_ValidCases(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	// 1. Valid empty state file
+	if err := SaveState(path, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	err := ValidateStateFile(path)
+	if err != nil {
+		t.Fatalf("expected no error for empty state, got %v", err)
+	}
+
+	// 2. Valid state file with groups and entities
+	stateMap := []StateMap{
+		{
+			url: "http://registry.example.com/group1",
+			Entities: []Entity{
+				{Name: "alpine", Repository: "library", Tag: "latest", Digest: "sha256:abc123"},
+			},
+		},
+	}
+	if err := SaveState(path, stateMap, "sha256:config123"); err != nil {
+		t.Fatal(err)
+	}
+	err = ValidateStateFile(path)
+	if err != nil {
+		t.Fatalf("expected no error for valid state, got %v", err)
+	}
+}
+

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -204,6 +204,7 @@ type AppConfig struct {
 	HarborRegistryURL         string                 `json:"harbor_registry_url,omitempty"`
 	DirectDelivery            DirectDeliveryConfig   `json:"direct_delivery,omitempty"`
 	Audit                     AuditConfig            `json:"audit,omitempty"`
+	Headless                  bool                   `json:"headless,omitempty"`
 }
 
 type StateConfig struct {

--- a/pkg/config/getters.go
+++ b/pkg/config/getters.go
@@ -225,3 +225,11 @@ func (cm *ConfigManager) GetDirectDeliveryConfig() DirectDeliveryConfig {
 
 	return cm.config.AppConfig.DirectDelivery
 }
+
+func (cm *ConfigManager) IsHeadless() bool {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	return cm.config.AppConfig.Headless
+}
+

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -176,13 +176,16 @@ func (cm *ConfigManager) ReloadConfig() ([]ConfigChange, []string, error) {
 	return changes, warnings, nil
 }
 
-func InitConfigManager(token, groundControlURL, configPath, prevConfigPath string, jsonLogging, useUnsecure bool, cryptoProvider crypto.Provider) (*ConfigManager, []string, error) {
+func InitConfigManager(token, groundControlURL, configPath, prevConfigPath string, jsonLogging, useUnsecure bool, cryptoProvider crypto.Provider, headless bool) (*ConfigManager, []string, error) {
 	var cfg *Config
 	var err error
 
-	if _, err := url.ParseRequestURI(groundControlURL); err != nil {
-		return nil, nil, fmt.Errorf("invalid URL provided for ground_control_url env var: %w", err)
+	if !headless {
+		if _, err := url.ParseRequestURI(groundControlURL); err != nil {
+			return nil, nil, fmt.Errorf("invalid URL provided for ground_control_url env var: %w", err)
+		}
 	}
+
 
 	cfg, err = readAndReturnConfig(configPath, cryptoProvider)
 	if errors.Is(err, os.ErrNotExist) {
@@ -190,6 +193,8 @@ func InitConfigManager(token, groundControlURL, configPath, prevConfigPath strin
 	} else if err != nil {
 		return nil, nil, fmt.Errorf("failed to read config: %w", err)
 	}
+
+	cfg.AppConfig.Headless = headless
 
 	// Override use_unsecure from CLI/env if set
 	if useUnsecure {

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -91,7 +91,7 @@ func TestInitConfigManager(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := InitConfigManager(token, ground_control_url, tt.path, "", false, false, crypto.NewAESProvider())
+			_, _, err := InitConfigManager(token, ground_control_url, tt.path, "", false, false, crypto.NewAESProvider(), false)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -99,6 +99,13 @@ func TestInitConfigManager(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInitConfigManagerHeadless(t *testing.T) {
+	token := "dummy-token"
+	// Invalid or empty GC URL should be allowed when headless is true
+	_, _, err := InitConfigManager(token, "", "/non/existent/path.json", "", false, false, crypto.NewAESProvider(), true)
+	require.NoError(t, err)
 }
 
 func TestConfigManager_WriteConfig(t *testing.T) {

--- a/pkg/config/modifiers.go
+++ b/pkg/config/modifiers.go
@@ -163,3 +163,4 @@ func ApplyHarborRegistryOverride(sc StateConfig, override string) (StateConfig, 
 
 	return sc, nil
 }
+

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -35,8 +35,10 @@ func ValidateAndEnforceDefaults(config *Config, defaultGroundControlURL string) 
 		config.AppConfig.GroundControlURL = URL(defaultGroundControlURL)
 	}
 
-	if _, err := url.ParseRequestURI(string(config.AppConfig.GroundControlURL)); err != nil {
-		return nil, nil, fmt.Errorf("invalid URL provided for ground_control_url: %w", err)
+	if !config.AppConfig.Headless {
+		if _, err := url.ParseRequestURI(string(config.AppConfig.GroundControlURL)); err != nil {
+			return nil, nil, fmt.Errorf("invalid URL provided for ground_control_url: %w", err)
+		}
 	}
 
 	warnings = append(warnings, validateAndEnforceLogLevel(config)...)


### PR DESCRIPTION
- Fixes: #227

## Description
This Pull Request implements the Headless Satellite Mode, allowing the Harbor Satellite to run standalone in edge/isolated environments without relying on or communicating with Ground Control.

Key changes:
- Added `--headless` CLI flag and `HEADLESS` environment variable support.
- Skipped all Ground Control-dependent schedulers (Zero Touch Registration, Heartbeat/Status Reporting, and State Replication) when headless mode is active.
- Relaxed command-line argument validation for token, ground control, and harbor registry URLs under headless mode.
- Added `ValidateStateFile` startup validation for the local `state.json` config.
- Clearly log that the satellite is running in headless mode.
- Added unit tests for headless configuration initialization and state validation.

## Additional context
All automated test suites for `pkg/config` and `internal/satellite/state` have passed successfully.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

