### PR TITLE
feat :- implement pre-load images for offline bootstrap

### DIFF
--- a/cmd/harbor-satellite/main.go
+++ b/cmd/harbor-satellite/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/container-registry/harbor-satellite/internal/satellite/parsec"
 	"github.com/container-registry/harbor-satellite/internal/satellite/registry"
 	"github.com/container-registry/harbor-satellite/internal/satellite/watcher"
+	"github.com/container-registry/harbor-satellite/internal/satellite/state"
 	"github.com/container-registry/harbor-satellite/internal/utils"
 	"github.com/container-registry/harbor-satellite/pkg/config"
 
@@ -66,6 +67,118 @@ type SatelliteOptions struct {
 }
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "bootstrap" {
+		bootstrapCmd := flag.NewFlagSet("bootstrap", flag.ExitOnError)
+		var artifactPath string
+		var configDir string
+		var useUnsecure bool
+		var jsonLogging bool
+		var byoRegistry bool
+		var registryURL string
+		var registryUsername string
+		var registryPassword string
+
+		bootstrapCmd.StringVar(&artifactPath, "artifact", "", "Path to OCI layout directory or tar archive file")
+		bootstrapCmd.StringVar(&configDir, "config-dir", "", "Configuration directory path (default: ~/.config/satellite)")
+		bootstrapCmd.BoolVar(&useUnsecure, "use-unsecure", false, "Use insecure (HTTP) connections to registries")
+		bootstrapCmd.BoolVar(&jsonLogging, "json-logging", true, "Enable JSON logging")
+		bootstrapCmd.BoolVar(&byoRegistry, "byo-registry", false, "Use external registry instead of embedded Zot")
+		bootstrapCmd.StringVar(&registryURL, "registry-url", "", "External registry URL")
+		bootstrapCmd.StringVar(&registryUsername, "registry-username", "", "External registry username")
+		bootstrapCmd.StringVar(&registryPassword, "registry-password", "", "External registry password")
+
+		_ = bootstrapCmd.Parse(os.Args[2:])
+
+		if artifactPath == "" {
+			fmt.Println("Missing required argument: --artifact")
+			os.Exit(1)
+		}
+
+		// Resolve config directory path
+		if configDir == "" {
+			var err error
+			configDir, err = config.DefaultConfigDir()
+			if err != nil {
+				fmt.Printf("Error resolving default config directory: %v\n", err)
+				os.Exit(1)
+			}
+		}
+
+		pathConfig, err := config.ResolvePathConfig(configDir)
+		if err != nil {
+			fmt.Printf("Error resolving config paths: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Set up dummy crypto provider
+		cryptoProvider := crypto.NewAESProvider()
+
+		// Read configuration, allow missing file because we are bootstrapping
+		cm, _, err := config.InitConfigManager("", "http://localhost:8080", pathConfig.ConfigFile, pathConfig.PrevConfigFile, jsonLogging, useUnsecure, cryptoProvider)
+		if err != nil {
+			fmt.Printf("Error initiating config manager: %v\n", err)
+			os.Exit(1)
+		}
+
+		if byoRegistry {
+			cm.With(
+				config.SetBringOwnRegistry(true),
+				config.SetLocalRegistryURL(registryURL),
+				config.SetLocalRegistryUsername(registryUsername),
+				config.SetLocalRegistryPassword(registryPassword),
+			)
+		} else {
+			// Update Zot config with storage path
+			zotConfigJSON, err := config.BuildZotConfigWithStoragePath(pathConfig.ZotStorageDir)
+			if err != nil {
+				fmt.Printf("Error building Zot config: %v\n", err)
+				os.Exit(1)
+			}
+			cm.With(config.SetZotConfigRaw(json.RawMessage(zotConfigJSON)))
+		}
+
+		// Start background context
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ctx, log := logger.InitLogger(ctx, cm.GetLogLevel(), jsonLogging, nil)
+
+		// Start Zot if using embedded registry
+		if !cm.GetOwnRegistry() {
+			log.Info().Msg("Launching embedded Zot registry for bootstrap")
+			zm := registry.NewZotManager(log.With().Str("component", "zot manager").Logger(), cm.GetRawZotConfig(), pathConfig.ZotTempConfig)
+			if err := zm.HandleRegistrySetup(ctx); err != nil {
+				log.Fatal().Err(err).Msg("Failed to start embedded registry")
+			}
+		}
+
+		// Resolve local registry endpoint for pushing
+		localRegistryEndpoint, err := resolveLocalRegistryEndpoint(cm)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to resolve local registry endpoint")
+		}
+
+		regCreds := cm.GetRemoteRegistryCredentials()
+
+		bootstrapOpts := state.BootstrapOptions{
+			ArtifactPath:     artifactPath,
+			ConfigDir:        configDir,
+			StateFilePath:    pathConfig.StateFile,
+			RegistryURL:      localRegistryEndpoint,
+			RegistryUsername: regCreds.Username,
+			RegistryPassword: regCreds.Password,
+			UseUnsecure:      useUnsecure || cm.UseUnsecure(),
+		}
+
+		err = state.BootstrapSatellite(ctx, bootstrapOpts)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Bootstrap failed")
+		}
+
+		log.Info().Msg("Bootstrap completed successfully. Shutting down registry.")
+		return
+	}
+
 	_ = godotenv.Load(".env") //nolint:errcheck // .env file is optional
 
 	if err := env.LoadSatellite(); err != nil {

--- a/internal/satellite/state/bootstrap.go
+++ b/internal/satellite/state/bootstrap.go
@@ -1,0 +1,234 @@
+package state
+
+import (
+	"archive/tar"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/container-registry/harbor-satellite/internal/logger"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+// BootstrapOptions holds configuration for the bootstrap process.
+type BootstrapOptions struct {
+	ArtifactPath      string
+	ConfigDir         string
+	StateFilePath     string
+	RegistryURL       string
+	RegistryUsername  string
+	RegistryPassword  string
+	UseUnsecure       bool
+}
+
+// BootstrapSatellite loads OCI layout or tarball archive and pushes images to the local registry.
+func BootstrapSatellite(ctx context.Context, opts BootstrapOptions) error {
+	log := logger.FromContext(ctx)
+	log.Info().Str("artifact", opts.ArtifactPath).Msg("Starting satellite image bootstrap process")
+
+	// Detect if artifact is a directory or file
+	info, err := os.Stat(opts.ArtifactPath)
+	if err != nil {
+		return fmt.Errorf("failed to access artifact path %s: %w", opts.ArtifactPath, err)
+	}
+
+	var ociDir string
+	var tempDir string
+
+	if info.IsDir() {
+		ociDir = opts.ArtifactPath
+		log.Info().Msgf("Detected OCI layout directory at %s", ociDir)
+	} else {
+		// Create temporary directory for extraction
+		tempDir, err = os.MkdirTemp("", "satellite-bootstrap-*")
+		if err != nil {
+			return fmt.Errorf("failed to create temp directory for extraction: %w", err)
+		}
+		defer func() {
+			if tempDir != "" {
+				log.Debug().Str("path", tempDir).Msg("Cleaning up temp directory")
+				_ = os.RemoveAll(tempDir)
+			}
+		}()
+
+		log.Info().Msgf("Detected archive file. Extracting %s to %s", opts.ArtifactPath, tempDir)
+		if err := extractTar(opts.ArtifactPath, tempDir); err != nil {
+			return fmt.Errorf("failed to extract tarball: %w", err)
+		}
+		ociDir = tempDir
+	}
+
+	// Load OCI layout
+	ociLayout, err := layout.FromPath(ociDir)
+	if err != nil {
+		return fmt.Errorf("failed to load OCI layout from path %s: %w", ociDir, err)
+	}
+
+	index, err := ociLayout.ImageIndex()
+	if err != nil {
+		return fmt.Errorf("failed to read OCI layout index: %w", err)
+	}
+
+	indexManifest, err := index.IndexManifest()
+	if err != nil {
+		return fmt.Errorf("failed to parse index manifest: %w", err)
+	}
+
+	pushAuth := authn.FromConfig(authn.AuthConfig{
+		Username: opts.RegistryUsername,
+		Password: opts.RegistryPassword,
+	})
+
+	var nameOpts []name.Option
+	pushOpts := []remote.Option{remote.WithAuth(pushAuth), remote.WithContext(ctx)}
+
+	if opts.UseUnsecure {
+		nameOpts = append(nameOpts, name.Insecure)
+	}
+
+	var entities []Entity
+
+	for i, manifestDesc := range indexManifest.Manifests {
+		// Read reference name from annotations (standard: org.opencontainers.image.ref.name)
+		refName := manifestDesc.Annotations["org.opencontainers.image.ref.name"]
+		if refName == "" {
+			// Fallback: generate a dummy name using digest
+			refName = fmt.Sprintf("library/bootstrap:%s", manifestDesc.Digest.Hex[:12])
+			log.Warn().Msgf("No reference name annotation found for manifest %s. Using fallback: %s", manifestDesc.Digest.String(), refName)
+		}
+
+		log.Info().Msgf("Loading image/index [%d/%d]: %s", i+1, len(indexManifest.Manifests), refName)
+
+		// Parse target reference on local registry
+		dstRefStr := fmt.Sprintf("%s/%s", opts.RegistryURL, refName)
+		dstRef, err := name.ParseReference(dstRefStr, nameOpts...)
+		if err != nil {
+			return fmt.Errorf("failed to parse destination ref %s: %w", dstRefStr, err)
+		}
+
+		// Pull image/index from OCI layout and push to registry
+		img, err := index.Image(manifestDesc.Digest)
+		if err == nil {
+			// Validate integrity
+			_, err = img.Manifest()
+			if err != nil {
+				return fmt.Errorf("manifest integrity check failed for %s: %w", refName, err)
+			}
+			log.Info().Msgf("Pushing image %s to local registry", refName)
+			if err := remote.Write(dstRef, img, pushOpts...); err != nil {
+				return fmt.Errorf("failed to push image %s: %w", refName, err)
+			}
+		} else {
+			idx, err := index.ImageIndex(manifestDesc.Digest)
+			if err != nil {
+				return fmt.Errorf("failed to retrieve index or image for %s: %w", refName, err)
+			}
+			// Validate integrity
+			_, err = idx.IndexManifest()
+			if err != nil {
+				return fmt.Errorf("index manifest integrity check failed for %s: %w", refName, err)
+			}
+			log.Info().Msgf("Pushing index %s to local registry", refName)
+			if err := remote.WriteIndex(dstRef, idx, pushOpts...); err != nil {
+				return fmt.Errorf("failed to push index %s: %w", refName, err)
+			}
+		}
+
+		// Split the reference into repository and image name
+		// library/alpine:latest -> repo=library, name=alpine, tag=latest
+		parsedRef, err := name.ParseReference(refName)
+		if err != nil {
+			return fmt.Errorf("failed to parse OCI ref %s: %w", refName, err)
+		}
+
+		repoPath := parsedRef.Context().RepositoryStr()
+		tagValue := parsedRef.Identifier()
+
+		parts := strings.Split(repoPath, "/")
+		var repo, imgName string
+		if len(parts) >= 2 {
+			repo = parts[0]
+			imgName = strings.Join(parts[1:], "/")
+		} else {
+			repo = "library"
+			imgName = repoPath
+		}
+
+		entities = append(entities, Entity{
+			Name:       imgName,
+			Repository: repo,
+			Tag:        tagValue,
+			Digest:     manifestDesc.Digest.String(),
+		})
+	}
+
+	// Generate and write state.json
+	stateMap := []StateMap{
+		{
+			url:      "offline-bootstrap",
+			Entities: entities,
+		},
+	}
+
+	log.Info().Str("path", opts.StateFilePath).Msg("Writing state.json from bootstrapped images")
+	if err := SaveState(opts.StateFilePath, stateMap, ""); err != nil {
+		return fmt.Errorf("failed to save bootstrap state: %w", err)
+	}
+
+	log.Info().Msg("Bootstrap completed successfully")
+	return nil
+}
+
+// extractTar extracts a tar file to the destination directory.
+func extractTar(tarPath, destDir string) error {
+	file, err := os.Open(tarPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	tarReader := tar.NewReader(file)
+
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		target := filepath.Join(destDir, header.Name)
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			dir := filepath.Dir(target)
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return err
+			}
+
+			outFile, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR|os.O_TRUNC, header.FileInfo().Mode())
+			if err != nil {
+				return err
+			}
+
+			if _, err := io.Copy(outFile, tarReader); err != nil {
+				outFile.Close()
+				return err
+			}
+			outFile.Close()
+		}
+	}
+
+	return nil
+}

--- a/internal/satellite/state/bootstrap_test.go
+++ b/internal/satellite/state/bootstrap_test.go
@@ -1,0 +1,107 @@
+package state
+
+import (
+	"archive/tar"
+	"context"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractTar(t *testing.T) {
+	tempDir := t.TempDir()
+	tarFile := filepath.Join(tempDir, "test.tar")
+
+	// Create a dummy tarball
+	f, err := os.Create(tarFile)
+	require.NoError(t, err)
+	defer f.Close()
+
+	tw := tar.NewWriter(f)
+	
+	// Add a directory
+	err = tw.WriteHeader(&tar.Header{
+		Name:     "subfolder/",
+		Typeflag: tar.TypeDir,
+	})
+	require.NoError(t, err)
+
+	// Add a file
+	content := []byte("hello world")
+	err = tw.WriteHeader(&tar.Header{
+		Name:     "subfolder/file.txt",
+		Size:     int64(len(content)),
+		Typeflag: tar.TypeReg,
+		Mode:     0o644,
+	})
+	require.NoError(t, err)
+	_, err = tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+
+	// Extract
+	extractDir := filepath.Join(tempDir, "extract")
+	require.NoError(t, extractTar(tarFile, extractDir))
+
+	// Verify
+	extractedFile := filepath.Join(extractDir, "subfolder/file.txt")
+	require.FileExists(t, extractedFile)
+	data, err := os.ReadFile(extractedFile)
+	require.NoError(t, err)
+	require.Equal(t, "hello world", string(data))
+}
+
+func TestBootstrapSatellite(t *testing.T) {
+	// Start in-memory mock registry
+	regHandler := registry.New()
+	server := httptest.NewServer(regHandler)
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	tempDir := t.TempDir()
+	ociPath := filepath.Join(tempDir, "oci")
+
+	// Programmatically write OCI layout
+	path, err := layout.Write(ociPath, empty.Index)
+	require.NoError(t, err)
+
+	img := empty.Image
+	err = path.AppendImage(img, layout.WithAnnotations(map[string]string{
+		"org.opencontainers.image.ref.name": "library/alpine:latest",
+	}))
+	require.NoError(t, err)
+
+	stateFile := filepath.Join(tempDir, "state.json")
+
+	opts := BootstrapOptions{
+		ArtifactPath:  ociPath,
+		ConfigDir:     tempDir,
+		StateFilePath: stateFile,
+		RegistryURL:   u.Host,
+		UseUnsecure:   true,
+	}
+
+	err = BootstrapSatellite(context.Background(), opts)
+	require.NoError(t, err)
+
+	// Verify state file generated
+	require.FileExists(t, stateFile)
+	persisted, err := LoadState(stateFile)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	require.Len(t, persisted.Groups, 1)
+	require.Equal(t, "offline-bootstrap", persisted.Groups[0].URL)
+	require.Len(t, persisted.Groups[0].Entities, 1)
+	require.Equal(t, "alpine", persisted.Groups[0].Entities[0].Name)
+	require.Equal(t, "library", persisted.Groups[0].Entities[0].Repository)
+	require.Equal(t, "latest", persisted.Groups[0].Entities[0].Tag)
+}


### PR DESCRIPTION
- Fixes: #244

## Description
This Pull Request implements the `bootstrap` subcommand to support pre-loading a satellite with container images from an OCI layout directory or a tar archive file. This is crucial for fully air-gapped environments where Ground Control or Harbor cannot be reached during initialization.

Key changes:
- Introduced the `bootstrap` subcommand (`harbor-satellite bootstrap --artifact <path>`).
- Implemented OCI layout loading and extraction from tar archive files.
- Integrated background initialization of the embedded Zot registry to handle image pushing.
- Generates a local `state.json` file containing metadata of all bootstrapped images.
- Validates manifest and index integrity during image loading.
- Added comprehensive unit tests for tarball extraction and the bootstrap flow.

## Additional context
Unit tests for `pkg/config` and `internal/satellite/state` are passing successfully.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated `bootstrap` command for initializing a satellite from an OCI image layout or tarball.
  * Supports embedded or external registries, registry credentials, custom configuration directories, secure or insecure connections, and JSON logging.
  * Automatically publishes bundled artifacts and saves the resulting offline bootstrap state.
* **Bug Fixes**
  * Improved handling of artifact extraction and image or index publishing during bootstrap.
* **Tests**
  * Added coverage for archive extraction and successful OCI layout bootstrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->