### PR TITLE
fix: downgrade LogChanges routine metrics from Warn to Info

### DIFF
--- a/internal/satellite/state/state_process.go
+++ b/internal/satellite/state/state_process.go
@@ -604,8 +604,8 @@ func (f *FetchAndReplicateStateProcess) FetchAndProcessState(ctx context.Context
 }
 
 func (f *FetchAndReplicateStateProcess) LogChanges(deleteEntity, replicateEntity []Entity, log *zerolog.Logger) {
-	log.Warn().Msgf("Total artifacts to delete: %d", len(deleteEntity))
-	log.Warn().Msgf("Total artifacts to replicate: %d", len(replicateEntity))
+	log.Info().Msgf("Total artifacts to delete: %d", len(deleteEntity))
+	log.Info().Msgf("Total artifacts to replicate: %d", len(replicateEntity))
 }
 
 func FetchEntitiesFromState(state StateReader) []Entity {


### PR DESCRIPTION
Fixes #557

## Summary

`LogChanges` currently emits routine synchronization counters using the `Warn` log level, even during normal steady-state operation.

This change updates these messages to use `Info`, which better reflects their informational nature while preserving their visibility.

## Why

`FetchAndReplicateStateProcess` executes continuously, and `LogChanges` is invoked on each synchronization cycle.

The current implementation logs messages such as:

- `Total artifacts to delete: 0`
- `Total artifacts to replicate: 0`

at the `Warn` level, even when no action is required.

Using `Info` for these routine counters helps keep warning logs focused on unexpected or actionable conditions.

## Changes

- Replaced `log.Warn()` with `log.Info()` for routine synchronization counters in `LogChanges()`.

## Testing

- No functional behavior was changed.
- Existing test suites continue to pass.
- Verified that synchronization counters are now emitted at the `Info` level.

## Additional Context

This issue was identified while reviewing the satellite state synchronization and logging flow.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

