### PR TITLE
fix(harbor): refactor GetClient to return errors instead of panicking

### DIFF
--- a/internal/groundcontrol/harbor/client.go
+++ b/internal/groundcontrol/harbor/client.go
@@ -10,11 +10,12 @@ import (
 
 var (
 	client     *v2client.HarborAPI
+	clientErr  error
 	clientOnce sync.Once
 )
 
 // Returns Harbor v2 client
-func GetClient() *v2client.HarborAPI {
+func GetClient() (*v2client.HarborAPI, error) {
 	clientOnce.Do(func() {
 		cfg := env.GC.Harbor
 		clientConfig := &harbor.ClientSetConfig{
@@ -22,16 +23,16 @@ func GetClient() *v2client.HarborAPI {
 			Username: cfg.Username,
 			Password: cfg.Password,
 		}
-		client = GetClientByConfig(clientConfig)
+		client, clientErr = GetClientByConfig(clientConfig)
 	})
 
-	return client
+	return client, clientErr
 }
 
-func GetClientByConfig(clientConfig *harbor.ClientSetConfig) *v2client.HarborAPI {
+func GetClientByConfig(clientConfig *harbor.ClientSetConfig) (*v2client.HarborAPI, error) {
 	cs, err := harbor.NewClientSet(clientConfig)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return cs.V2()
+	return cs.V2(), nil
 }

--- a/internal/groundcontrol/harbor/project.go
+++ b/internal/groundcontrol/harbor/project.go
@@ -11,7 +11,10 @@ import (
 )
 
 func GetProject(ctx context.Context, name string) (bool, error) {
-	client := GetClient()
+	client, err := GetClient()
+	if err != nil {
+		return false, fmt.Errorf("getting harbor client: %w", err)
+	}
 	proj, err := client.Project.HeadProject(ctx, &project.HeadProjectParams{
 		ProjectName: name,
 	})
@@ -26,7 +29,10 @@ func GetProject(ctx context.Context, name string) (bool, error) {
 }
 
 func CreateSatelliteProject(ctx context.Context) (bool, error) {
-	client := GetClient()
+	client, err := GetClient()
+	if err != nil {
+		return false, fmt.Errorf("getting harbor client: %w", err)
+	}
 	var (
 		public  = true
 		storage = int64(-1)

--- a/internal/groundcontrol/harbor/replication.go
+++ b/internal/groundcontrol/harbor/replication.go
@@ -9,7 +9,10 @@ import (
 )
 
 func ListReplication(ctx context.Context, opts ListParams) ([]*models.ReplicationPolicy, error) {
-	client := GetClient()
+	client, err := GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("getting harbor client: %w", err)
+	}
 	response, err := client.Replication.ListReplicationPolicies(
 		ctx,
 		&replication.ListReplicationPoliciesParams{

--- a/internal/groundcontrol/harbor/robot.go
+++ b/internal/groundcontrol/harbor/robot.go
@@ -21,7 +21,10 @@ func GetRobotDetails(r *robot.CreateRobotCreated) (int64, string, string, int64)
 }
 
 func IsRobotPresent(ctx context.Context, name string) (bool, error) {
-	client := GetClient()
+	client, err := GetClient()
+	if err != nil {
+		return false, fmt.Errorf("getting harbor client: %w", err)
+	}
 
 	name = fmt.Sprintf("name=%s", name)
 	response, err := client.Robot.ListRobot(
@@ -42,7 +45,10 @@ func IsRobotPresent(ctx context.Context, name string) (bool, error) {
 }
 
 func ListRobots(ctx context.Context, opts ListParams) (*robot.ListRobotOK, error) {
-	client := GetClient()
+	client, err := GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("getting harbor client: %w", err)
+	}
 	response, err := client.Robot.ListRobot(
 		ctx,
 		&robot.ListRobotParams{
@@ -59,7 +65,10 @@ func ListRobots(ctx context.Context, opts ListParams) (*robot.ListRobotOK, error
 }
 
 func DeleteRobotAccount(ctx context.Context, robotID int64) (*robot.DeleteRobotOK, error) {
-	client := GetClient()
+	client, err := GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("getting harbor client: %w", err)
+	}
 	response, err := client.Robot.DeleteRobot(
 		ctx,
 		&robot.DeleteRobotParams{
@@ -73,7 +82,10 @@ func DeleteRobotAccount(ctx context.Context, robotID int64) (*robot.DeleteRobotO
 }
 
 func RefreshRobotAccount(ctx context.Context, secret string, robotID int64) (*robot.RefreshSecOK, error) {
-	client := GetClient()
+	client, err := GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("getting harbor client: %w", err)
+	}
 	response, err := client.Robot.RefreshSec(
 		ctx,
 		&robot.RefreshSecParams{
@@ -90,7 +102,10 @@ func RefreshRobotAccount(ctx context.Context, secret string, robotID int64) (*ro
 }
 
 func UpdateRobotAccount(ctx context.Context, opts *models.Robot) (*robot.UpdateRobotOK, error) {
-	client := GetClient()
+	client, err := GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("getting harbor client: %w", err)
+	}
 	response, err := client.Robot.UpdateRobot(
 		ctx,
 		&robot.UpdateRobotParams{
@@ -105,7 +120,10 @@ func UpdateRobotAccount(ctx context.Context, opts *models.Robot) (*robot.UpdateR
 }
 
 func GetRobotAccount(ctx context.Context, id int64) (*models.Robot, error) {
-	client := GetClient()
+	client, err := GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("getting harbor client: %w", err)
+	}
 	response, err := client.Robot.GetRobotByID(
 		ctx,
 		&robot.GetRobotByIDParams{
@@ -119,7 +137,10 @@ func GetRobotAccount(ctx context.Context, id int64) (*models.Robot, error) {
 }
 
 func CreateRobotAccount(ctx context.Context, opts *models.RobotCreate) (*robot.CreateRobotCreated, error) {
-	client := GetClient()
+	client, err := GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("getting harbor client: %w", err)
+	}
 	response, err := client.Robot.CreateRobot(
 		ctx,
 		&robot.CreateRobotParams{


### PR DESCRIPTION
Description:
Fixes #552 

What this PR does / why we need it: When internal/groundcontrol/harbor/client.go initializes the Harbor client (GetClientByConfig and GetClient), it previously used panic(err) if harbor.NewClientSet returned an error. This is a Go anti-pattern for server applications like Ground Control, as a simple client misconfiguration or invalid URL would cause the entire process to crash.

This PR refactors GetClientByConfig and GetClient to return (*v2client.HarborAPI, error) instead. All downstream callers (in robot.go, project.go, and replication.go) have been properly updated to capture the error and safely propagate it up the stack using standard error handling.

Which issue(s) this PR fixes: Fixes #(Replace with Issue Number)

Special notes for your reviewer: I used a module-level clientErr error to safely capture and return the error resulting from clientOnce.Do(). All callers were updated to check if err != nil and return the error gracefully.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

