### PR TITLE
feat: add P2P configuration and validation for air-gapped peer replication

### DIFF
--- a/internal/satellite/state/peer_replicator.go
+++ b/internal/satellite/state/peer_replicator.go
@@ -1,0 +1,53 @@
+package state
+
+import (
+	"context"
+
+	"github.com/container-registry/harbor-satellite/pkg/config"
+)
+
+// PeerAwareReplicator wraps an existing Replicator and attempts peer acquisition before fallback.
+// In this initial architectural milestone, it strictly delegates all entities to the fallback replicator.
+type PeerAwareReplicator struct {
+	p2pCfg   config.P2PConfig
+	fallback Replicator
+
+	localURL      string
+	localUsername string
+	localPassword string
+	useUnsecure   bool
+}
+
+// NewPeerAwareReplicator creates a new PeerAwareReplicator that delegates to the provided fallback.
+// Panics if the fallback replicator is nil.
+func NewPeerAwareReplicator(
+	cfg config.P2PConfig,
+	fallback Replicator,
+	localURL string,
+	localUsername string,
+	localPassword string,
+	useUnsecure bool,
+) *PeerAwareReplicator {
+	if fallback == nil {
+		panic("fallback replicator cannot be nil")
+	}
+
+	return &PeerAwareReplicator{
+		p2pCfg:        cfg,
+		fallback:      fallback,
+		localURL:      localURL,
+		localUsername: localUsername,
+		localPassword: localPassword,
+		useUnsecure:   useUnsecure,
+	}
+}
+
+// Replicate delegates to the wrapped fallback replicator. Peer-to-peer acquisition logic will be added in a future PR.
+func (p *PeerAwareReplicator) Replicate(ctx context.Context, replicationEntities []Entity) error {
+	return p.fallback.Replicate(ctx, replicationEntities)
+}
+
+// DeleteReplicationEntity delegates directly to the fallback replicator.
+func (p *PeerAwareReplicator) DeleteReplicationEntity(ctx context.Context, replicationEntities []Entity) error {
+	return p.fallback.DeleteReplicationEntity(ctx, replicationEntities)
+}

--- a/internal/satellite/state/peer_replicator_test.go
+++ b/internal/satellite/state/peer_replicator_test.go
@@ -3,6 +3,7 @@ package state
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/container-registry/harbor-satellite/pkg/config"
 	"github.com/stretchr/testify/assert"
@@ -47,9 +48,9 @@ func TestNewPeerAwareReplicator(t *testing.T) {
 	t.Run("successfully creates replicator", func(t *testing.T) {
 		mockFallback := &mockReplicator{}
 		p2pCfg := config.P2PConfig{
-			Enabled:        true,
-			Peers:          []string{"http://10.0.0.1"},
-			TimeoutSeconds: 30,
+			Enabled:            true,
+			Peers:              []string{"http://10.0.0.1"},
+			AcquisitionTimeout: 30 * time.Second,
 		}
 
 		r := NewPeerAwareReplicator(

--- a/internal/satellite/state/peer_replicator_test.go
+++ b/internal/satellite/state/peer_replicator_test.go
@@ -1,0 +1,102 @@
+package state
+
+import (
+	"context"
+	"testing"
+
+	"github.com/container-registry/harbor-satellite/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockReplicator is a simple mock that implements the Replicator interface.
+type mockReplicator struct {
+	replicateCalled       bool
+	deleteCalled          bool
+	entitiesReplicated    []Entity
+	entitiesDeleted       []Entity
+	replicateReturnError  error
+	deleteReturnError     error
+}
+
+func (m *mockReplicator) Replicate(ctx context.Context, entities []Entity) error {
+	m.replicateCalled = true
+	m.entitiesReplicated = entities
+	return m.replicateReturnError
+}
+
+func (m *mockReplicator) DeleteReplicationEntity(ctx context.Context, entities []Entity) error {
+	m.deleteCalled = true
+	m.entitiesDeleted = entities
+	return m.deleteReturnError
+}
+
+func TestNewPeerAwareReplicator(t *testing.T) {
+	t.Run("panics on nil fallback", func(t *testing.T) {
+		assert.PanicsWithValue(t, "fallback replicator cannot be nil", func() {
+			NewPeerAwareReplicator(
+				config.P2PConfig{},
+				nil,
+				"local-url",
+				"user",
+				"pass",
+				false,
+			)
+		})
+	})
+
+	t.Run("successfully creates replicator", func(t *testing.T) {
+		mockFallback := &mockReplicator{}
+		p2pCfg := config.P2PConfig{
+			Enabled:        true,
+			Peers:          []string{"http://10.0.0.1"},
+			TimeoutSeconds: 30,
+		}
+
+		r := NewPeerAwareReplicator(
+			p2pCfg,
+			mockFallback,
+			"local-url",
+			"user",
+			"pass",
+			false,
+		)
+
+		assert.NotNil(t, r)
+		assert.Equal(t, p2pCfg, r.p2pCfg)
+		assert.Equal(t, mockFallback, r.fallback)
+		assert.Equal(t, "local-url", r.localURL)
+		assert.Equal(t, "user", r.localUsername)
+		assert.Equal(t, "pass", r.localPassword)
+		assert.False(t, r.useUnsecure)
+	})
+}
+
+func TestPeerAwareReplicator_Delegation(t *testing.T) {
+	t.Run("delegates Replicate to fallback", func(t *testing.T) {
+		mockFallback := &mockReplicator{}
+		r := NewPeerAwareReplicator(config.P2PConfig{}, mockFallback, "", "", "", false)
+
+		entities := []Entity{
+			{Name: "image1", Repository: "library", Tag: "latest"},
+		}
+
+		err := r.Replicate(context.Background(), entities)
+		assert.NoError(t, err)
+		assert.True(t, mockFallback.replicateCalled)
+		assert.Equal(t, entities, mockFallback.entitiesReplicated)
+	})
+
+	t.Run("delegates DeleteReplicationEntity to fallback", func(t *testing.T) {
+		mockFallback := &mockReplicator{}
+		r := NewPeerAwareReplicator(config.P2PConfig{}, mockFallback, "", "", "", false)
+
+		entities := []Entity{
+			{Name: "image1", Repository: "library", Tag: "latest"},
+		}
+
+		err := r.DeleteReplicationEntity(context.Background(), entities)
+		assert.NoError(t, err)
+		assert.True(t, mockFallback.deleteCalled)
+		assert.Equal(t, entities, mockFallback.entitiesDeleted)
+	})
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -187,6 +187,13 @@ type DirectDeliveryConfig struct {
 	ImageDir string `json:"image_dir,omitempty"` // auto-detected if empty
 }
 
+// P2PConfig holds settings for Air-Gapped Peer-to-Peer proxying.
+type P2PConfig struct {
+	Enabled        bool     `json:"enabled,omitempty"`
+	Peers          []string `json:"peers,omitempty"`
+	TimeoutSeconds int      `json:"timeout_seconds,omitempty"`
+}
+
 type AppConfig struct {
 	GroundControlURL          URL                    `json:"ground_control_url,omitempty"`
 	LogLevel                  string                 `json:"log_level,omitempty"`
@@ -204,6 +211,7 @@ type AppConfig struct {
 	HarborRegistryURL         string                 `json:"harbor_registry_url,omitempty"`
 	DirectDelivery            DirectDeliveryConfig   `json:"direct_delivery,omitempty"`
 	Audit                     AuditConfig            `json:"audit,omitempty"`
+	P2P                       P2PConfig              `json:"p2p,omitempty"`
 }
 
 type StateConfig struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/rs/zerolog"
 )
@@ -189,9 +190,35 @@ type DirectDeliveryConfig struct {
 
 // P2PConfig holds settings for Air-Gapped Peer-to-Peer proxying.
 type P2PConfig struct {
-	Enabled        bool     `json:"enabled,omitempty"`
-	Peers          []string `json:"peers,omitempty"`
-	TimeoutSeconds int      `json:"timeout_seconds,omitempty"`
+	Enabled                bool          `json:"enabled,omitempty"`
+	Peers                  []string      `json:"peers,omitempty"`
+	AcquisitionTimeout     time.Duration `json:"acquisition_timeout,omitempty"`
+	MaxConcurrentTransfers int           `json:"max_concurrent_transfers,omitempty"`
+}
+
+// UnmarshalJSON implements custom unmarshaling to handle time.Duration strings.
+func (p *P2PConfig) UnmarshalJSON(data []byte) error {
+	type Alias P2PConfig
+	aux := &struct {
+		AcquisitionTimeout string `json:"acquisition_timeout,omitempty"`
+		*Alias
+	}{
+		Alias: (*Alias)(p),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	if aux.AcquisitionTimeout != "" {
+		d, err := time.ParseDuration(aux.AcquisitionTimeout)
+		if err != nil {
+			return err
+		}
+		p.AcquisitionTimeout = d
+	}
+
+	return nil
 }
 
 type AppConfig struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,166 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestP2PConfigParsing(t *testing.T) {
+	t.Run("default is false", func(t *testing.T) {
+		var c Config
+		err := json.Unmarshal([]byte(`{"app_config": {}}`), &c)
+		require.NoError(t, err)
+		require.False(t, c.AppConfig.P2P.Enabled)
+	})
+
+	t.Run("parses true and fields", func(t *testing.T) {
+		var c Config
+		err := json.Unmarshal([]byte(`{"app_config": {"p2p": {"enabled": true, "peers": ["https://peer1"], "acquisition_timeout": "60s", "max_concurrent_transfers": 10}}}`), &c)
+		require.NoError(t, err)
+		require.True(t, c.AppConfig.P2P.Enabled)
+		require.Equal(t, []string{"https://peer1"}, c.AppConfig.P2P.Peers)
+		require.Equal(t, 60*time.Second, c.AppConfig.P2P.AcquisitionTimeout)
+		require.Equal(t, 10, c.AppConfig.P2P.MaxConcurrentTransfers)
+	})
+}
+
+func TestValidateP2PConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        func() *Config
+		expectErr     bool
+		expectWarning bool
+	}{
+		{
+			name: "disabled returns nil",
+			config: func() *Config {
+				return &Config{}
+			},
+			expectErr:     false,
+			expectWarning: false,
+		},
+		{
+			name: "enabled with no peers returns error",
+			config: func() *Config {
+				c := &Config{}
+				c.AppConfig.P2P.Enabled = true
+				c.AppConfig.P2P.AcquisitionTimeout = 10 * time.Second
+				c.AppConfig.P2P.MaxConcurrentTransfers = 5
+				return c
+			},
+			expectErr:     true,
+			expectWarning: false,
+		},
+		{
+			name: "enabled with invalid peer url returns error",
+			config: func() *Config {
+				c := &Config{}
+				c.AppConfig.P2P.Enabled = true
+				c.AppConfig.P2P.Peers = []string{"not-a-url"}
+				c.AppConfig.P2P.AcquisitionTimeout = 10 * time.Second
+				c.AppConfig.P2P.MaxConcurrentTransfers = 5
+				return c
+			},
+			expectErr:     true,
+			expectWarning: false,
+		},
+		{
+			name: "enabled with zero timeout returns specific error",
+			config: func() *Config {
+				c := &Config{}
+				c.AppConfig.P2P.Enabled = true
+				c.AppConfig.P2P.Peers = []string{"https://peer1"}
+				c.AppConfig.P2P.AcquisitionTimeout = 0
+				c.AppConfig.P2P.MaxConcurrentTransfers = 5
+				return c
+			},
+			expectErr:     true,
+			expectWarning: false,
+		},
+		{
+			name: "enabled with short timeout returns error",
+			config: func() *Config {
+				c := &Config{}
+				c.AppConfig.P2P.Enabled = true
+				c.AppConfig.P2P.Peers = []string{"https://peer1"}
+				c.AppConfig.P2P.AcquisitionTimeout = 1 * time.Second
+				c.AppConfig.P2P.MaxConcurrentTransfers = 5
+				return c
+			},
+			expectErr:     true,
+			expectWarning: false,
+		},
+		{
+			name: "enabled with long timeout returns error",
+			config: func() *Config {
+				c := &Config{}
+				c.AppConfig.P2P.Enabled = true
+				c.AppConfig.P2P.Peers = []string{"https://peer1"}
+				c.AppConfig.P2P.AcquisitionTimeout = 10 * time.Minute
+				c.AppConfig.P2P.MaxConcurrentTransfers = 5
+				return c
+			},
+			expectErr:     true,
+			expectWarning: false,
+		},
+		{
+			name: "enabled with zero concurrent transfers returns warning and defaults",
+			config: func() *Config {
+				c := &Config{}
+				c.AppConfig.P2P.Enabled = true
+				c.AppConfig.P2P.Peers = []string{"https://peer1"}
+				c.AppConfig.P2P.AcquisitionTimeout = 10 * time.Second
+				c.AppConfig.P2P.MaxConcurrentTransfers = 0
+				return c
+			},
+			expectErr:     false,
+			expectWarning: true,
+		},
+		{
+			name: "enabled with too many concurrent transfers returns error",
+			config: func() *Config {
+				c := &Config{}
+				c.AppConfig.P2P.Enabled = true
+				c.AppConfig.P2P.Peers = []string{"https://peer1"}
+				c.AppConfig.P2P.AcquisitionTimeout = 10 * time.Second
+				c.AppConfig.P2P.MaxConcurrentTransfers = 50
+				return c
+			},
+			expectErr:     true,
+			expectWarning: false,
+		},
+		{
+			name: "enabled with valid configuration succeeds",
+			config: func() *Config {
+				c := &Config{}
+				c.AppConfig.P2P.Enabled = true
+				c.AppConfig.P2P.Peers = []string{"https://peer1"}
+				c.AppConfig.P2P.AcquisitionTimeout = 30 * time.Second
+				c.AppConfig.P2P.MaxConcurrentTransfers = 10
+				return c
+			},
+			expectErr:     false,
+			expectWarning: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.config()
+			warnings, err := validateP2PConfig(cfg)
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if tt.expectWarning {
+				require.NotEmpty(t, warnings)
+			} else {
+				require.Empty(t, warnings)
+			}
+		})
+	}
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -27,127 +27,127 @@ func TestP2PConfigParsing(t *testing.T) {
 	})
 }
 
-func TestValidateP2PConfig(t *testing.T) {
-	tests := []struct {
-		name          string
-		config        func() *Config
-		expectErr     bool
-		expectWarning bool
-	}{
-		{
-			name: "disabled returns nil",
-			config: func() *Config {
-				return &Config{}
-			},
-			expectErr:     false,
-			expectWarning: false,
+var validateP2PConfigTests = []struct {
+	name          string
+	config        func() *Config
+	expectErr     bool
+	expectWarning bool
+}{
+	{
+		name: "disabled returns nil",
+		config: func() *Config {
+			return &Config{}
 		},
-		{
-			name: "enabled with no peers returns error",
-			config: func() *Config {
-				c := &Config{}
-				c.AppConfig.P2P.Enabled = true
-				c.AppConfig.P2P.AcquisitionTimeout = 10 * time.Second
-				c.AppConfig.P2P.MaxConcurrentTransfers = 5
-				return c
-			},
-			expectErr:     true,
-			expectWarning: false,
+		expectErr:     false,
+		expectWarning: false,
+	},
+	{
+		name: "enabled with no peers returns error",
+		config: func() *Config {
+			c := &Config{}
+			c.AppConfig.P2P.Enabled = true
+			c.AppConfig.P2P.AcquisitionTimeout = 10 * time.Second
+			c.AppConfig.P2P.MaxConcurrentTransfers = 5
+			return c
 		},
-		{
-			name: "enabled with invalid peer url returns error",
-			config: func() *Config {
-				c := &Config{}
-				c.AppConfig.P2P.Enabled = true
-				c.AppConfig.P2P.Peers = []string{"not-a-url"}
-				c.AppConfig.P2P.AcquisitionTimeout = 10 * time.Second
-				c.AppConfig.P2P.MaxConcurrentTransfers = 5
-				return c
-			},
-			expectErr:     true,
-			expectWarning: false,
+		expectErr:     true,
+		expectWarning: false,
+	},
+	{
+		name: "enabled with invalid peer url returns error",
+		config: func() *Config {
+			c := &Config{}
+			c.AppConfig.P2P.Enabled = true
+			c.AppConfig.P2P.Peers = []string{"not-a-url"}
+			c.AppConfig.P2P.AcquisitionTimeout = 10 * time.Second
+			c.AppConfig.P2P.MaxConcurrentTransfers = 5
+			return c
 		},
-		{
-			name: "enabled with zero timeout returns specific error",
-			config: func() *Config {
-				c := &Config{}
-				c.AppConfig.P2P.Enabled = true
-				c.AppConfig.P2P.Peers = []string{"https://peer1"}
-				c.AppConfig.P2P.AcquisitionTimeout = 0
-				c.AppConfig.P2P.MaxConcurrentTransfers = 5
-				return c
-			},
-			expectErr:     true,
-			expectWarning: false,
+		expectErr:     true,
+		expectWarning: false,
+	},
+	{
+		name: "enabled with zero timeout returns specific error",
+		config: func() *Config {
+			c := &Config{}
+			c.AppConfig.P2P.Enabled = true
+			c.AppConfig.P2P.Peers = []string{"https://peer1"}
+			c.AppConfig.P2P.AcquisitionTimeout = 0
+			c.AppConfig.P2P.MaxConcurrentTransfers = 5
+			return c
 		},
-		{
-			name: "enabled with short timeout returns error",
-			config: func() *Config {
-				c := &Config{}
-				c.AppConfig.P2P.Enabled = true
-				c.AppConfig.P2P.Peers = []string{"https://peer1"}
-				c.AppConfig.P2P.AcquisitionTimeout = 1 * time.Second
-				c.AppConfig.P2P.MaxConcurrentTransfers = 5
-				return c
-			},
-			expectErr:     true,
-			expectWarning: false,
+		expectErr:     true,
+		expectWarning: false,
+	},
+	{
+		name: "enabled with short timeout returns error",
+		config: func() *Config {
+			c := &Config{}
+			c.AppConfig.P2P.Enabled = true
+			c.AppConfig.P2P.Peers = []string{"https://peer1"}
+			c.AppConfig.P2P.AcquisitionTimeout = 1 * time.Second
+			c.AppConfig.P2P.MaxConcurrentTransfers = 5
+			return c
 		},
-		{
-			name: "enabled with long timeout returns error",
-			config: func() *Config {
-				c := &Config{}
-				c.AppConfig.P2P.Enabled = true
-				c.AppConfig.P2P.Peers = []string{"https://peer1"}
-				c.AppConfig.P2P.AcquisitionTimeout = 10 * time.Minute
-				c.AppConfig.P2P.MaxConcurrentTransfers = 5
-				return c
-			},
-			expectErr:     true,
-			expectWarning: false,
+		expectErr:     true,
+		expectWarning: false,
+	},
+	{
+		name: "enabled with long timeout returns error",
+		config: func() *Config {
+			c := &Config{}
+			c.AppConfig.P2P.Enabled = true
+			c.AppConfig.P2P.Peers = []string{"https://peer1"}
+			c.AppConfig.P2P.AcquisitionTimeout = 10 * time.Minute
+			c.AppConfig.P2P.MaxConcurrentTransfers = 5
+			return c
 		},
-		{
-			name: "enabled with zero concurrent transfers returns warning and defaults",
-			config: func() *Config {
-				c := &Config{}
-				c.AppConfig.P2P.Enabled = true
-				c.AppConfig.P2P.Peers = []string{"https://peer1"}
-				c.AppConfig.P2P.AcquisitionTimeout = 10 * time.Second
-				c.AppConfig.P2P.MaxConcurrentTransfers = 0
-				return c
-			},
-			expectErr:     false,
-			expectWarning: true,
+		expectErr:     true,
+		expectWarning: false,
+	},
+	{
+		name: "enabled with zero concurrent transfers returns warning and defaults",
+		config: func() *Config {
+			c := &Config{}
+			c.AppConfig.P2P.Enabled = true
+			c.AppConfig.P2P.Peers = []string{"https://peer1"}
+			c.AppConfig.P2P.AcquisitionTimeout = 10 * time.Second
+			c.AppConfig.P2P.MaxConcurrentTransfers = 0
+			return c
 		},
-		{
-			name: "enabled with too many concurrent transfers returns error",
-			config: func() *Config {
-				c := &Config{}
-				c.AppConfig.P2P.Enabled = true
-				c.AppConfig.P2P.Peers = []string{"https://peer1"}
-				c.AppConfig.P2P.AcquisitionTimeout = 10 * time.Second
-				c.AppConfig.P2P.MaxConcurrentTransfers = 50
-				return c
-			},
-			expectErr:     true,
-			expectWarning: false,
+		expectErr:     false,
+		expectWarning: true,
+	},
+	{
+		name: "enabled with too many concurrent transfers returns error",
+		config: func() *Config {
+			c := &Config{}
+			c.AppConfig.P2P.Enabled = true
+			c.AppConfig.P2P.Peers = []string{"https://peer1"}
+			c.AppConfig.P2P.AcquisitionTimeout = 10 * time.Second
+			c.AppConfig.P2P.MaxConcurrentTransfers = 50
+			return c
 		},
-		{
-			name: "enabled with valid configuration succeeds",
-			config: func() *Config {
-				c := &Config{}
-				c.AppConfig.P2P.Enabled = true
-				c.AppConfig.P2P.Peers = []string{"https://peer1"}
-				c.AppConfig.P2P.AcquisitionTimeout = 30 * time.Second
-				c.AppConfig.P2P.MaxConcurrentTransfers = 10
-				return c
-			},
-			expectErr:     false,
-			expectWarning: false,
+		expectErr:     true,
+		expectWarning: false,
+	},
+	{
+		name: "enabled with valid configuration succeeds",
+		config: func() *Config {
+			c := &Config{}
+			c.AppConfig.P2P.Enabled = true
+			c.AppConfig.P2P.Peers = []string{"https://peer1"}
+			c.AppConfig.P2P.AcquisitionTimeout = 30 * time.Second
+			c.AppConfig.P2P.MaxConcurrentTransfers = 10
+			return c
 		},
-	}
+		expectErr:     false,
+		expectWarning: false,
+	},
+}
 
-	for _, tt := range tests {
+func TestValidateP2PConfig(t *testing.T) {
+	for _, tt := range validateP2PConfigTests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := tt.config()
 			warnings, err := validateP2PConfig(cfg)

--- a/pkg/config/getters.go
+++ b/pkg/config/getters.go
@@ -1,6 +1,9 @@
 package config
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // Threadsafe getter functions to fetch config data.
 
@@ -231,4 +234,34 @@ func (cm *ConfigManager) GetP2PConfig() P2PConfig {
 	defer cm.mu.RUnlock()
 
 	return cm.config.AppConfig.P2P
+}
+
+func (cm *ConfigManager) IsP2PEnabled() bool {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	return cm.config.AppConfig.P2P.Enabled
+}
+
+func (cm *ConfigManager) GetP2PPeers() []string {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	peers := make([]string, len(cm.config.AppConfig.P2P.Peers))
+	copy(peers, cm.config.AppConfig.P2P.Peers)
+	return peers
+}
+
+func (cm *ConfigManager) GetP2PAcquisitionTimeout() time.Duration {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	return cm.config.AppConfig.P2P.AcquisitionTimeout
+}
+
+func (cm *ConfigManager) GetP2PMaxConcurrentTransfers() int {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	return cm.config.AppConfig.P2P.MaxConcurrentTransfers
 }

--- a/pkg/config/getters.go
+++ b/pkg/config/getters.go
@@ -225,3 +225,10 @@ func (cm *ConfigManager) GetDirectDeliveryConfig() DirectDeliveryConfig {
 
 	return cm.config.AppConfig.DirectDelivery
 }
+
+func (cm *ConfigManager) GetP2PConfig() P2PConfig {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	return cm.config.AppConfig.P2P
+}

--- a/pkg/config/modifiers.go
+++ b/pkg/config/modifiers.go
@@ -163,3 +163,9 @@ func ApplyHarborRegistryOverride(sc StateConfig, override string) (StateConfig, 
 
 	return sc, nil
 }
+
+func SetP2PConfig(p2p P2PConfig) func(*Config) {
+	return func(cfg *Config) {
+		cfg.AppConfig.P2P = p2p
+	}
+}

--- a/pkg/config/modifiers_test.go
+++ b/pkg/config/modifiers_test.go
@@ -91,6 +91,19 @@ func TestConfigManagerModifiers(t *testing.T) {
 				require.Equal(t, []string{"containerd"}, c.AppConfig.RegistryFallback.Runtimes)
 			},
 		},
+		{
+			name: "SetP2PConfig",
+			mutator: SetP2PConfig(P2PConfig{
+				Enabled:        true,
+				Peers:          []string{"https://peer1", "https://peer2"},
+				TimeoutSeconds: 15,
+			}),
+			check: func(t *testing.T, c *Config) {
+				require.True(t, c.AppConfig.P2P.Enabled)
+				require.Equal(t, []string{"https://peer1", "https://peer2"}, c.AppConfig.P2P.Peers)
+				require.Equal(t, 15, c.AppConfig.P2P.TimeoutSeconds)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -135,4 +148,40 @@ func TestGetRegistryFallbackConfigEmpty(t *testing.T) {
 	require.False(t, got.Enabled)
 	require.Nil(t, got.Registries)
 	require.Nil(t, got.Runtimes)
+}
+
+func TestGetP2PConfig(t *testing.T) {
+	cfg := &Config{
+		AppConfig: AppConfig{
+			P2P: P2PConfig{
+				Enabled:        true,
+				Peers:          []string{"https://peer1"},
+				TimeoutSeconds: 10,
+			},
+		},
+		ZotConfigRaw: json.RawMessage(`{}`),
+	}
+
+	cm, err := NewConfigManager("", "", "", "", true, cfg, crypto.NewAESProvider())
+	require.NoError(t, err)
+
+	got := cm.GetP2PConfig()
+	require.True(t, got.Enabled)
+	require.Equal(t, []string{"https://peer1"}, got.Peers)
+	require.Equal(t, 10, got.TimeoutSeconds)
+}
+
+func TestGetP2PConfigEmpty(t *testing.T) {
+	cfg := &Config{
+		AppConfig:    AppConfig{},
+		ZotConfigRaw: json.RawMessage(`{}`),
+	}
+
+	cm, err := NewConfigManager("", "", "", "", true, cfg, crypto.NewAESProvider())
+	require.NoError(t, err)
+
+	got := cm.GetP2PConfig()
+	require.False(t, got.Enabled)
+	require.Nil(t, got.Peers)
+	require.Equal(t, 0, got.TimeoutSeconds)
 }

--- a/pkg/config/modifiers_test.go
+++ b/pkg/config/modifiers_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/container-registry/harbor-satellite/internal/crypto"
 	"github.com/stretchr/testify/require"
@@ -94,14 +95,16 @@ func TestConfigManagerModifiers(t *testing.T) {
 		{
 			name: "SetP2PConfig",
 			mutator: SetP2PConfig(P2PConfig{
-				Enabled:        true,
-				Peers:          []string{"https://peer1", "https://peer2"},
-				TimeoutSeconds: 15,
+				Enabled:                true,
+				Peers:                  []string{"https://peer1", "https://peer2"},
+				AcquisitionTimeout:     15 * time.Second,
+				MaxConcurrentTransfers: 10,
 			}),
 			check: func(t *testing.T, c *Config) {
 				require.True(t, c.AppConfig.P2P.Enabled)
 				require.Equal(t, []string{"https://peer1", "https://peer2"}, c.AppConfig.P2P.Peers)
-				require.Equal(t, 15, c.AppConfig.P2P.TimeoutSeconds)
+				require.Equal(t, 15*time.Second, c.AppConfig.P2P.AcquisitionTimeout)
+				require.Equal(t, 10, c.AppConfig.P2P.MaxConcurrentTransfers)
 			},
 		},
 	}
@@ -154,9 +157,10 @@ func TestGetP2PConfig(t *testing.T) {
 	cfg := &Config{
 		AppConfig: AppConfig{
 			P2P: P2PConfig{
-				Enabled:        true,
-				Peers:          []string{"https://peer1"},
-				TimeoutSeconds: 10,
+				Enabled:                true,
+				Peers:                  []string{"https://peer1"},
+				AcquisitionTimeout:     10 * time.Second,
+				MaxConcurrentTransfers: 5,
 			},
 		},
 		ZotConfigRaw: json.RawMessage(`{}`),
@@ -168,7 +172,8 @@ func TestGetP2PConfig(t *testing.T) {
 	got := cm.GetP2PConfig()
 	require.True(t, got.Enabled)
 	require.Equal(t, []string{"https://peer1"}, got.Peers)
-	require.Equal(t, 10, got.TimeoutSeconds)
+	require.Equal(t, 10*time.Second, got.AcquisitionTimeout)
+	require.Equal(t, 5, got.MaxConcurrentTransfers)
 }
 
 func TestGetP2PConfigEmpty(t *testing.T) {
@@ -183,5 +188,6 @@ func TestGetP2PConfigEmpty(t *testing.T) {
 	got := cm.GetP2PConfig()
 	require.False(t, got.Enabled)
 	require.Nil(t, got.Peers)
-	require.Equal(t, 0, got.TimeoutSeconds)
+	require.Equal(t, time.Duration(0), got.AcquisitionTimeout)
+	require.Equal(t, 0, got.MaxConcurrentTransfers)
 }

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/container-registry/harbor-satellite/internal/satellite/registry"
 	"github.com/robfig/cron/v3"
@@ -412,9 +413,21 @@ func validateP2PConfig(config *Config) ([]string, error) {
 		}
 	}
 
-	if p2p.TimeoutSeconds < 0 {
-		warnings = append(warnings, "p2p.timeout_seconds cannot be negative, defaulting to 0")
-		config.AppConfig.P2P.TimeoutSeconds = 0
+	if p2p.AcquisitionTimeout == 0 {
+		return nil, errors.New("acquisition_timeout is required when p2p is enabled")
+	}
+
+	if p2p.AcquisitionTimeout < 5*time.Second || p2p.AcquisitionTimeout > 5*time.Minute {
+		return nil, errors.New("acquisition_timeout must be between 5s and 5m")
+	}
+
+	if p2p.MaxConcurrentTransfers == 0 {
+		p2p.MaxConcurrentTransfers = 5
+		warnings = append(warnings, "max_concurrent_transfers not set, defaulting to 5")
+	}
+
+	if p2p.MaxConcurrentTransfers < 1 || p2p.MaxConcurrentTransfers > 20 {
+		return nil, errors.New("max_concurrent_transfers must be between 1 and 20")
 	}
 
 	return warnings, nil

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -72,6 +72,12 @@ func ValidateAndEnforceDefaults(config *Config, defaultGroundControlURL string) 
 
 	warnings = append(warnings, validateRegistryFallbackConfig(config)...)
 
+	p2pWarnings, p2pErr := validateP2PConfig(config)
+	warnings = append(warnings, p2pWarnings...)
+	if p2pErr != nil {
+		return nil, warnings, p2pErr
+	}
+
 	warnings = append(warnings, validateAndEnforceAuditConfig(config)...)
 
 	return config, warnings, nil
@@ -383,6 +389,32 @@ func validateTLSConfig(tls *TLSConfig) ([]string, error) {
 
 	if tls.SkipVerify {
 		warnings = append(warnings, "TLS skip_verify is enabled, certificate verification will be skipped")
+	}
+
+	return warnings, nil
+}
+
+// validateP2PConfig validates P2P configuration when enabled.
+func validateP2PConfig(config *Config) ([]string, error) {
+	var warnings []string
+	p2p := &config.AppConfig.P2P
+	if !p2p.Enabled {
+		return warnings, nil
+	}
+
+	if len(p2p.Peers) == 0 {
+		return nil, errors.New("p2p is enabled but no peers are configured")
+	}
+
+	for _, peer := range p2p.Peers {
+		if _, err := url.ParseRequestURI(peer); err != nil {
+			return nil, fmt.Errorf("invalid peer URL %q: %w", peer, err)
+		}
+	}
+
+	if p2p.TimeoutSeconds < 0 {
+		warnings = append(warnings, "p2p.timeout_seconds cannot be negative, defaulting to 0")
+		config.AppConfig.P2P.TimeoutSeconds = 0
 	}
 
 	return warnings, nil

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -768,100 +767,3 @@ func TestAuditConfig_Equal(t *testing.T) {
 func intPtr(i int) *int    { return &i }
 func boolPtr(b bool) *bool { return &b }
 
-func TestP2PConfigParsing(t *testing.T) {
-	t.Run("default is false", func(t *testing.T) {
-		var c Config
-		err := json.Unmarshal([]byte(`{"app_config": {}}`), &c)
-		require.NoError(t, err)
-		require.False(t, c.AppConfig.P2P.Enabled)
-	})
-
-	t.Run("parses true and fields", func(t *testing.T) {
-		var c Config
-		err := json.Unmarshal([]byte(`{"app_config": {"p2p": {"enabled": true, "peers": ["https://peer1"], "timeout_seconds": 10}}}`), &c)
-		require.NoError(t, err)
-		require.True(t, c.AppConfig.P2P.Enabled)
-		require.Equal(t, []string{"https://peer1"}, c.AppConfig.P2P.Peers)
-		require.Equal(t, 10, c.AppConfig.P2P.TimeoutSeconds)
-	})
-}
-
-func TestValidateP2PConfig(t *testing.T) {
-	tests := []struct {
-		name          string
-		config        func() *Config
-		expectErr     bool
-		expectWarning bool
-	}{
-		{
-			name: "disabled returns nil",
-			config: func() *Config {
-				return &Config{}
-			},
-			expectErr:     false,
-			expectWarning: false,
-		},
-		{
-			name: "enabled with no peers returns error",
-			config: func() *Config {
-				c := &Config{}
-				c.AppConfig.P2P.Enabled = true
-				return c
-			},
-			expectErr:     true,
-			expectWarning: false,
-		},
-		{
-			name: "enabled with invalid peer url returns error",
-			config: func() *Config {
-				c := &Config{}
-				c.AppConfig.P2P.Enabled = true
-				c.AppConfig.P2P.Peers = []string{"not-a-url"}
-				return c
-			},
-			expectErr:     true,
-			expectWarning: false,
-		},
-		{
-			name: "enabled with valid peer and negative timeout returns warning",
-			config: func() *Config {
-				c := &Config{}
-				c.AppConfig.P2P.Enabled = true
-				c.AppConfig.P2P.Peers = []string{"https://peer1"}
-				c.AppConfig.P2P.TimeoutSeconds = -5
-				return c
-			},
-			expectErr:     false,
-			expectWarning: true,
-		},
-		{
-			name: "enabled with valid configuration succeeds",
-			config: func() *Config {
-				c := &Config{}
-				c.AppConfig.P2P.Enabled = true
-				c.AppConfig.P2P.Peers = []string{"https://peer1"}
-				c.AppConfig.P2P.TimeoutSeconds = 30
-				return c
-			},
-			expectErr:     false,
-			expectWarning: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := tt.config()
-			warnings, err := validateP2PConfig(cfg)
-			if tt.expectErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-			if tt.expectWarning {
-				require.NotEmpty(t, warnings)
-			} else {
-				require.Empty(t, warnings)
-			}
-		})
-	}
-}

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -766,3 +767,101 @@ func TestAuditConfig_Equal(t *testing.T) {
 
 func intPtr(i int) *int    { return &i }
 func boolPtr(b bool) *bool { return &b }
+
+func TestP2PConfigParsing(t *testing.T) {
+	t.Run("default is false", func(t *testing.T) {
+		var c Config
+		err := json.Unmarshal([]byte(`{"app_config": {}}`), &c)
+		require.NoError(t, err)
+		require.False(t, c.AppConfig.P2P.Enabled)
+	})
+
+	t.Run("parses true and fields", func(t *testing.T) {
+		var c Config
+		err := json.Unmarshal([]byte(`{"app_config": {"p2p": {"enabled": true, "peers": ["https://peer1"], "timeout_seconds": 10}}}`), &c)
+		require.NoError(t, err)
+		require.True(t, c.AppConfig.P2P.Enabled)
+		require.Equal(t, []string{"https://peer1"}, c.AppConfig.P2P.Peers)
+		require.Equal(t, 10, c.AppConfig.P2P.TimeoutSeconds)
+	})
+}
+
+func TestValidateP2PConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        func() *Config
+		expectErr     bool
+		expectWarning bool
+	}{
+		{
+			name: "disabled returns nil",
+			config: func() *Config {
+				return &Config{}
+			},
+			expectErr:     false,
+			expectWarning: false,
+		},
+		{
+			name: "enabled with no peers returns error",
+			config: func() *Config {
+				c := &Config{}
+				c.AppConfig.P2P.Enabled = true
+				return c
+			},
+			expectErr:     true,
+			expectWarning: false,
+		},
+		{
+			name: "enabled with invalid peer url returns error",
+			config: func() *Config {
+				c := &Config{}
+				c.AppConfig.P2P.Enabled = true
+				c.AppConfig.P2P.Peers = []string{"not-a-url"}
+				return c
+			},
+			expectErr:     true,
+			expectWarning: false,
+		},
+		{
+			name: "enabled with valid peer and negative timeout returns warning",
+			config: func() *Config {
+				c := &Config{}
+				c.AppConfig.P2P.Enabled = true
+				c.AppConfig.P2P.Peers = []string{"https://peer1"}
+				c.AppConfig.P2P.TimeoutSeconds = -5
+				return c
+			},
+			expectErr:     false,
+			expectWarning: true,
+		},
+		{
+			name: "enabled with valid configuration succeeds",
+			config: func() *Config {
+				c := &Config{}
+				c.AppConfig.P2P.Enabled = true
+				c.AppConfig.P2P.Peers = []string{"https://peer1"}
+				c.AppConfig.P2P.TimeoutSeconds = 30
+				return c
+			},
+			expectErr:     false,
+			expectWarning: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.config()
+			warnings, err := validateP2PConfig(cfg)
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if tt.expectWarning {
+				require.NotEmpty(t, warnings)
+			} else {
+				require.Empty(t, warnings)
+			}
+		})
+	}
+}


### PR DESCRIPTION
*Related to #542*

### Summary

While looking into how Satellites handle missing artifacts in air-gapped deployments, I noticed a gap in the current replication flow. If a Satellite needs an image but has no Ground Control or internet access, it has no way to retrieve it - - even if another Satellite on the same local network already has the artifact.

This PR doesn't implement peer-to-peer transfers yet. Instead, it introduces the configuration model and architectural foundation needed to support Satellite-to-Satellite artifact sharing in follow-up changes.

### The problem

```text
Satellite A (has image)          Satellite B (needs image)
        |                                 |
        |                          [no Ground Control]
        |                          [no internet]
        |                                 |
        X -------- currently impossible --------> X
```

### What changed

**Configuration**

Added a new `P2PConfig` section to `AppConfig` along with validation.

The validation currently checks:
- Peer URLs are valid.
- Acquisition timeout is between 5 seconds and 5 minutes.
- Maximum concurrent transfers is between 1 and 20.

If `max_concurrent_transfers` isn't configured, it defaults to 5 with a warning, following the same pattern used by `validateRegistryFallbackConfig`.

Since Go's standard JSON unmarshalling doesn't parse duration strings like `"30s"` into `time.Duration`, I also added a custom `UnmarshalJSON` implementation for the configuration.

**Replication**

Introduced `PeerAwareReplicator`, which wraps the existing `Replicator` interface.

At this stage it simply delegates to the existing implementation, but it establishes a clean extension point for peer-aware routing without changing `BasicReplicator` or the current replication pipeline.

### Why split it this way?

I wanted to get the configuration model and abstraction boundary reviewed before introducing networking code.

The planned follow-up work builds on this foundation:
1. Peer discovery and availability checks.
2. OCI artifact transfer.
3. Fallback handling when peers cannot satisfy a request.

Keeping these pieces separate should make each review much smaller and easier to reason about.

### Backward compatibility

This change does not modify the existing replication behavior.

When `p2p.enabled` is false (the default), the replication path is unchanged.

### Files changed

- `pkg/config/config.go` - - `P2PConfig` and custom `UnmarshalJSON`
- `pkg/config/validate.go` - -  `validateP2PConfig`
- `pkg/config/getters.go` - - thread-safe getters (`GetP2PPeers` returns a copy)
- `pkg/config/modifiers.go` - - `SetP2PConfig`
- `internal/satellite/state/peer_replicator.go` - - `PeerAwareReplicator`
- `pkg/config/config_test.go` - - configuration and JSON parsing tests
- `internal/satellite/state/peer_replicator_test.go` - -  delegation and constructor tests

### Testing

Verified with:

`go build ./...`  
`go test ./...`  
`go test -race ./...`  

All completed successfully.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

