### PR TITLE
fix: resolve SaveState double-close panic by tracking close status

### DIFF
--- a/internal/satellite/state/state_persistence.go
+++ b/internal/satellite/state/state_persistence.go
@@ -45,9 +45,12 @@ func SaveState(path string, stateMap []StateMap, configDigest string) error {
 	}
 	tmpName := tmp.Name()
 
+	fileClosed := false
 	cleanup := func() {
-		if closeErr := tmp.Close(); closeErr != nil && err == nil {
-			err = fmt.Errorf("close temp file: %w", closeErr)
+		if !fileClosed {
+			if closeErr := tmp.Close(); closeErr != nil && err == nil {
+				err = fmt.Errorf("close temp file: %w", closeErr)
+			}
 		}
 		if err != nil {
 			if removeErr := os.Remove(tmpName); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
@@ -66,6 +69,7 @@ func SaveState(path string, stateMap []StateMap, configDigest string) error {
 	if err = tmp.Close(); err != nil {
 		return fmt.Errorf("close temp file: %w", err)
 	}
+	fileClosed = true
 	if err = os.Rename(tmpName, path); err != nil {
 		return fmt.Errorf("rename temp to state file: %w", err)
 	}


### PR DESCRIPTION
Fixes #556

## Summary

`SaveState` explicitly closes the temporary file before renaming it, but the deferred cleanup function attempted to close the same file again during function exit.

This change tracks whether the temporary file has already been closed and skips the deferred `Close()` when appropriate, ensuring the file is closed exactly once.

## Why

On the successful execution path:

1. The temporary file is written and synced.
2. `tmp.Close()` succeeds.
3. The file is renamed successfully.
4. The deferred cleanup executes and calls `tmp.Close()` again.

If the second `Close()` returns an error, the deferred cleanup may overwrite the successful return value, causing `SaveState` to report a failure even though the state file was successfully persisted.

## Changes

- Introduced a `fileClosed` flag to track whether the temporary file has already been closed.
- Updated the deferred cleanup to skip `Close()` once the explicit close succeeds.
- Preserved the existing cleanup behavior for all error paths.

## Testing

Verified that the existing persistence tests continue to pass:

- `TestSaveAndLoadRoundTrip`
- `TestSaveEmptyState`

Additionally, confirmed that the successful execution path no longer performs a duplicate `Close()` on the temporary file.

## Additional Context

This issue was identified while reviewing the satellite state persistence flow during graceful shutdown.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

