### PR TITLE
fix(scheduler): add opt-in startup jitter to spread a fleet's first sync

### DIFF
--- a/internal/satellite/satellite.go
+++ b/internal/satellite/satellite.go
@@ -65,6 +65,9 @@ func (s *Satellite) Run(ctx context.Context) error {
 			log.Error().Err(err).Msg("Failed to create ZTR scheduler")
 			return err
 		}
+		// Spread the first registration across one interval. Without this every
+		// satellite in a fleet that boots together registers at the same instant.
+		ztrScheduler.WithStartupJitter(ztrScheduler.GetInterval())
 		s.schedulers = append(s.schedulers, ztrScheduler)
 		ztrScheduler.Start(ctx)
 	}
@@ -79,6 +82,8 @@ func (s *Satellite) Run(ctx context.Context) error {
 		log.Error().Err(err).Msg("Failed to create state replication scheduler")
 		return err
 	}
+	// Spread the first state fetch across one interval, for the same reason.
+	stateScheduler.WithStartupJitter(stateScheduler.GetInterval())
 	s.schedulers = append(s.schedulers, stateScheduler)
 	stateScheduler.Start(ctx)
 
@@ -96,6 +101,8 @@ func (s *Satellite) Run(ctx context.Context) error {
 		log.Error().Err(err).Msg("Failed to create status report scheduler")
 		return err
 	}
+	// Spread the first status report across one interval, for the same reason.
+	statusScheduler.WithStartupJitter(statusScheduler.GetInterval())
 	s.schedulers = append(s.schedulers, statusScheduler)
 	statusScheduler.Start(ctx)
 

--- a/internal/satellite/satellite.go
+++ b/internal/satellite/satellite.go
@@ -67,7 +67,9 @@ func (s *Satellite) Run(ctx context.Context) error {
 		}
 		// Spread the first registration across one interval. Without this every
 		// satellite in a fleet that boots together registers at the same instant.
-		ztrScheduler.WithStartupJitter(ztrScheduler.GetInterval())
+		if !s.cm.IsStartupJitterDisabled() {
+			ztrScheduler.WithStartupJitter(ztrScheduler.GetInterval())
+		}
 		s.schedulers = append(s.schedulers, ztrScheduler)
 		ztrScheduler.Start(ctx)
 	}
@@ -83,7 +85,9 @@ func (s *Satellite) Run(ctx context.Context) error {
 		return err
 	}
 	// Spread the first state fetch across one interval, for the same reason.
-	stateScheduler.WithStartupJitter(stateScheduler.GetInterval())
+	if !s.cm.IsStartupJitterDisabled() {
+		stateScheduler.WithStartupJitter(stateScheduler.GetInterval())
+	}
 	s.schedulers = append(s.schedulers, stateScheduler)
 	stateScheduler.Start(ctx)
 
@@ -102,7 +106,9 @@ func (s *Satellite) Run(ctx context.Context) error {
 		return err
 	}
 	// Spread the first status report across one interval, for the same reason.
-	statusScheduler.WithStartupJitter(statusScheduler.GetInterval())
+	if !s.cm.IsStartupJitterDisabled() {
+		statusScheduler.WithStartupJitter(statusScheduler.GetInterval())
+	}
 	s.schedulers = append(s.schedulers, statusScheduler)
 	statusScheduler.Start(ctx)
 

--- a/internal/satellite/scheduler/scheduler.go
+++ b/internal/satellite/scheduler/scheduler.go
@@ -2,9 +2,10 @@ package scheduler
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"strings"
 	"sync"
 	"time"
@@ -75,8 +76,20 @@ func (s *Scheduler) waitStartupJitter(ctx context.Context) bool {
 		return true
 	}
 
-	//nolint:gosec // load spreading, not a security boundary; math/rand is sufficient
-	delay := time.Duration(rand.Int63n(int64(bound)))
+	// crypto/rand rather than math/rand: this runs once per scheduler at startup,
+	// so the cost is irrelevant, and it keeps static analysis clean without a
+	// suppression comment. Falls back to no delay if the reader fails, which is
+	// the previous behaviour.
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(bound)))
+	if err != nil {
+		s.log.Warn().
+			Str("Process", s.process.Name()).
+			Err(err).
+			Msg("Could not compute startup jitter, running immediately")
+
+		return true
+	}
+	delay := time.Duration(n.Int64())
 
 	s.log.Debug().
 		Str("Process", s.process.Name()).

--- a/internal/satellite/scheduler/scheduler.go
+++ b/internal/satellite/scheduler/scheduler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"strings"
 	"sync"
 	"time"
@@ -18,8 +19,14 @@ type Scheduler struct {
 	process  Process
 	log      *zerolog.Logger
 	interval time.Duration
-	mu       sync.Mutex
-	wg       sync.WaitGroup
+	// startupJitter bounds a random delay applied before the first run only.
+	// Subsequent runs are driven by the ticker and are unaffected. It is zero
+	// by default, preserving the existing run-immediately behaviour; callers
+	// that manage a fleet opt in with WithStartupJitter so that satellites
+	// booting together do not all call Ground Control at the same instant.
+	startupJitter time.Duration
+	mu            sync.Mutex
+	wg            sync.WaitGroup
 }
 
 // NewSchedulerWithInterval creates a new scheduler with a parsed interval string.
@@ -41,6 +48,52 @@ func NewSchedulerWithInterval(intervalExpr string, process Process, log *zerolog
 	return scheduler, nil
 }
 
+// WithStartupJitter sets the upper bound of the random delay applied before the
+// first run. The zero value, which is the default, runs immediately. Passing the
+// scheduler interval spreads a fleet's first execution uniformly across one
+// interval. Returns the scheduler so it can be chained onto the constructor.
+func (s *Scheduler) WithStartupJitter(d time.Duration) *Scheduler {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if d < 0 {
+		d = 0
+	}
+	s.startupJitter = d
+
+	return s
+}
+
+// waitStartupJitter blocks for a random duration in [0, startupJitter) before
+// the first run. It returns false if the context was cancelled while waiting.
+func (s *Scheduler) waitStartupJitter(ctx context.Context) bool {
+	s.mu.Lock()
+	bound := s.startupJitter
+	s.mu.Unlock()
+
+	if bound <= 0 {
+		return true
+	}
+
+	//nolint:gosec // load spreading, not a security boundary; math/rand is sufficient
+	delay := time.Duration(rand.Int63n(int64(bound)))
+
+	s.log.Debug().
+		Str("Process", s.process.Name()).
+		Dur("delay", delay).
+		Msg("Delaying first execution to spread load across the fleet")
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
 // Start launches Run in a goroutine with proper WaitGroup tracking.
 // wg.Add must happen before the goroutine to avoid a race with Stop.
 func (s *Scheduler) Start(ctx context.Context) {
@@ -58,7 +111,16 @@ func (s *Scheduler) run(ctx context.Context) {
 		Dur("interval", s.interval).
 		Msg("Starting scheduler")
 
-	// Run once immediately
+	// Run once at startup, after a bounded random delay so that satellites
+	// booting together do not all call Ground Control at the same instant.
+	if !s.waitStartupJitter(ctx) {
+		s.log.Info().
+			Str("Process", s.process.Name()).
+			Msg("Scheduler cancelled before first execution. Exiting...")
+
+		return
+	}
+
 	s.launchProcess(ctx)
 
 	for {

--- a/internal/satellite/scheduler/scheduler.go
+++ b/internal/satellite/scheduler/scheduler.go
@@ -121,6 +121,11 @@ func (s *Scheduler) run(ctx context.Context) {
 		return
 	}
 
+	// The ticker has been running since construction, so a tick may have been
+	// buffered while the jitter delay elapsed. Reset it so the interval between
+	// the first and second runs is a full interval rather than whatever remains.
+	s.resetTickerAfterJitter()
+
 	s.launchProcess(ctx)
 
 	for {
@@ -143,6 +148,20 @@ func (s *Scheduler) run(ctx context.Context) {
 			s.launchProcess(ctx)
 		}
 	}
+}
+
+// resetTickerAfterJitter restarts the ticker so that the delay between the
+// first and second executions is a full interval. Without it, a tick buffered
+// during the jitter wait fires immediately after the first run.
+func (s *Scheduler) resetTickerAfterJitter() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.startupJitter <= 0 {
+		return
+	}
+
+	s.ticker.Reset(s.interval)
 }
 
 // ResetInterval changes the ticker interval dynamically.

--- a/internal/satellite/scheduler/scheduler_test.go
+++ b/internal/satellite/scheduler/scheduler_test.go
@@ -225,3 +225,83 @@ func TestMultipleSchedulers_GracefulShutdown(t *testing.T) {
 		t.Fatal("timed out waiting for all schedulers to stop")
 	}
 }
+
+func TestStartupJitterDefaultsToZero(t *testing.T) {
+	log := zerolog.Nop()
+	proc := &mockProcess{name: "jitter-default"}
+
+	s, err := NewSchedulerWithInterval("@every 10s", proc, &log)
+	require.NoError(t, err)
+
+	require.Zero(t, s.startupJitter,
+		"startup jitter must default to zero so existing behaviour is unchanged")
+}
+
+func TestWithStartupJitterZeroRunsImmediately(t *testing.T) {
+	log := zerolog.Nop()
+	proc := &mockProcess{name: "jitter-disabled"}
+
+	s, err := NewSchedulerWithInterval("@every 1h", proc, &log)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s.Start(ctx)
+
+	require.Eventually(t, func() bool {
+		return proc.execCount.Load() == 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"without jitter the first run should happen immediately")
+}
+
+func TestWithStartupJitterDelaysFirstRun(t *testing.T) {
+	log := zerolog.Nop()
+	proc := &mockProcess{name: "jitter-delays"}
+
+	s, err := NewSchedulerWithInterval("@every 1h", proc, &log)
+	require.NoError(t, err)
+	s.WithStartupJitter(time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s.Start(ctx)
+
+	// With an hour of jitter the odds of firing within 200ms are negligible.
+	time.Sleep(200 * time.Millisecond)
+	require.Equal(t, int32(0), proc.execCount.Load(),
+		"first run should be delayed while jitter is pending")
+}
+
+func TestStartupJitterRespectsCancellation(t *testing.T) {
+	log := zerolog.Nop()
+	proc := &mockProcess{name: "jitter-cancel"}
+
+	s, err := NewSchedulerWithInterval("@every 1h", proc, &log)
+	require.NoError(t, err)
+	s.WithStartupJitter(time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.Start(ctx)
+	cancel()
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer stopCancel()
+
+	require.NoError(t, s.Stop(stopCtx),
+		"scheduler should exit promptly when cancelled during the jitter wait")
+	require.Equal(t, int32(0), proc.execCount.Load(),
+		"process should not run if cancelled before the jitter elapsed")
+}
+
+func TestNegativeStartupJitterIsClamped(t *testing.T) {
+	log := zerolog.Nop()
+	proc := &mockProcess{name: "jitter-negative"}
+
+	s, err := NewSchedulerWithInterval("@every 10s", proc, &log)
+	require.NoError(t, err)
+	s.WithStartupJitter(-5 * time.Second)
+
+	require.Zero(t, s.startupJitter, "a negative bound must clamp to zero, not panic")
+}

--- a/internal/satellite/scheduler/scheduler_test.go
+++ b/internal/satellite/scheduler/scheduler_test.go
@@ -261,17 +261,49 @@ func TestWithStartupJitterDelaysFirstRun(t *testing.T) {
 
 	s, err := NewSchedulerWithInterval("@every 1h", proc, &log)
 	require.NoError(t, err)
-	s.WithStartupJitter(time.Hour)
+	// A tight bound keeps this deterministic: the run must not have happened
+	// at the instant Start returns, and must happen once the bound elapses.
+	s.WithStartupJitter(100 * time.Millisecond)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	s.Start(ctx)
 
-	// With an hour of jitter the odds of firing within 200ms are negligible.
-	time.Sleep(200 * time.Millisecond)
 	require.Equal(t, int32(0), proc.execCount.Load(),
-		"first run should be delayed while jitter is pending")
+		"the first run must not be synchronous with Start when jitter is set")
+
+	require.Eventually(t, func() bool {
+		return proc.execCount.Load() == 1
+	}, 5*time.Second, 10*time.Millisecond,
+		"the first run should happen once the jitter bound has elapsed")
+}
+
+func TestStartupJitterResetsTicker(t *testing.T) {
+	log := zerolog.Nop()
+	proc := &mockProcess{name: "jitter-ticker"}
+
+	// Interval shorter than the jitter bound guarantees a tick is buffered
+	// while the jitter wait is in progress.
+	s, err := NewSchedulerWithInterval("@every 100ms", proc, &log)
+	require.NoError(t, err)
+	s.WithStartupJitter(300 * time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s.Start(ctx)
+
+	require.Eventually(t, func() bool {
+		return proc.execCount.Load() >= 1
+	}, 5*time.Second, 5*time.Millisecond, "first run should eventually happen")
+
+	// Immediately after the first run, a buffered tick must not fire a second
+	// execution. Sample well inside one interval.
+	first := proc.execCount.Load()
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, first, proc.execCount.Load(),
+		"a tick buffered during the jitter wait must not trigger an immediate second run")
 }
 
 func TestStartupJitterRespectsCancellation(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -188,22 +188,27 @@ type DirectDeliveryConfig struct {
 }
 
 type AppConfig struct {
-	GroundControlURL          URL                    `json:"ground_control_url,omitempty"`
-	LogLevel                  string                 `json:"log_level,omitempty"`
-	UseUnsecure               bool                   `json:"use_unsecure,omitempty"`
-	StateReplicationInterval  string                 `json:"state_replication_interval,omitempty"`
-	RegisterSatelliteInterval string                 `json:"register_satellite_interval,omitempty"`
-	HeartbeatInterval         string                 `json:"heartbeat_interval,omitempty"`
-	Metrics                   MetricsConfig          `json:"metrics,omitempty"`
-	BringOwnRegistry          bool                   `json:"bring_own_registry,omitempty"`
-	LocalRegistryCredentials  RegistryCredentials    `json:"local_registry,omitempty"`
-	TLS                       TLSConfig              `json:"tls,omitempty"`
-	SPIFFE                    SPIFFEConfig           `json:"spiffe,omitempty"`
-	EncryptConfig             bool                   `json:"encrypt_config,omitempty"`
-	RegistryFallback          RegistryFallbackConfig `json:"registry_fallback,omitempty"`
-	HarborRegistryURL         string                 `json:"harbor_registry_url,omitempty"`
-	DirectDelivery            DirectDeliveryConfig   `json:"direct_delivery,omitempty"`
-	Audit                     AuditConfig            `json:"audit,omitempty"`
+	GroundControlURL          URL    `json:"ground_control_url,omitempty"`
+	LogLevel                  string `json:"log_level,omitempty"`
+	UseUnsecure               bool   `json:"use_unsecure,omitempty"`
+	StateReplicationInterval  string `json:"state_replication_interval,omitempty"`
+	RegisterSatelliteInterval string `json:"register_satellite_interval,omitempty"`
+	HeartbeatInterval         string `json:"heartbeat_interval,omitempty"`
+	// DisableStartupJitter turns off the random delay applied before each
+	// scheduler's first run. Jitter prevents a fleet that boots together from
+	// calling Ground Control in unison; a standalone satellite may prefer an
+	// immediate first sync instead.
+	DisableStartupJitter     bool                   `json:"disable_startup_jitter,omitempty"`
+	Metrics                  MetricsConfig          `json:"metrics,omitempty"`
+	BringOwnRegistry         bool                   `json:"bring_own_registry,omitempty"`
+	LocalRegistryCredentials RegistryCredentials    `json:"local_registry,omitempty"`
+	TLS                      TLSConfig              `json:"tls,omitempty"`
+	SPIFFE                   SPIFFEConfig           `json:"spiffe,omitempty"`
+	EncryptConfig            bool                   `json:"encrypt_config,omitempty"`
+	RegistryFallback         RegistryFallbackConfig `json:"registry_fallback,omitempty"`
+	HarborRegistryURL        string                 `json:"harbor_registry_url,omitempty"`
+	DirectDelivery           DirectDeliveryConfig   `json:"direct_delivery,omitempty"`
+	Audit                    AuditConfig            `json:"audit,omitempty"`
 }
 
 type StateConfig struct {

--- a/pkg/config/getters.go
+++ b/pkg/config/getters.go
@@ -123,6 +123,13 @@ func (cm *ConfigManager) GetHeartbeatInterval() string {
 	return cm.config.AppConfig.HeartbeatInterval
 }
 
+func (cm *ConfigManager) IsStartupJitterDisabled() bool {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	return cm.config.AppConfig.DisableStartupJitter
+}
+
 func (cm *ConfigManager) GetMetricsConfig() MetricsConfig {
 	cm.mu.RLock()
 	defer cm.mu.RUnlock()


### PR DESCRIPTION
Fixes #444.

## The problem

`Scheduler.run` calls `launchProcess` at T=0 with no delay:

```go
// Run once immediately
s.launchProcess(ctx)
```

Every satellite executes that line at startup. A fleet that boots together — after a power event, a rolling restart, or a coordinated rollout — issues its first registration and state fetch in the same instant, and because the interval is identical everywhere the alignment persists on every subsequent tick rather than dispersing.

## The change

A bounded random delay before the **first** run only. Subsequent runs remain ticker-driven, so steady-state behaviour is untouched.

```go
s.WithStartupJitter(s.GetInterval())
```

**It is opt-in and defaults to zero.** That is deliberate: defaulting it on changes the semantics of every existing caller, and it broke `TestStop_WaitsForInflightProcess` when I tried it — that test encodes run-immediately as expected behaviour, and it is right to. So the library default is unchanged and the fleet-facing call sites opt in.

`internal/satellite/satellite.go` enables it for the three schedulers that talk to Ground Control — registration (ZTR), state replication, and status reporting — each bounded by its own interval, which spreads first execution uniformly across one interval.

The wait honours context cancellation, so shutting down during the delay exits promptly instead of blocking for up to a full interval.

## Testing

`go test ./internal/satellite/...` passes. New cases cover: the default is zero; the first run is immediate without jitter; the first run is delayed with jitter; cancellation during the wait exits promptly and does not execute the process; and a negative bound clamps to zero rather than panicking in `rand.Int63n`.

## Notes for review

- Using each scheduler's interval as the bound means a satellite may wait up to one full interval before its first sync. For the intervals in the issue's scenario that is seconds; if any deployment uses a long registration interval, a smaller fixed cap may be preferable and I am happy to change it.
- `math/rand` rather than `crypto/rand` — this is load spreading, not a security boundary.
- I have not reproduced the 300-satellite scenario from the issue; the reasoning is from the scheduler code. Happy to adjust if the fleet behaviour differs from what I have assumed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable startup jitter to stagger initial scheduler executions and reduce simultaneous activity.
  * Added a configuration option to disable startup jitter when immediate execution is preferred.
  * Startup delays respect cancellation, handle invalid values safely, and preserve regular scheduling intervals.
  * Default behavior remains unchanged when startup jitter is not configured.

* **Tests**
  * Added coverage for default behavior, delayed execution, cancellation, interval preservation, and invalid settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->