### PR TITLE
fix: enforce strict @every format in cron validator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -438,7 +438,6 @@ require (
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	github.com/robfig/cron/v3 v3.0.1
 	github.com/rubenv/sql-migrate v1.8.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -7,9 +7,9 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/container-registry/harbor-satellite/internal/satellite/registry"
-	"github.com/robfig/cron/v3"
 	"github.com/rs/zerolog"
 )
 
@@ -203,13 +203,14 @@ func enforceAuditRotation(f *SyslogAuditFile) []string {
 	return warnings
 }
 
-// isValidCronExpression checks the validity of a cron expression.
-func isValidCronExpression(cronExpression string) bool {
-	if _, err := cron.ParseStandard(cronExpression); err != nil {
+// isValidScheduleExpression checks the validity of a schedule expression.
+func isValidScheduleExpression(expr string) bool {
+	const prefix = "@every "
+	if !strings.HasPrefix(expr, prefix) {
 		return false
 	}
-
-	return true
+	_, err := time.ParseDuration(strings.TrimPrefix(expr, prefix))
+	return err == nil
 }
 
 // validateAndEnforceLogLevel validates log level and defaults to info if invalid.
@@ -256,17 +257,17 @@ func validateBringOwnRegistry(config *Config) ([]string, error) {
 func validateAndEnforceCronSchedules(config *Config) []string {
 	var warnings []string
 
-	if !isValidCronExpression(config.AppConfig.StateReplicationInterval) {
+	if !isValidScheduleExpression(config.AppConfig.StateReplicationInterval) {
 		config.AppConfig.StateReplicationInterval = DefaultFetchAndReplicateCronExpr
 		warnings = append(warnings, fmt.Sprintf("invalid schedule provided for state_replication_interval, using default schedule %s", DefaultFetchAndReplicateCronExpr))
 	}
 
-	if !isValidCronExpression(config.AppConfig.RegisterSatelliteInterval) {
+	if !isValidScheduleExpression(config.AppConfig.RegisterSatelliteInterval) {
 		config.AppConfig.RegisterSatelliteInterval = DefaultZTRCronExpr
 		warnings = append(warnings, fmt.Sprintf("invalid schedule provided for register_satellite_interval, using default schedule %s", DefaultZTRCronExpr))
 	}
 
-	if !isValidCronExpression(config.AppConfig.HeartbeatInterval) {
+	if !isValidScheduleExpression(config.AppConfig.HeartbeatInterval) {
 		config.AppConfig.HeartbeatInterval = DefaultHeartbeatCronExpr
 		warnings = append(warnings, fmt.Sprintf("invalid schedule provided for heartbeat_interval, using default schedule %s", DefaultHeartbeatCronExpr))
 	}

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -203,14 +203,13 @@ func enforceAuditRotation(f *SyslogAuditFile) []string {
 	return warnings
 }
 
-// isValidScheduleExpression checks the validity of a schedule expression.
 func isValidScheduleExpression(expr string) bool {
 	const prefix = "@every "
 	if !strings.HasPrefix(expr, prefix) {
 		return false
 	}
-	_, err := time.ParseDuration(strings.TrimPrefix(expr, prefix))
-	return err == nil
+	duration, err := time.ParseDuration(strings.TrimPrefix(expr, prefix))
+	return err == nil && duration > 0
 }
 
 // validateAndEnforceLogLevel validates log level and defaults to info if invalid.

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -120,6 +120,25 @@ func TestValidateAndEnforceDefaults(t *testing.T) {
 			},
 		},
 		{
+			name: "zero and negative schedule values",
+			config: &Config{
+				AppConfig: AppConfig{
+					GroundControlURL:          URL("https://example.com"),
+					StateReplicationInterval:  "@every 0s",
+					RegisterSatelliteInterval: "@every -1m",
+				},
+				ZotConfigRaw: []byte(DefaultZotConfigJSON),
+			},
+			expectError:    false,
+			expectWarnings: true,
+			expectedConfig: &Config{
+				AppConfig: AppConfig{
+					StateReplicationInterval:  DefaultFetchAndReplicateCronExpr,
+					RegisterSatelliteInterval: DefaultZTRCronExpr,
+				},
+			},
+		},
+		{
 			name: "bring own registry missing URL",
 			config: &Config{
 				AppConfig: AppConfig{


### PR DESCRIPTION
- Fixes: #472

## Description
This PR addresses a bug where the configuration validator silently accepted invalid standard cron expressions (which crash the scheduler) while seemingly overriding valid `@every <duration>` schedules. 

The issue was caused by using `cron.ParseStandard` from `robfig/cron/v3`, which is too permissive for the internal scheduler that strictly expects the `@every <duration>` format.

This replaces the `robfig/cron/v3` parser with a strict `time.ParseDuration` check to ensure the config validator only accepts the `@every ` format supported by the internal scheduler.

## Additional context
- I removed the now-unused `robfig/cron/v3` parser logic from `isValidCronExpression`.
- I have verified that `task test` passes with this new strict validation logic.
- I confirmed via manual scratch testing that standard cron strings like `*/5 * * * *` are now successfully rejected and correctly fallback to the default.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schedule settings now support duration-based expressions using the `@every` format.

* **Bug Fixes**
  * Improved validation for replication and satellite registration intervals.
  * Invalid schedule values continue to fall back to safe defaults with warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->