### PR TITLE
fix: publish satellite state artifact when a satellite has no group states

### DIFF
--- a/internal/groundcontrol/server/helpers.go
+++ b/internal/groundcontrol/server/helpers.go
@@ -33,19 +33,36 @@ func isConfigInUse(ctx context.Context, q *database.Queries, config database.Con
 	return len(satellites) > 0, nil
 }
 
-func createOrUpdateSatStateArtifact(ctx context.Context, satelliteName string, states []string, configName string) error {
-	if satelliteName == "" {
-		return fmt.Errorf("the satellite name must be at least one character long")
-	}
+// satelliteStateArtifact is the published form of SatelliteStateArtifact. The
+// generated model tags states as omitempty, so an empty list is left out of the
+// JSON entirely and a satellite cannot tell a cleared state from an unchanged
+// one. The published artifact needs to carry an explicit "states": [].
+type satelliteStateArtifact struct {
+	Config string   `json:"config,omitempty"`
+	States []string `json:"states"`
+}
+
+// buildSatelliteStateArtifact assembles the artifact published for a satellite.
+// A satellite with no group states still needs one, otherwise it either never
+// receives an artifact or keeps consuming a previously published group list, so
+// a nil slice is normalized to an empty one rather than marshaling to null.
+func buildSatelliteStateArtifact(states []string, configName string) satelliteStateArtifact {
 	if states == nil {
 		states = []string{}
 	}
 
-	artifact := SatelliteStateArtifact{
+	return satelliteStateArtifact{
 		States: states,
 		Config: utils.AssembleConfigState(configName),
 	}
-	data, err := json.Marshal(artifact)
+}
+
+func createOrUpdateSatStateArtifact(ctx context.Context, satelliteName string, states []string, configName string) error {
+	if satelliteName == "" {
+		return fmt.Errorf("the satellite name must be at least one character long")
+	}
+
+	data, err := json.Marshal(buildSatelliteStateArtifact(states, configName))
 	if err != nil {
 		return fmt.Errorf("failed to marshal satellite state artifact to JSON: %w", err)
 	}

--- a/internal/groundcontrol/server/helpers.go
+++ b/internal/groundcontrol/server/helpers.go
@@ -34,11 +34,11 @@ func isConfigInUse(ctx context.Context, q *database.Queries, config database.Con
 }
 
 func createOrUpdateSatStateArtifact(ctx context.Context, satelliteName string, states []string, configName string) error {
-	if len(states) == 0 {
-		return nil
-	}
 	if satelliteName == "" {
 		return fmt.Errorf("the satellite name must be at least one character long")
+	}
+	if states == nil {
+		states = []string{}
 	}
 
 	artifact := SatelliteStateArtifact{

--- a/internal/groundcontrol/server/helpers_test.go
+++ b/internal/groundcontrol/server/helpers_test.go
@@ -11,6 +11,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBuildSatelliteStateArtifact(t *testing.T) {
+	previous := env.GC.Harbor
+	t.Cleanup(func() { env.GC.Harbor = previous })
+	env.GC.Harbor = env.Harbor{URL: "http://harbor"}
+
+	tests := []struct {
+		name   string
+		states []string
+		want   string
+	}{
+		{
+			name:   "nil states are normalized to an empty list",
+			states: nil,
+			want:   `{"states":[],"config":"http://harbor/satellite/config-state/cfg/state:latest"}`,
+		},
+		{
+			name:   "empty states are serialized explicitly",
+			states: []string{},
+			want:   `{"states":[],"config":"http://harbor/satellite/config-state/cfg/state:latest"}`,
+		},
+		{
+			name:   "populated states are left as they are",
+			states: []string{"http://harbor/satellite/group-state/grp/state:latest"},
+			want:   `{"states":["http://harbor/satellite/group-state/grp/state:latest"],"config":"http://harbor/satellite/config-state/cfg/state:latest"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			artifact := buildSatelliteStateArtifact(tt.states, "cfg")
+			require.NotNil(t, artifact.States, "states must never be nil, otherwise it marshals to null")
+
+			data, err := json.Marshal(artifact)
+			require.NoError(t, err)
+			require.JSONEq(t, tt.want, string(data))
+		})
+	}
+}
+
 func TestCreateOrUpdateSatStateArtifact(t *testing.T) {
 	previous := env.GC.Harbor
 	t.Cleanup(func() { env.GC.Harbor = previous })
@@ -25,7 +64,8 @@ func TestCreateOrUpdateSatStateArtifact(t *testing.T) {
 	// pushStateArtifact, so a satellite with no groups left never got a
 	// cleared state published. Reaching the Harbor validation error here
 	// (raised inside pushStateArtifact) is what proves that early return is
-	// gone for both a nil and an explicitly empty states slice.
+	// gone for both a nil and an explicitly empty states slice. The contents
+	// of the published artifact are covered by TestBuildSatelliteStateArtifact.
 	t.Run("reaches harbor validation instead of returning early for empty states", func(t *testing.T) {
 		tests := []struct {
 			name   string

--- a/internal/groundcontrol/server/helpers_test.go
+++ b/internal/groundcontrol/server/helpers_test.go
@@ -1,13 +1,48 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/container-registry/harbor-satellite/internal/crypto"
+	"github.com/container-registry/harbor-satellite/internal/env"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCreateOrUpdateSatStateArtifact(t *testing.T) {
+	previous := env.GC.Harbor
+	t.Cleanup(func() { env.GC.Harbor = previous })
+	env.GC.Harbor = env.Harbor{}
+
+	t.Run("rejects an empty satellite name", func(t *testing.T) {
+		err := createOrUpdateSatStateArtifact(context.Background(), "", []string{"state"}, "cfg")
+		require.ErrorContains(t, err, "satellite name")
+	})
+
+	// Before the fix, an empty group list returned nil before ever reaching
+	// pushStateArtifact, so a satellite with no groups left never got a
+	// cleared state published. Reaching the Harbor validation error here
+	// (raised inside pushStateArtifact) is what proves that early return is
+	// gone for both a nil and an explicitly empty states slice.
+	t.Run("reaches harbor validation instead of returning early for empty states", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			states []string
+		}{
+			{name: "nil states", states: nil},
+			{name: "empty states", states: []string{}},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				err := createOrUpdateSatStateArtifact(context.Background(), "sat-1", tt.states, "cfg")
+				require.ErrorContains(t, err, "HARBOR_URL")
+			})
+		}
+	})
+}
 
 func TestHashRobotCredentials(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
- Fixes: #537

## Description

This PR makes Ground Control publish a satellite state artifact even when the satellite has no group states.

`CreateOrUpdateSatStateArtifact` returned early when `states` was empty, so nothing was published at all. A satellite registered with no groups never received a state artifact, and a satellite removed from its final group kept reading the artifact published before the removal, so it carried on replicating a group it no longer belonged to.

### Changes

- Removed the early return in `internal/groundcontrol/utils/helper.go` so the empty case publishes with an empty states list.
- Dropped `omitempty` from `States` in `internal/groundcontrol/models/models.go`. With the tag in place an empty list is left out of the JSON entirely and the satellite reads that the same as a missing field.
- `getGroupStates` returns a nil slice when a satellite has no groups, and nil marshals to `null` rather than `[]`, so nil is normalized to an empty slice before the artifact is built.
- Added `internal/groundcontrol/utils/helper_test.go`, which is the first test file in that package.

## Additional context

`SatelliteStateArtifact` is marshalled in one place only, and the satellite side unmarshals into a separate type in `internal/satellite/state/state.go`, so dropping `omitempty` does not affect the consumer. The struct carries a `swagger:model` annotation but is not in the committed spec, so nothing needed regenerating.

The tests sit at the unit level. `CreateOrUpdateSatStateArtifact` pushes to a live registry and there is no registry fixture in the repo, so the registration and group removal handlers cannot reach the publish step in a unit test. I checked that both tests fail when the fix is reverted. Happy to add a fixture if you would rather have coverage at the handler level.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Satellite state artifacts are now handled consistently when no state data is available.
  * Invalid satellite names are validated before processing.
  * Empty state data can now proceed through artifact creation and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->