### PR TITLE
test: skip disk serial check when block device directory is inaccessible

### DIFF
--- a/internal/satellite/identity/device_linux.go
+++ b/internal/satellite/identity/device_linux.go
@@ -131,7 +131,7 @@ func (d *LinuxDeviceIdentity) GetBootID() (string, error) {
 func (d *LinuxDeviceIdentity) GetDiskSerial() (string, error) {
 	entries, err := os.ReadDir(d.blockDevPath)
 	if err != nil {
-		return "", fmt.Errorf("read block devices: %w", err)
+		return "", fmt.Errorf("read block devices: %w: %w", ErrComponentUnavailable, err)
 	}
 
 	for _, entry := range entries {


### PR DESCRIPTION
### Description
This PR resolves unit test failures for `TestLinuxDeviceIdentity_GetDiskSerial` in restricted, sandboxed, or containerized environments where `/sys/class/block` is not exposed or readable.

### Changes
* Wraps `ErrComponentUnavailable` in the error returned when `os.ReadDir(d.blockDevPath)` fails inside `GetDiskSerial()`.
* This allows the test suite to safely catch the error and skip checking the disk serial in environments without access to block devices.

Closes #568 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when a device’s disk serial number cannot be read, including both the component-unavailable status and the underlying filesystem error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->