### PR TITLE
feat: integrate OCI digest verification into replication workflow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -422,7 +422,7 @@ require (
 	github.com/olekukonko/tablewriter v1.1.4 // indirect
 	github.com/open-policy-agent/opa v1.17.0 // indirect
 	github.com/opencontainers/distribution-spec/specs-go v0.0.0-20250220192232-583e014d1541 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.3.0 // indirect
 	github.com/openvex/go-vex v0.2.7 // indirect

--- a/internal/oci/digest.go
+++ b/internal/oci/digest.go
@@ -1,0 +1,23 @@
+package oci
+
+import (
+	"fmt"
+
+	"github.com/opencontainers/go-digest"
+)
+
+// VerifyDigest computes the digest of the provided content and compares it
+// against the expected OCI digest string.
+func VerifyDigest(content []byte, expectedDigest string) error {
+	expected, err := digest.Parse(expectedDigest)
+	if err != nil {
+		return fmt.Errorf("parse expected digest: %w", err)
+	}
+
+	actual := expected.Algorithm().FromBytes(content)
+	if actual != expected {
+		return fmt.Errorf("digest mismatch: expected %s, got %s", expected, actual)
+	}
+
+	return nil
+}

--- a/internal/oci/digest_test.go
+++ b/internal/oci/digest_test.go
@@ -1,0 +1,42 @@
+package oci
+
+import (
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyDigestSuccess(t *testing.T) {
+	content := []byte("hello world")
+	expected := digest.FromBytes(content).String()
+
+	err := VerifyDigest(content, expected)
+	require.NoError(t, err)
+}
+
+func TestVerifyDigestMismatch(t *testing.T) {
+	content := []byte("hello world")
+	wrongExpected := digest.FromBytes([]byte("wrong content")).String()
+
+	err := VerifyDigest(content, wrongExpected)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "digest mismatch")
+}
+
+func TestVerifyDigestInvalidDigest(t *testing.T) {
+	content := []byte("hello world")
+	invalidExpected := "not-a-valid-digest"
+
+	err := VerifyDigest(content, invalidExpected)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parse expected digest")
+}
+
+func TestVerifyDigestEmptyContent(t *testing.T) {
+	content := []byte{}
+	expected := digest.FromBytes(content).String()
+
+	err := VerifyDigest(content, expected)
+	require.NoError(t, err)
+}

--- a/internal/satellite/state/replicator.go
+++ b/internal/satellite/state/replicator.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/container-registry/harbor-satellite/internal/logger"
+	"github.com/container-registry/harbor-satellite/internal/oci"
 	satTLS "github.com/container-registry/harbor-satellite/internal/satellite/tls"
 	"github.com/container-registry/harbor-satellite/pkg/config"
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -131,6 +132,17 @@ func (r *BasicReplicator) Replicate(ctx context.Context, replicationEntities []E
 		if err != nil {
 			log.Error().Msgf("Failed to fetch image descriptor: %v", err)
 			return err
+		}
+
+		// Verify manifest integrity if an expected digest is provided.
+		// We verify the manifest here (instead of intercepting the blob stream)
+		// because verifying the manifest provides a trusted root for the artifact's
+		// layer dependency graph without modifying the underlying streaming behavior.
+		if entity.Digest != "" {
+			if err := oci.VerifyDigest(desc.Manifest, entity.Digest); err != nil {
+				log.Error().Msgf("Manifest verification failed for %s: %v", entity.GetName(), err)
+				return fmt.Errorf("verify manifest digest: %w", err)
+			}
 		}
 
 		img, err := desc.Image()

--- a/internal/satellite/state/replicator_test.go
+++ b/internal/satellite/state/replicator_test.go
@@ -58,6 +58,23 @@ func TestReplicate_NewImage(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestReplicate_VerifyDigestFailure(t *testing.T) {
+	srcAddr := newTestRegistry(t)
+	dstAddr := newTestRegistry(t)
+
+	pushImage(t, srcAddr, "alpine", "latest", 2)
+
+	r := NewBasicReplicator("", "", srcAddr, dstAddr, "", "", true)
+	ctx := testContext()
+
+	err := r.Replicate(ctx, []Entity{
+		{Name: "alpine", Repository: "library", Tag: "latest", Digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "verify manifest digest")
+	require.Contains(t, err.Error(), "digest mismatch")
+}
+
 func TestReplicate_SkipsExistingImage(t *testing.T) {
 	srcAddr := newTestRegistry(t)
 	dstAddr := newTestRegistry(t)

--- a/internal/satellite/state/replicator_test.go
+++ b/internal/satellite/state/replicator_test.go
@@ -58,6 +58,29 @@ func TestReplicate_NewImage(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestReplicate_VerifyDigestSuccess(t *testing.T) {
+	srcAddr := newTestRegistry(t)
+	dstAddr := newTestRegistry(t)
+
+	img := pushImage(t, srcAddr, "alpine", "happy", 2)
+	expectedDigest, err := img.Digest()
+	require.NoError(t, err)
+
+	r := NewBasicReplicator("", "", srcAddr, dstAddr, "", "", true)
+	ctx := testContext()
+
+	err = r.Replicate(ctx, []Entity{
+		{Name: "alpine", Repository: "library", Tag: "happy", Digest: expectedDigest.String()},
+	})
+	require.NoError(t, err)
+
+	// Verify image exists at destination
+	dstRef, err := name.ParseReference(dstAddr+"/library/alpine:happy", name.Insecure)
+	require.NoError(t, err)
+	_, err = remote.Head(dstRef)
+	require.NoError(t, err)
+}
+
 func TestReplicate_VerifyDigestFailure(t *testing.T) {
 	srcAddr := newTestRegistry(t)
 	dstAddr := newTestRegistry(t)


### PR DESCRIPTION
## Summary

- Integrated the reusable `oci.VerifyDigest` utility from #574 into the core replication workflow.
- Added OCI manifest integrity verification after fetching artifact metadata.
- Added unit tests to ensure replication stops when digest validation fails.

## Motivation

Harbor Satellite replicates OCI artifacts between registries.

As Harbor Satellite evolves toward air-gapped and peer-to-peer artifact distribution workflows, ensuring artifact integrity before accepting content from external sources becomes increasingly important.

PR #574 introduced a reusable OCI digest verification layer, but the capability was not yet connected to the actual replication workflow.

## Implementation Details

The implementation verifies the OCI manifest immediately after `remote.Get()` retrieves the artifact descriptor.

### Architectural Decision

OCI layer data is streamed internally through `remote.Write()`. Intercepting and validating the complete blob stream would require modifying the existing streaming behavior and introduce unnecessary complexity.

Instead, this implementation validates the OCI manifest as the trust anchor. The manifest contains cryptographic references (digests) for the associated layers, allowing replication to verify artifact integrity before continuing.

Changes:
- Integrated `oci.VerifyDigest(desc.Manifest, entity.Digest)` into `internal/satellite/state/replicator.go`.
- Replication now aborts when the fetched manifest does not match the expected digest.
- Added `TestReplicate_VerifyDigestFailure` to verify that invalid manifests are rejected.
- Existing replication behavior remains unchanged for valid artifacts.

## Testing

- `go test ./...`

## Related Issues

Fixes #575

Related:
- #574
- #542

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added OCI manifest digest verification during replication.
  * Replication now stops and reports an error when content does not match the requested digest.
  * Improved handling of invalid or mismatched digest values.

* **Tests**
  * Added coverage for successful verification, mismatches, invalid digests, empty content, and replication failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->