### PR TITLE
ci: parallelize latest image publishing by platform

### DIFF
--- a/.github/actions/publish-and-sign/action.yaml
+++ b/.github/actions/publish-and-sign/action.yaml
@@ -5,6 +5,22 @@ inputs:
   IMAGE_TAGS:
     description: 'Tags for the image, e.g. "latest, v1.0.0"'
     required: true
+  SOURCE_IMAGE_TAGS:
+    description: "Source tags used for intermediate platform images"
+    required: false
+  PUBLISH_MODE:
+    description: "Publish mode: all, platform, or manifest"
+    required: false
+    default: all
+  PLATFORM:
+    description: "Single platform to build, e.g. linux/amd64"
+    required: false
+  ARCH_SUFFIX:
+    description: "Architecture suffix for temporary image tags, e.g. amd64"
+    required: false
+  ARCH_SUFFIXES:
+    description: "Space-separated architecture suffixes to combine into the final manifest"
+    required: false
   GITHUB_TOKEN:
     description: "GitHub token"
     required: true
@@ -37,10 +53,14 @@ runs:
 
     - name: Set up Docker Buildx with remote BuildKit
       shell: bash
+      env:
+        BUILDER_SUFFIX: ${{ inputs.PUBLISH_MODE }}-${{ inputs.PLATFORM }}
       run: |
-        docker buildx rm remote >/dev/null 2>&1 || true
-        docker buildx create --name remote --driver remote tcp://buildkitd.github-runners.svc:1234 --use
-        docker buildx inspect remote --bootstrap
+        BUILDER_NAME=$(printf 'remote-%s-%s-%s' "${GITHUB_RUN_ID:-local}" "${GITHUB_RUN_ATTEMPT:-0}" "${BUILDER_SUFFIX:-default}" | tr -c 'A-Za-z0-9_.-' '-')
+        echo "BUILDX_BUILDER=$BUILDER_NAME" >> "$GITHUB_ENV"
+        docker buildx rm "$BUILDER_NAME" >/dev/null 2>&1 || true
+        docker buildx create --name "$BUILDER_NAME" --driver remote tcp://buildkitd.github-runners.svc:1234 --use
+        docker buildx inspect "$BUILDER_NAME" --bootstrap
 
     - name: Provide envsubst for Cosign installer
       shell: bash
@@ -76,7 +96,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
       run: cosign env
 
-    - name: Publish and Sign Both Components
+    - name: Publish Images or Manifest
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
@@ -85,9 +105,24 @@ runs:
         REG_PASS: ${{ inputs.REGISTRY_PASSWORD }}
         PROJECT_NAME: ${{ inputs.PROJECT_NAME }}
         TAG: ${{ inputs.IMAGE_TAGS }}
+        SOURCE_IMAGE_TAGS: ${{ inputs.SOURCE_IMAGE_TAGS }}
+        PUBLISH_MODE: ${{ inputs.PUBLISH_MODE }}
+        PLATFORM: ${{ inputs.PLATFORM }}
+        ARCH_SUFFIX: ${{ inputs.ARCH_SUFFIX }}
+        ARCH_SUFFIXES: ${{ inputs.ARCH_SUFFIXES }}
       run: |
         for attempt in 1 2 3; do
-          if task publish-and-sign; then
+          case "$PUBLISH_MODE" in
+            platform) publish_cmd=(task publish-platform) ;;
+            manifest) publish_cmd=(task publish-manifest-and-sign) ;;
+            all)      publish_cmd=(task publish-and-sign) ;;
+            *)
+              echo "Unsupported PUBLISH_MODE: $PUBLISH_MODE" >&2
+              exit 2
+              ;;
+          esac
+
+          if "${publish_cmd[@]}"; then
             exit 0
           else
             status=$?
@@ -98,13 +133,13 @@ runs:
           fi
 
           echo "Publish attempt $attempt failed with status $status; resetting remote BuildKit builder before retry..."
-          docker buildx rm remote >/dev/null 2>&1 || true
-          if ! docker buildx create --name remote --driver remote tcp://buildkitd.github-runners.svc:1234 --use; then
+          docker buildx rm "$BUILDX_BUILDER" >/dev/null 2>&1 || true
+          if ! docker buildx create --name "$BUILDX_BUILDER" --driver remote tcp://buildkitd.github-runners.svc:1234 --use; then
             echo "Remote BuildKit builder creation failed; retrying after backoff..."
             sleep $((attempt * 20))
             continue
           fi
-          if ! docker buildx inspect remote --bootstrap; then
+          if ! docker buildx inspect "$BUILDX_BUILDER" --bootstrap; then
             echo "Remote BuildKit builder bootstrap failed; retrying after backoff..."
             sleep $((attempt * 20))
             continue

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,10 @@ on:
       - "*.md"
       - "assets/**"
 
+concurrency:
+  group: latest-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   push-latest-images:
     permissions:
@@ -121,6 +125,7 @@ jobs:
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
+          repo-token: ${{ github.token }}
 
       - name: Install GoReleaser
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,20 @@ jobs:
       id-token: write
     runs-on: container-registry
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch_suffix: amd64
+          - platform: linux/arm64
+            arch_suffix: arm64
+          - platform: linux/ppc64le
+            arch_suffix: ppc64le
+          - platform: linux/s390x
+            arch_suffix: s390x
+          - platform: linux/riscv64
+            arch_suffix: riscv64
     steps:
       - name: Print GitHub ref for debugging
         run: |
@@ -28,11 +42,42 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Publish and Sign Snapshot Image
+      - name: Publish Snapshot Platform Image
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main')
         uses: ./.github/actions/publish-and-sign
         with:
           IMAGE_TAGS: latest
+          SOURCE_IMAGE_TAGS: latest-${{ github.sha }}
+          PUBLISH_MODE: platform
+          PLATFORM: ${{ matrix.platform }}
+          ARCH_SUFFIX: ${{ matrix.arch_suffix }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+          REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS }}
+          REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
+          PROJECT_NAME: ${{ vars.PROJECT_NAME }}
+
+  create-latest-manifest:
+    needs: push-latest-images
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: container-registry
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Create and Sign Snapshot Manifest
+        uses: ./.github/actions/publish-and-sign
+        with:
+          IMAGE_TAGS: latest
+          SOURCE_IMAGE_TAGS: latest-${{ github.sha }}
+          PUBLISH_MODE: manifest
+          ARCH_SUFFIXES: amd64 arm64 ppc64le s390x riscv64
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
           REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,11 +11,33 @@ on:
       - "assets/**"
 
 concurrency:
-  group: latest-${{ github.ref_name }}
-  cancel-in-progress: true
+  # For pushes to main the publishing flow is two-phase (per-arch matrix then
+  # sequential manifest assembly for both components). Cancelling mid-run can
+  # leave satellite:latest and ground-control:latest pointing at different
+  # commits with nothing to repair the inconsistency, so we let main-branch
+  # runs queue instead of cancelling each other.
+  # For pull requests we keep cancel-in-progress: true for fast feedback.
+  group: ${{ github.ref == 'refs/heads/main' && 'publish-main' || format('ci-{0}', github.ref_name) }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  setup:
+    permissions: {}
+    runs-on: container-registry
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    outputs:
+      arches: ${{ steps.arch-list.outputs.arches }}
+      arch_suffixes: ${{ steps.arch-list.outputs.arch_suffixes }}
+    steps:
+      - name: Emit supported architectures
+        id: arch-list
+        run: |
+          ARCHES='["amd64","arm64","ppc64le","s390x","riscv64"]'
+          echo "arches=$ARCHES" >> "$GITHUB_OUTPUT"
+          echo "arch_suffixes=amd64 arm64 ppc64le s390x riscv64" >> "$GITHUB_OUTPUT"
+
   push-latest-images:
+    needs: [setup]
     permissions:
       contents: read
       id-token: write
@@ -24,17 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - platform: linux/amd64
-            arch_suffix: amd64
-          - platform: linux/arm64
-            arch_suffix: arm64
-          - platform: linux/ppc64le
-            arch_suffix: ppc64le
-          - platform: linux/s390x
-            arch_suffix: s390x
-          - platform: linux/riscv64
-            arch_suffix: riscv64
+        arch: ${{ fromJSON(needs.setup.outputs.arches) }}
     steps:
       - name: Print GitHub ref for debugging
         run: |
@@ -53,8 +65,8 @@ jobs:
           IMAGE_TAGS: latest
           SOURCE_IMAGE_TAGS: latest-${{ github.sha }}
           PUBLISH_MODE: platform
-          PLATFORM: ${{ matrix.platform }}
-          ARCH_SUFFIX: ${{ matrix.arch_suffix }}
+          PLATFORM: linux/${{ matrix.arch }}
+          ARCH_SUFFIX: ${{ matrix.arch }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
           REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS }}
@@ -62,7 +74,7 @@ jobs:
           PROJECT_NAME: ${{ vars.PROJECT_NAME }}
 
   create-latest-manifest:
-    needs: push-latest-images
+    needs: [setup, push-latest-images]
     permissions:
       contents: read
       id-token: write
@@ -81,12 +93,42 @@ jobs:
           IMAGE_TAGS: latest
           SOURCE_IMAGE_TAGS: latest-${{ github.sha }}
           PUBLISH_MODE: manifest
-          ARCH_SUFFIXES: amd64 arm64 ppc64le s390x riscv64
+          ARCH_SUFFIXES: ${{ needs.setup.outputs.arch_suffixes }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
           REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS }}
           REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
           PROJECT_NAME: ${{ vars.PROJECT_NAME }}
+
+  cleanup-temp-tags:
+    needs: [setup, create-latest-manifest]
+    permissions:
+      contents: read
+    runs-on: container-registry
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Task
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        with:
+          version: 3.x
+          repo-token: ${{ github.token }}
+
+      - name: Delete temporary per-arch source tags
+        continue-on-error: true
+        env:
+          REGISTRY: ${{ vars.REGISTRY_ADDRESS }}
+          REG_USER: ${{ vars.REGISTRY_USERNAME }}
+          REG_PASS: ${{ secrets.REGISTRY_PASSWORD }}
+          PROJECT_NAME: ${{ vars.PROJECT_NAME }}
+          SOURCE_IMAGE_TAGS: latest-${{ github.sha }}
+          ARCH_SUFFIXES: ${{ needs.setup.outputs.arch_suffixes }}
+        run: task cleanup-platform-tags
 
   publish-release:
     permissions:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -240,6 +240,21 @@ tasks:
           SOURCE_IMAGE_TAGS: "{{.SOURCE_TAGS}}"
           ARCH_SUFFIXES: "{{.ARCH_SUFFIXES}}"
 
+  cleanup-platform-tags:
+    desc: Delete temporary per-arch source tags from the registry after manifest assembly
+    vars:
+      REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
+      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
+      SOURCE_TAGS: "{{.SOURCE_IMAGE_TAGS | default .Env.SOURCE_IMAGE_TAGS}}"
+      ARCH_SUFFIXES: "{{.ARCH_SUFFIXES | default .Env.ARCH_SUFFIXES}}"
+    cmds:
+      - task: _publish:cleanup-platform-tags
+        vars:
+          REGISTRY: "{{.REGISTRY}}"
+          PROJECT_NAME: "{{.PROJECT_NAME}}"
+          SOURCE_IMAGE_TAGS: "{{.SOURCE_TAGS}}"
+          ARCH_SUFFIXES: "{{.ARCH_SUFFIXES}}"
+
   release:
     desc: Create release with GoReleaser
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -152,7 +152,7 @@ tasks:
     desc: "Publish both components to registry"
     aliases: [p]
     vars:
-      TAG: '{{.TAG | default "dev"}}'
+      TAG: '{{.TAG | default .Env.TAG | default "dev"}}'
       PLATFORMS: "{{.PLATFORMS}}"
     cmds:
       - task: _publish:both
@@ -164,7 +164,9 @@ tasks:
   publish-and-sign:
     desc: Build, push, and sign both components
     vars:
-      TAG: '{{.TAG | default "dev"}}'
+      TAG: '{{.TAG | default .Env.TAG | default "dev"}}'
+      REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
+      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
     cmds:
       - task: _publish:image-and-sign
         vars:
@@ -178,6 +180,65 @@ tasks:
           PROJECT_NAME: "{{.PROJECT_NAME}}"
           COMPONENT: ground-control
           IMAGE_TAGS: "{{.TAG}}"
+
+  publish-platform:
+    desc: Build and push one platform for both components
+    vars:
+      TAG: '{{.TAG | default .Env.TAG | default "dev"}}'
+      SOURCE_TAGS: "{{.SOURCE_IMAGE_TAGS | default .SOURCE_TAG | default .TAG}}"
+      PLATFORM_IMAGE_TAGS:
+        sh: |
+          printf '%s' "{{.SOURCE_TAGS}}" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/^v//' | awk 'NF { printf "%s%s-{{.ARCH_SUFFIX}}", sep, $0; sep="," }'
+      REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
+      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
+      PLATFORM: "{{.PLATFORM | default .Env.PLATFORM}}"
+      ARCH_SUFFIX: "{{.ARCH_SUFFIX | default .Env.ARCH_SUFFIX}}"
+    preconditions:
+      - sh: test -n "{{.PLATFORM}}"
+        msg: "PLATFORM is required. Set via task var or PLATFORM env var."
+      - sh: test -n "{{.ARCH_SUFFIX}}"
+        msg: "ARCH_SUFFIX is required. Set via task var or ARCH_SUFFIX env var."
+    cmds:
+      - task: _publish:image
+        vars:
+          REGISTRY: "{{.REGISTRY}}"
+          PROJECT_NAME: "{{.PROJECT_NAME}}"
+          COMPONENT: satellite
+          IMAGE_TAGS: "{{.PLATFORM_IMAGE_TAGS}}"
+          PLATFORMS: "{{.PLATFORM}}"
+      - task: _publish:image
+        vars:
+          REGISTRY: "{{.REGISTRY}}"
+          PROJECT_NAME: "{{.PROJECT_NAME}}"
+          COMPONENT: ground-control
+          IMAGE_TAGS: "{{.PLATFORM_IMAGE_TAGS}}"
+          PLATFORMS: "{{.PLATFORM}}"
+
+  publish-manifest-and-sign:
+    desc: Create and sign multi-arch manifests for both components
+    vars:
+      TAG: '{{.TAG | default .Env.TAG | default "dev"}}'
+      SOURCE_TAGS: "{{.SOURCE_IMAGE_TAGS | default .SOURCE_TAG | default .TAG}}"
+      REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
+      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
+      ARCH_SUFFIXES: "{{.ARCH_SUFFIXES | default .Env.ARCH_SUFFIXES | default .PLATFORMS_LINUX}}"
+    cmds:
+      - task: _publish:manifest-and-sign
+        vars:
+          REGISTRY: "{{.REGISTRY}}"
+          PROJECT_NAME: "{{.PROJECT_NAME}}"
+          COMPONENT: satellite
+          IMAGE_TAGS: "{{.TAG}}"
+          SOURCE_IMAGE_TAGS: "{{.SOURCE_TAGS}}"
+          ARCH_SUFFIXES: "{{.ARCH_SUFFIXES}}"
+      - task: _publish:manifest-and-sign
+        vars:
+          REGISTRY: "{{.REGISTRY}}"
+          PROJECT_NAME: "{{.PROJECT_NAME}}"
+          COMPONENT: ground-control
+          IMAGE_TAGS: "{{.TAG}}"
+          SOURCE_IMAGE_TAGS: "{{.SOURCE_TAGS}}"
+          ARCH_SUFFIXES: "{{.ARCH_SUFFIXES}}"
 
   release:
     desc: Create release with GoReleaser

--- a/taskfiles/publish.yml
+++ b/taskfiles/publish.yml
@@ -60,6 +60,7 @@ tasks:
         msg: "PROJECT_NAME is required. Set via task var or PROJECT_NAME env var."
     cmds:
       - |
+        set -e
         DOCKERFILE="Dockerfile"
         CONTEXT="."
         BUILD_COMPONENT="{{.COMPONENT}}"
@@ -147,6 +148,77 @@ tasks:
           "$IMAGE_ADDR" \
           --timeout 1m
       - echo "Signed {{.COMPONENT}}"
+    silent: true
+
+  manifest-and-sign:
+    desc: Create and sign a multi-arch image manifest from arch-specific tags
+    vars:
+      REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
+      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
+      COMPONENT: "{{.COMPONENT | default .Env.COMPONENT | default \"satellite\"}}"
+      IMAGE_TAGS: "{{.IMAGE_TAGS | default .Env.IMAGE_TAGS | default \"dev\"}}"
+      SOURCE_IMAGE_TAGS: "{{.SOURCE_IMAGE_TAGS | default .Env.SOURCE_IMAGE_TAGS | default .IMAGE_TAGS | default .Env.IMAGE_TAGS | default \"dev\"}}"
+      ARCH_SUFFIXES: "{{.ARCH_SUFFIXES | default .Env.ARCH_SUFFIXES}}"
+    preconditions:
+      - sh: test -n "{{.REGISTRY}}"
+        msg: "REGISTRY is required. Set via task var or REGISTRY env var."
+      - sh: test -n "{{.PROJECT_NAME}}"
+        msg: "PROJECT_NAME is required. Set via task var or PROJECT_NAME env var."
+      - sh: test -n "{{.ARCH_SUFFIXES}}"
+        msg: "ARCH_SUFFIXES is required. Set via task var or ARCH_SUFFIXES env var."
+    cmds:
+      - |
+        set -e
+        if command -v docker &>/dev/null && ! docker --version 2>&1 | grep -qi podman; then
+          RUNTIME="docker"
+        else
+          RUNTIME="podman"
+        fi
+        echo "Using $RUNTIME runtime..."
+
+        if [ -n "$REG_USER" ] && [ -n "$REG_PASS" ]; then
+          echo "Logging into {{.REGISTRY}}..."
+          echo "$REG_PASS" | $RUNTIME login {{.REGISTRY}} -u "$REG_USER" --password-stdin
+        fi
+
+        IFS=',' read -r -a TARGET_TAGS <<< "{{.IMAGE_TAGS}}"
+        IFS=',' read -r -a SOURCE_TAGS <<< "{{.SOURCE_IMAGE_TAGS}}"
+
+        if [ "${#TARGET_TAGS[@]}" -ne "${#SOURCE_TAGS[@]}" ]; then
+          echo "Error: IMAGE_TAGS count (${#TARGET_TAGS[@]}) does not match SOURCE_IMAGE_TAGS count (${#SOURCE_TAGS[@]})" >&2
+          exit 1
+        fi
+
+        for i in "${!TARGET_TAGS[@]}"; do
+          tag=$(echo "${TARGET_TAGS[$i]}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/^v//')
+          source_tag=$(echo "${SOURCE_TAGS[$i]}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/^v//')
+          if [ -z "$tag" ] || [ -z "$source_tag" ]; then
+            continue
+          fi
+          IMAGE_ADDR="{{.REGISTRY}}/{{.PROJECT_NAME}}/{{.COMPONENT}}:$tag"
+          SOURCES=""
+          for suffix in {{.ARCH_SUFFIXES}}; do
+            SOURCES="$SOURCES {{.REGISTRY}}/{{.PROJECT_NAME}}/{{.COMPONENT}}:$source_tag-$suffix"
+          done
+
+          echo "Creating {{.COMPONENT}} manifest $IMAGE_ADDR from:$SOURCES"
+          if [ "$RUNTIME" = "docker" ]; then
+            docker buildx imagetools create -t "$IMAGE_ADDR" $SOURCES
+          else
+            MANIFEST_NAME="localhost/{{.COMPONENT}}:$tag-manifest"
+            podman manifest rm "$MANIFEST_NAME" 2>/dev/null || true
+            podman manifest create "$MANIFEST_NAME" $SOURCES
+            podman manifest push --all "$MANIFEST_NAME" "docker://$IMAGE_ADDR"
+          fi
+
+          echo "Signing {{.COMPONENT}} manifest $IMAGE_ADDR..."
+          cosign sign --yes --recursive \
+            --registry-username="$REG_USER" \
+            --registry-password="$REG_PASS" \
+            "$IMAGE_ADDR" \
+            --timeout 1m
+        done
+      - echo "Created and signed {{.COMPONENT}} manifest"
     silent: true
 
   snapshot-release:

--- a/taskfiles/publish.yml
+++ b/taskfiles/publish.yml
@@ -221,6 +221,55 @@ tasks:
       - echo "Created and signed {{.COMPONENT}} manifest"
     silent: true
 
+  cleanup-platform-tags:
+    desc: Delete temporary per-arch source tags from Harbor after manifest assembly
+    vars:
+      REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
+      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
+      SOURCE_IMAGE_TAGS: "{{.SOURCE_IMAGE_TAGS | default .Env.SOURCE_IMAGE_TAGS}}"
+      ARCH_SUFFIXES: "{{.ARCH_SUFFIXES | default .Env.ARCH_SUFFIXES}}"
+    preconditions:
+      - sh: test -n "{{.REGISTRY}}"
+        msg: "REGISTRY is required. Set via task var or REGISTRY env var."
+      - sh: test -n "{{.PROJECT_NAME}}"
+        msg: "PROJECT_NAME is required. Set via task var or PROJECT_NAME env var."
+      - sh: test -n "{{.SOURCE_IMAGE_TAGS}}"
+        msg: "SOURCE_IMAGE_TAGS is required."
+      - sh: test -n "{{.ARCH_SUFFIXES}}"
+        msg: "ARCH_SUFFIXES is required. Set via task var or ARCH_SUFFIXES env var."
+    cmds:
+      - |
+        set +e
+        failed=0
+        IFS=',' read -r -a source_tags_arr <<< "{{.SOURCE_IMAGE_TAGS}}"
+        for component in satellite ground-control; do
+          for suffix in {{.ARCH_SUFFIXES}}; do
+            for source_tag in "${source_tags_arr[@]}"; do
+              source_tag=$(echo "$source_tag" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+              [ -z "$source_tag" ] && continue
+              tag="${source_tag}-${suffix}"
+              url="https://{{.REGISTRY}}/api/v2.0/projects/{{.PROJECT_NAME}}/repositories/${component}/artifacts/${tag}/tags/${tag}"
+              echo "Removing temporary tag ${tag} from ${component}..."
+              http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+                -X DELETE \
+                -u "$REG_USER:$REG_PASS" \
+                "$url")
+              case "$http_code" in
+                200|202|404) echo "  done (HTTP ${http_code})" ;;
+                *)
+                  echo "  warning: HTTP ${http_code} deleting ${component}:${tag}" >&2
+                  failed=1
+                  ;;
+              esac
+            done
+          done
+        done
+        if [ "$failed" -ne 0 ]; then
+          echo "Warning: some tag deletions returned unexpected status codes (see above)." >&2
+        fi
+        exit 0  # cleanup is best-effort; never block CI
+    silent: true
+
   snapshot-release:
     desc: Create snapshot release with GoReleaser
     cmds:

--- a/taskfiles/publish.yml
+++ b/taskfiles/publish.yml
@@ -251,6 +251,8 @@ tasks:
               url="https://{{.REGISTRY}}/api/v2.0/projects/{{.PROJECT_NAME}}/repositories/${component}/artifacts/${tag}/tags/${tag}"
               echo "Removing temporary tag ${tag} from ${component}..."
               http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+                --connect-timeout 10 \
+                --max-time 30 \
                 -X DELETE \
                 -u "$REG_USER:$REG_PASS" \
                 "$url")


### PR DESCRIPTION
- Fixes: #312 

## Description

Refactors the `push-latest-images` workflow to publish latest images per platform using a GitHub Actions matrix.

Previously, the workflow pushed all supported architectures in a single job through one multi-platform `docker buildx build`, making the snapshot image publish step one of the slowest parts of CI.

This change:
- Runs latest image publishing in parallel for each supported platform
- Pushes arch-specific temporary tags such as `latest-amd64` and `latest-arm64`
- Adds a final `create-latest-manifest` job that combines those tags into the final multi-arch `latest` manifest
- Signs the final manifest after it is created
- Keeps release tag publishing on the existing path to limit scope

## Validation

- Ran `task --list`
- Parsed updated workflow/action/task YAML files with `yq`
- Verified the workflow matrix and final manifest job wiring locally

Full publish behavior will be validated by CI because it depends on registry credentials and the remote BuildKit runner.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-platform image publishing and signed multi-architecture manifest creation.
  * Added Docker and Podman support for manifest creation and signing.
  * Added configurable publishing modes, platforms, architecture suffixes, and source tags.
  * Expanded “latest” image publishing across amd64, arm64, ppc64le, s390x, and riscv64.
  * Added automatic cleanup of temporary architecture-specific image tags.

* **Improvements**
  * Publishing now supports environment-provided tags, registries, and project settings.
  * Improved build retry reliability by recreating the build environment for each attempt.
  * Added safer coordination for concurrent main-branch publishing runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->