### PR TITLE
feat(scheduler): track per-run history and rename IsComplete to Shoul…

### DIFF
--- a/internal/satellite/scheduler/process.go
+++ b/internal/satellite/scheduler/process.go
@@ -16,5 +16,5 @@ type Process interface {
 	IsRunning() bool
 
 	// ShouldStop returns true if the process scheduling should be stopped
-	IsComplete() bool
+	ShouldStop() bool
 }

--- a/internal/satellite/scheduler/scheduler.go
+++ b/internal/satellite/scheduler/scheduler.go
@@ -8,8 +8,26 @@ import (
 	"sync"
 	"time"
 
+	"github.com/container-registry/harbor-satellite/pkg/config"
 	"github.com/rs/zerolog"
 )
+
+// RunResult records the outcome of a single execution of a scheduled process.
+type RunResult struct {
+	StartedAt  time.Time
+	FinishedAt time.Time
+	Err        error
+}
+
+// Duration returns how long the run took.
+func (r RunResult) Duration() time.Duration {
+	return r.FinishedAt.Sub(r.StartedAt)
+}
+
+// Success reports whether the run completed without error.
+func (r RunResult) Success() bool {
+	return r.Err == nil
+}
 
 // Scheduler manages the execution of processes with configurable intervals.
 type Scheduler struct {
@@ -20,6 +38,7 @@ type Scheduler struct {
 	interval time.Duration
 	mu       sync.Mutex
 	wg       sync.WaitGroup
+	history   []RunResult
 }
 
 // NewSchedulerWithInterval creates a new scheduler with a parsed interval string.
@@ -71,7 +90,7 @@ func (s *Scheduler) run(ctx context.Context) {
 			return
 
 		case <-s.ticker.C:
-			if s.process.IsComplete() {
+			if s.process.ShouldStop() {
 				s.log.Info().
 					Str("Process", s.process.Name()).
 					Msg("Process marked as complete. Stopping scheduling.")
@@ -149,18 +168,62 @@ func (s *Scheduler) launchProcess(ctx context.Context) {
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
-			if err := s.process.Execute(ctx); err != nil {
-				s.log.Warn().
-					Str("Process", s.process.Name()).
-					Err(err).
-					Msg("Error occurred while executing process.")
+
+			result := RunResult{StartedAt: time.Now()}
+			result.Err = s.process.Execute(ctx)
+			result.FinishedAt = time.Now()
+			s.recordRun(result)
+
+			logEvent := s.log.Info()
+			if result.Err != nil {
+            	logEvent = s.log.Warn()
 			}
+			logEvent.
+            	Str("Process", s.process.Name()).
+             	Dur("duration", result.Duration()).
+              	Bool("success", result.Success()).
+               	AnErr("error", result.Err).
+                Msg("Process run completed")
 		}()
 	} else {
 		s.log.Debug().
 			Str("Process", s.process.Name()).
 			Msg("Process already executing")
 	}
+}
+
+// recordRun appends a run result, discarding the oldest entry once
+// maxRunHistory is exceeded.
+func (s *Scheduler) recordRun(result RunResult) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.history = append(s.history, result)
+	if len(s.history) > config.MaxRunHistory {
+		s.history = s.history[len(s.history)-config.MaxRunHistory:]
+	}
+}
+
+// History returns a copy of the retained run results, oldest first.
+func (s *Scheduler) History() []RunResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	out := make([]RunResult, len(s.history))
+	copy(out, s.history)
+	return out
+}
+
+// LastRun returns the most recent run result and true, or a zero value
+// and false if the process has not executed yet.
+func (s *Scheduler) LastRun() (RunResult, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.history) == 0 {
+		return RunResult{}, false
+	}
+	return s.history[len(s.history)-1], true
 }
 
 func parseEveryExpr(expr string) (time.Duration, error) {

--- a/internal/satellite/scheduler/scheduler_test.go
+++ b/internal/satellite/scheduler/scheduler_test.go
@@ -2,11 +2,13 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/container-registry/harbor-satellite/pkg/config"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +26,7 @@ type mockProcess struct {
 
 func (m *mockProcess) Name() string     { return m.name }
 func (m *mockProcess) IsRunning() bool  { return m.running.Load() }
-func (m *mockProcess) IsComplete() bool { return m.complete.Load() }
+func (m *mockProcess) ShouldStop() bool { return m.complete.Load() }
 
 func (m *mockProcess) Execute(ctx context.Context) error {
 	m.running.Store(true)
@@ -174,6 +176,81 @@ func TestContextCancellation_StopsScheduler(t *testing.T) {
 	// After stop, no more executions should occur
 	time.Sleep(150 * time.Millisecond)
 	require.Equal(t, countAtStop, proc.execCount.Load(), "no executions after stop")
+}
+
+func TestHistory_RecordsSuccessAndFailure(t *testing.T) {
+	callNum := atomic.Int32{}
+	testErr := errors.New("boom")
+
+	proc := &mockProcess{
+		name: "flaky-task",
+		execFn: func(_ context.Context) error {
+			if callNum.Add(1) == 2 {
+				return testErr
+			}
+			return nil
+		},
+	}
+
+	sched, err := NewSchedulerWithInterval("@every 30ms", proc, nopLogger())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sched.Start(ctx)
+
+	require.Eventually(t, func() bool {
+		return len(sched.History()) >= 3
+	}, 2*time.Second, 10*time.Millisecond)
+
+	cancel()
+	require.NoError(t, sched.Stop(context.Background()))
+
+	history := sched.History()
+	require.GreaterOrEqual(t, len(history), 3)
+
+	for _, run := range history {
+		require.False(t, run.StartedAt.IsZero())
+		require.False(t, run.FinishedAt.IsZero())
+		require.False(t, run.FinishedAt.Before(run.StartedAt))
+	}
+
+	// The second recorded run should be the failure.
+	require.Error(t, history[1].Err)
+	require.False(t, history[1].Success())
+	require.True(t, history[0].Success())
+
+	last, ok := sched.LastRun()
+	require.True(t, ok)
+	require.Equal(t, history[len(history)-1], last)
+}
+
+func TestLastRun_NoRunsYet(t *testing.T) {
+	proc := &mockProcess{name: "never-started"}
+
+	sched, err := NewSchedulerWithInterval("@every 1h", proc, nopLogger())
+	require.NoError(t, err)
+
+	_, ok := sched.LastRun()
+	require.False(t, ok, "LastRun should report false before any execution")
+}
+
+func TestHistory_BoundedByMaxRunHistory(t *testing.T) {
+	proc := &mockProcess{name: "fast-task"}
+
+	sched, err := NewSchedulerWithInterval("@every 5ms", proc, nopLogger())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sched.Start(ctx)
+
+	require.Eventually(t, func() bool {
+		return proc.execCount.Load() > int32(config.MaxRunHistory)+5
+	}, 3*time.Second, 10*time.Millisecond)
+
+	cancel()
+	require.NoError(t, sched.Stop(context.Background()))
+
+	require.LessOrEqual(t, len(sched.History()), config.MaxRunHistory)
 }
 
 func TestMultipleSchedulers_GracefulShutdown(t *testing.T) {

--- a/internal/satellite/state/registration_process.go
+++ b/internal/satellite/state/registration_process.go
@@ -165,7 +165,7 @@ func (z *ZtrProcess) IsRunning() bool {
 	return z.isRunning
 }
 
-func (z *ZtrProcess) IsComplete() bool {
+func (z *ZtrProcess) ShouldStop() bool {
 	z.mu.Lock()
 	defer z.mu.Unlock()
 	return z.cm.IsZTRDone()

--- a/internal/satellite/state/reporting_process.go
+++ b/internal/satellite/state/reporting_process.go
@@ -210,7 +210,7 @@ func (s *StatusReportingProcess) IsRunning() bool {
 	return s.isRunning
 }
 
-func (s *StatusReportingProcess) IsComplete() bool {
+func (s *StatusReportingProcess) ShouldStop() bool {
 	return false
 }
 

--- a/internal/satellite/state/spiffe_registration.go
+++ b/internal/satellite/state/spiffe_registration.go
@@ -165,7 +165,7 @@ func (s *SpiffeZtrProcess) IsRunning() bool {
 	return s.isRunning
 }
 
-func (s *SpiffeZtrProcess) IsComplete() bool {
+func (s *SpiffeZtrProcess) ShouldStop() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/internal/satellite/state/state_process.go
+++ b/internal/satellite/state/state_process.go
@@ -240,7 +240,7 @@ func (f *FetchAndReplicateStateProcess) Name() string {
 
 // The state fetch process is prepetual, the only criteria for completion is
 // if the statellite is shut down.
-func (f *FetchAndReplicateStateProcess) IsComplete() bool {
+func (f *FetchAndReplicateStateProcess) ShouldStop() bool {
 	return false
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -225,3 +225,7 @@ var validLogLevels = map[string]bool{
 	zerolog.LevelFatalValue: true,
 	zerolog.LevelPanicValue: true,
 }
+
+// maxRunHistory bounds the number of retained run results per scheduler
+// to avoid unbounded memory growth for long-lived processes.
+const MaxRunHistory int = 10


### PR DESCRIPTION
- Fixes: #528  

## Description
1. Renamed `IsComplete()` → `ShouldStop()`
Makes explicit that this signals the scheduler should stop scheduling the process entirely (unchanged behavior for ZtrProcess, FetchAndReplicateStateProcess, SpiffeZtrProcess, StatusReportingProcess).

2. Added per-run history tracking on Scheduler
similar in spirit to isComplete, but per-instance, not per-process-lifecycle: each `Execute() `call now records a `RunResult{StartedAt, FinishedAt, Err}` in a bounded ring buffer (last 10 runs), exposed via `History()` and `LastRun()`

3. Every run now logs one line (Info on success, Warn on failure) with duration/success/error fields


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scheduler run history, including start and finish times, duration, success status, and errors.
  * Added access to the latest run and retained run history.
  * Limited retained history to the latest 10 runs.

* **Improvements**
  * Updated process stopping behavior across scheduler processes for clearer lifecycle handling.
  * Scheduler logging now reflects whether runs succeed or fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->