### PR TITLE
feat: add reusable OCI digest verification utility

### DIFF
--- a/internal/oci/digest.go
+++ b/internal/oci/digest.go
@@ -1,0 +1,23 @@
+package oci
+
+import (
+	"fmt"
+
+	"github.com/opencontainers/go-digest"
+)
+
+// VerifyDigest computes the digest of the provided content and compares it
+// against the expected OCI digest string.
+func VerifyDigest(content []byte, expectedDigest string) error {
+	expected, err := digest.Parse(expectedDigest)
+	if err != nil {
+		return fmt.Errorf("parse expected digest: %w", err)
+	}
+
+	actual := expected.Algorithm().FromBytes(content)
+	if actual != expected {
+		return fmt.Errorf("digest mismatch: expected %s, got %s", expected, actual)
+	}
+
+	return nil
+}

--- a/internal/oci/digest_test.go
+++ b/internal/oci/digest_test.go
@@ -1,0 +1,42 @@
+package oci
+
+import (
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyDigestSuccess(t *testing.T) {
+	content := []byte("hello world")
+	expected := digest.FromBytes(content).String()
+
+	err := VerifyDigest(content, expected)
+	require.NoError(t, err)
+}
+
+func TestVerifyDigestMismatch(t *testing.T) {
+	content := []byte("hello world")
+	wrongExpected := digest.FromBytes([]byte("wrong content")).String()
+
+	err := VerifyDigest(content, wrongExpected)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "digest mismatch")
+}
+
+func TestVerifyDigestInvalidDigest(t *testing.T) {
+	content := []byte("hello world")
+	invalidExpected := "not-a-valid-digest"
+
+	err := VerifyDigest(content, invalidExpected)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parse expected digest")
+}
+
+func TestVerifyDigestEmptyContent(t *testing.T) {
+	content := []byte{}
+	expected := digest.FromBytes(content).String()
+
+	err := VerifyDigest(content, expected)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

- Added a reusable OCI digest verification utility.
- Added validation for OCI content integrity using OCI digest standards.
- Added unit tests covering valid and invalid verification scenarios.

## Motivation

Harbor Satellite replicates OCI artifacts between registries.

As Harbor Satellite evolves toward air-gapped and peer-to-peer artifact distribution workflows, validating artifact integrity before accepting content from external sources becomes important.

Currently, digest verification logic is coupled with replication flows and cannot be reused independently.

## Implementation

- Added a new `internal/oci` package.
- Implemented digest verification independent of Harbor, Zot, and replication logic.
- Added validation for:
  - OCI content digest matching
  - Invalid digest formats
  - Digest mismatch scenarios

The utility is intentionally kept independent so future artifact transfer workflows can reuse the same validation layer.

## Testing

- `go test ./...`

## Related Issue

Fixes #573

Related:
#542


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

