### PR TITLE
feat: add version compatibility check between satellite and ground control

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,7 @@ REGISTRY_DATA_DIR=
 
 # Local config and shutdown behavior.
 CONFIG_DIR=
+HEALTH_PORT=8082
 SHUTDOWN_TIMEOUT=30s
 
 # CRI registry fallback and Harbor registry override.
@@ -62,6 +63,10 @@ LOCKOUT_DURATION=5m
 
 # Satellite status freshness threshold.
 STALE_THRESHOLD=1h
+
+# Satellite/Ground Control compatibility. Major versions must match, and minor
+# versions may differ by this many releases.
+COMPATIBILITY_MAX_MINOR_SKEW=2
 
 # PostgreSQL.
 DB_HOST=

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,8 +12,8 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -w -s -X github.com/container-registry/harbor-satellite/internal/version.GitCommit={{.FullCommit}}
-      - -X github.com/container-registry/harbor-satellite/internal/version.Version={{.Tag}}
+      - -w -s -X github.com/container-registry/harbor-satellite/pkg/version.GitCommit={{.FullCommit}}
+      - -X github.com/container-registry/harbor-satellite/pkg/version.Version={{.Tag}}
     goos:
       - linux
       - darwin
@@ -59,8 +59,8 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -w -s -X github.com/container-registry/harbor-satellite/internal/version.GitCommit={{.FullCommit}}
-      - -X github.com/container-registry/harbor-satellite/internal/version.Version={{.Tag}}
+      - -w -s -X github.com/container-registry/harbor-satellite/pkg/version.GitCommit={{.FullCommit}}
+      - -X github.com/container-registry/harbor-satellite/pkg/version.Version={{.Tag}}
     goos:
       - linux
       - darwin
@@ -106,8 +106,8 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -w -s -X github.com/container-registry/harbor-satellite/internal/version.GitCommit={{.FullCommit}}
-      - -X github.com/container-registry/harbor-satellite/internal/version.Version={{.Tag}}
+      - -w -s -X github.com/container-registry/harbor-satellite/pkg/version.GitCommit={{.FullCommit}}
+      - -X github.com/container-registry/harbor-satellite/pkg/version.Version={{.Tag}}
     goos:
       - linux
       - darwin

--- a/cmd/satellite/main.go
+++ b/cmd/satellite/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"time"
 
@@ -18,6 +20,7 @@ import (
 	"github.com/container-registry/harbor-satellite/internal/satellite/watcher"
 	"github.com/container-registry/harbor-satellite/internal/utils"
 	"github.com/container-registry/harbor-satellite/pkg/config"
+	"github.com/container-registry/harbor-satellite/pkg/version"
 
 	"github.com/joho/godotenv"
 	"github.com/rs/zerolog"
@@ -53,6 +56,7 @@ type SatelliteOptions struct {
 	RegistryPassword       string
 	ConfigDir              string
 	RegistryDataDir        string
+	HealthPort             int
 	NoRegistryFallback     bool
 	FallbackOnly           bool
 	HarborRegistryURL      string
@@ -79,6 +83,7 @@ func main() {
 		RegistryUsername:       envCfg.RegistryUsername,
 		ConfigDir:              envCfg.ConfigDir,
 		RegistryDataDir:        envCfg.RegistryDataDir,
+		HealthPort:             envCfg.HealthPort,
 		NoRegistryFallback:     envCfg.NoRegistryFallback,
 		HarborRegistryURL:      envCfg.HarborRegistryURL,
 		DirectDelivery:         envCfg.DirectDelivery,
@@ -100,6 +105,7 @@ func main() {
 	flag.StringVar(&opts.RegistryPassword, "registry-password", "", "External registry password")
 	flag.StringVar(&opts.ConfigDir, "config-dir", opts.ConfigDir, "Configuration directory path (default: ~/.config/satellite)")
 	flag.StringVar(&opts.RegistryDataDir, "registry-data-dir", opts.RegistryDataDir, "Registry data directory (overrides default storage path derived from config-dir)")
+	flag.IntVar(&opts.HealthPort, "health-port", opts.HealthPort, "Satellite health endpoint port. Set to 0 to disable")
 	flag.StringVar(&shutdownTimeout, "shutdown-timeout", shutdownTimeout, "Graceful shutdown timeout (e.g., '30s'). Defaults to SHUTDOWN_TIMEOUT env var or 30s")
 	flag.BoolVar(&opts.NoRegistryFallback, "no-registry-fallback", opts.NoRegistryFallback, "Disable all CRI registry fallback configuration")
 	flag.BoolVar(&opts.FallbackOnly, "fallback-only", false, "Apply CRI registry fallback configs and exit without starting satellite")
@@ -378,6 +384,10 @@ func run(opts SatelliteOptions, pathConfig *config.PathConfig, shutdownTimeout s
 	// Handle registry setup
 	wg.Go(func() error { return handleRegistrySetup(ctx, log, cm, pathConfig) })
 
+	if opts.HealthPort > 0 {
+		wg.Go(func() error { return startHealthServer(ctx, opts.HealthPort, log) })
+	}
+
 	// Watch for changes in the config file
 	wg.Go(func() error {
 		return watcher.WatchChanges(ctx, log.With().Str("component", "file watcher").Logger(), pathConfig.ConfigFile, eventChan)
@@ -432,6 +442,52 @@ func run(opts SatelliteOptions, pathConfig *config.PathConfig, shutdownTimeout s
 	}
 
 	return gracefulShutdown(ctx, log, s, wg, shutdownTimeout)
+}
+
+func startHealthServer(ctx context.Context, port int, log *zerolog.Logger) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(healthResponse("healthy")); err != nil {
+			log.Warn().Err(err).Msg("Failed to write health response")
+		}
+	})
+
+	server := &http.Server{
+		Addr:              fmt.Sprintf(":%d", port),
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			log.Warn().Err(err).Msg("Failed to shut down health server")
+		}
+	}()
+
+	log.Info().Int("port", port).Msg("Starting satellite health server")
+	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return fmt.Errorf("health server: %w", err)
+	}
+
+	return nil
+}
+
+func healthResponse(status string) map[string]string {
+	info := version.BuildInfo()
+	return map[string]string{
+		"status":     status,
+		"version":    info.Version,
+		"git_commit": info.GitCommit,
+	}
 }
 
 func gracefulShutdown(ctx context.Context, log *zerolog.Logger, s *satellite.Satellite, wg *errgroup.Group, shutdownTimeout string) error {

--- a/cmd/satellite/main_test.go
+++ b/cmd/satellite/main_test.go
@@ -21,6 +21,14 @@ func newTestConfigManager(t *testing.T, cfg *config.Config) *config.ConfigManage
 	return cm
 }
 
+func TestHealthResponseIncludesVersion(t *testing.T) {
+	resp := healthResponse("healthy")
+
+	require.Equal(t, "healthy", resp["status"])
+	require.Equal(t, "0.0.0", resp["version"])
+	require.Equal(t, "unknown", resp["git_commit"])
+}
+
 func TestResolveLocalRegistryEndpoint_BYO(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -14,6 +14,7 @@ func LoadGC() error {
 	if err := envparser.Parse(&cfg); err != nil {
 		return err
 	}
+	cfg.Compatibility = cfg.Compatibility.ApplyDefaults()
 	GC = cfg
 	return nil
 }

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -3,6 +3,8 @@ package env
 import (
 	"testing"
 	"time"
+
+	"github.com/container-registry/harbor-satellite/pkg/version"
 )
 
 func TestLoadParsesGroundControlEnvironment(t *testing.T) {
@@ -16,6 +18,7 @@ func TestLoadParsesGroundControlEnvironment(t *testing.T) {
 	t.Setenv("HARBOR_PASSWORD", "robot-secret")
 	t.Setenv("PORT", "8080")
 	t.Setenv("SESSION_DURATION", "12h")
+	t.Setenv("COMPATIBILITY_MAX_MINOR_SKEW", "3")
 	t.Setenv("SPIFFE_SERVER_ENABLED", "true")
 	t.Setenv("SPIFFE_PROVIDER", "static")
 	t.Setenv("SPIRE_SERVER_PORT", "9090")
@@ -36,6 +39,9 @@ func TestLoadParsesGroundControlEnvironment(t *testing.T) {
 	}
 	if cfg.Server.Port != 8080 || cfg.Server.SessionDuration != 12*time.Hour {
 		t.Fatalf("server env was not parsed: %+v", cfg.Server)
+	}
+	if cfg.Compatibility.MaxMinorSkew != 3 {
+		t.Fatalf("compatibility env was not parsed: %+v", cfg.Compatibility)
 	}
 	if !cfg.SPIFFE.Enabled || cfg.SPIFFE.Provider != "static" {
 		t.Fatalf("spiffe env was not parsed: %+v", cfg.SPIFFE)
@@ -60,6 +66,9 @@ func TestLoadAppliesDefaults(t *testing.T) {
 	if cfg.Server.Port != 8080 {
 		t.Fatalf("server port default = %d, want 8080", cfg.Server.Port)
 	}
+	if cfg.Compatibility.MaxMinorSkew != version.DefaultMaxMinorSkew {
+		t.Fatalf("compatibility max minor skew default = %d, want %d", cfg.Compatibility.MaxMinorSkew, version.DefaultMaxMinorSkew)
+	}
 	if cfg.SPIFFE.TrustDomain != "harbor-satellite.local" {
 		t.Fatalf("SPIFFE trust domain default = %q", cfg.SPIFFE.TrustDomain)
 	}
@@ -68,6 +77,13 @@ func TestLoadAppliesDefaults(t *testing.T) {
 	}
 	if got := cfg.Harbor.RobotDurationDaysValue(); got != 30 {
 		t.Fatalf("RobotDurationDaysValue() = %d, want 30", got)
+	}
+
+	if err := LoadSatellite(); err != nil {
+		t.Fatalf("LoadSatellite() error = %v", err)
+	}
+	if Satellite.HealthPort != 8082 {
+		t.Fatalf("satellite health port default = %d, want 8082", Satellite.HealthPort)
 	}
 }
 
@@ -82,6 +98,7 @@ func TestLoadSatelliteParsesEnvironment(t *testing.T) {
 	t.Setenv("REGISTRY_PASSWORD", "secret")
 	t.Setenv("CONFIG_DIR", "/tmp/satellite-config")
 	t.Setenv("REGISTRY_DATA_DIR", "/tmp/registry")
+	t.Setenv("HEALTH_PORT", "9091")
 	t.Setenv("SHUTDOWN_TIMEOUT", "45s")
 	t.Setenv("NO_REGISTRY_FALLBACK", "true")
 	t.Setenv("HARBOR_REGISTRY_URL", "https://harbor.example")
@@ -101,5 +118,8 @@ func TestLoadSatelliteParsesEnvironment(t *testing.T) {
 	}
 	if cfg.RegistryDataDir != "/tmp/registry" || cfg.ShutdownTimeout != "45s" {
 		t.Fatalf("satellite path/timing env was not parsed: %+v", cfg)
+	}
+	if cfg.HealthPort != 9091 {
+		t.Fatalf("satellite health port env was not parsed: %+v", cfg)
 	}
 }

--- a/internal/env/ground-control.go
+++ b/internal/env/ground-control.go
@@ -3,11 +3,14 @@ package env
 import (
 	"strconv"
 	"time"
+
+	"github.com/container-registry/harbor-satellite/pkg/version"
 )
 
 type GroundControl struct {
 	Harbor         Harbor
 	Server         Server
+	Compatibility  Compatibility `envPrefix:"COMPATIBILITY_"`
 	EmbeddedSPIRE  EmbeddedSPIRE
 	Database       Database       `envPrefix:"DB_"`
 	PasswordPolicy PasswordPolicy `envPrefix:"PASSWORD_"`
@@ -47,6 +50,17 @@ type Server struct {
 	SessionDuration time.Duration `env:"SESSION_DURATION" envDefault:"24h"`
 	LockoutDuration time.Duration `env:"LOCKOUT_DURATION" envDefault:"5m"`
 	StaleThreshold  time.Duration `env:"STALE_THRESHOLD"  envDefault:"1h"`
+}
+
+type Compatibility struct {
+	MaxMinorSkew uint64 `env:"MAX_MINOR_SKEW"`
+}
+
+func (c Compatibility) ApplyDefaults() Compatibility {
+	if c.MaxMinorSkew == 0 {
+		c.MaxMinorSkew = version.DefaultMaxMinorSkew
+	}
+	return c
 }
 
 type PasswordPolicy struct {

--- a/internal/env/harbor-satellite.go
+++ b/internal/env/harbor-satellite.go
@@ -17,6 +17,7 @@ type HarborSatellite struct {
 	RegistryPassword       string `env:"REGISTRY_PASSWORD"`
 	ConfigDir              string `env:"CONFIG_DIR"`
 	RegistryDataDir        string `env:"REGISTRY_DATA_DIR"`
+	HealthPort             int    `env:"HEALTH_PORT"               envDefault:"8082"`
 	ShutdownTimeout        string `env:"SHUTDOWN_TIMEOUT"          envDefault:"30s"`
 	NoRegistryFallback     bool   `env:"NO_REGISTRY_FALLBACK"      envDefault:"false"`
 	HarborRegistryURL      string `env:"HARBOR_REGISTRY_URL"`

--- a/internal/groundcontrol/server/cached_images_test.go
+++ b/internal/groundcontrol/server/cached_images_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/container-registry/harbor-satellite/internal/groundcontrol/database"
+	"github.com/container-registry/harbor-satellite/pkg/version"
 	"github.com/gorilla/mux"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
@@ -29,8 +30,9 @@ func newMockServer(t *testing.T) (*Server, sqlmock.Sqlmock) {
 	})
 
 	return &Server{
-		db:        db,
-		dbQueries: database.New(db),
+		db:           db,
+		dbQueries:    database.New(db),
+		maxMinorSkew: 2,
 	}, mock
 }
 
@@ -85,6 +87,7 @@ func TestSyncHandler_WithCachedImages(t *testing.T) {
 
 	reqBody := SatelliteStatusRequest{
 		Name:               "edge-01",
+		Version:            "0.0.0",
 		ImageCount:         2,
 		RequestCreatedTime: now,
 		CachedImages: []CachedImageReport{
@@ -129,6 +132,7 @@ func TestSyncHandler_NoCachedImages(t *testing.T) {
 
 	reqBody := SatelliteStatusRequest{
 		Name:               "edge-01",
+		Version:            "0.0.0",
 		RequestCreatedTime: now,
 	}
 	body := mustMarshalJSON(t, reqBody)
@@ -151,6 +155,7 @@ func TestSyncHandler_UnknownSatellite(t *testing.T) {
 
 	reqBody := SatelliteStatusRequest{
 		Name:               "unknown",
+		Version:            "0.0.0",
 		RequestCreatedTime: time.Now().UTC(),
 	}
 	body := mustMarshalJSON(t, reqBody)
@@ -161,6 +166,32 @@ func TestSyncHandler_UnknownSatellite(t *testing.T) {
 	server.SyncSatellite(rr, req)
 
 	require.Equal(t, http.StatusForbidden, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSyncHandler_IncompatibleSatelliteVersion(t *testing.T) {
+	server, mock := newMockServer(t)
+
+	originalVersion := version.Version
+	version.Version = "2.4.0"
+	t.Cleanup(func() {
+		version.Version = originalVersion
+	})
+
+	reqBody := SatelliteStatusRequest{
+		Name:               "edge-01",
+		Version:            "1.4.0",
+		RequestCreatedTime: time.Now().UTC(),
+	}
+	body := mustMarshalJSON(t, reqBody)
+	req := httptest.NewRequest(http.MethodPost, "/satellites/sync", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	server.SyncSatellite(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "major versions must match")
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -277,6 +308,7 @@ func TestSyncHandler_InvalidHeartbeatInterval(t *testing.T) {
 
 	reqBody := SatelliteStatusRequest{
 		Name:                "edge-01",
+		Version:             "0.0.0",
 		StateReportInterval: "bad-format",
 		RequestCreatedTime:  now,
 	}
@@ -311,6 +343,7 @@ func TestSyncHandler_BatchInsertArtifactsFails(t *testing.T) {
 
 	reqBody := SatelliteStatusRequest{
 		Name:               "edge-01",
+		Version:            "0.0.0",
 		RequestCreatedTime: now,
 		CachedImages: []CachedImageReport{
 			{Reference: "localhost:8585/nginx:latest@sha256:abc", SizeBytes: 50000},
@@ -355,6 +388,7 @@ func TestGetCachedImagesHandler_DBFailure(t *testing.T) {
 func TestCachedImageJSON(t *testing.T) {
 	t.Run("serialization roundtrip", func(t *testing.T) {
 		original := SatelliteStatusRequest{
+			Version:    "0.0.0",
 			Name:       "edge-01",
 			ImageCount: 2,
 			CachedImages: []CachedImageReport{
@@ -381,6 +415,7 @@ func TestCachedImageJSON(t *testing.T) {
 
 	t.Run("omits cached_images when empty", func(t *testing.T) {
 		original := SatelliteStatusRequest{
+			Version:    "0.0.0",
 			Name:       "edge-01",
 			ImageCount: 0,
 		}

--- a/internal/groundcontrol/server/handlers.go
+++ b/internal/groundcontrol/server/handlers.go
@@ -3,6 +3,8 @@ package server
 import (
 	"log"
 	"net/http"
+
+	"github.com/container-registry/harbor-satellite/pkg/version"
 )
 
 const (
@@ -19,9 +21,18 @@ func (s *Server) Health(w http.ResponseWriter, _ *http.Request) {
 	err := s.db.Ping()
 	if err != nil {
 		log.Printf("error pinging db: %v", err)
-		WriteJSONResponse(w, http.StatusServiceUnavailable, HealthResponse{Status: Unhealthy})
+		WriteJSONResponse(w, http.StatusServiceUnavailable, healthResponse(string(Unhealthy)))
 		return
 	}
 
-	WriteJSONResponse(w, http.StatusOK, HealthResponse{Status: Healthy})
+	WriteJSONResponse(w, http.StatusOK, healthResponse(string(Healthy)))
+}
+
+func healthResponse(status string) HealthResponse {
+	info := version.BuildInfo()
+	return HealthResponse{
+		Status:    HealthResponseStatus(status),
+		Version:   info.Version,
+		GitCommit: info.GitCommit,
+	}
 }

--- a/internal/groundcontrol/server/satellite_handlers.go
+++ b/internal/groundcontrol/server/satellite_handlers.go
@@ -14,6 +14,7 @@ import (
 	auditlog "github.com/container-registry/harbor-satellite/internal/groundcontrol/logger"
 	"github.com/container-registry/harbor-satellite/internal/groundcontrol/spiffe"
 	"github.com/container-registry/harbor-satellite/internal/groundcontrol/utils"
+	"github.com/container-registry/harbor-satellite/pkg/version"
 )
 
 func (s *Server) RegisterSatellite(w http.ResponseWriter, r *http.Request) {
@@ -246,6 +247,10 @@ func (s *Server) RegisterSatellite(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) Ztr(w http.ResponseWriter, r *http.Request) {
+	if !s.isSatelliteVersionCompatible(w, r.Header.Get(version.HeaderName)) {
+		return
+	}
+
 	var request ZTRRequest
 	if err := DecodeRequestBody(r, &request); err != nil {
 		HandleAppError(w, err)
@@ -403,6 +408,10 @@ func (s *Server) Ztr(w http.ResponseWriter, r *http.Request) {
 // The satellite's identity is extracted from the TLS client certificate (SVID).
 // This eliminates the need for single-use tokens.
 func (s *Server) SpiffeZtr(w http.ResponseWriter, r *http.Request) {
+	if !s.isSatelliteVersionCompatible(w, r.Header.Get(version.HeaderName)) {
+		return
+	}
+
 	// Extract SPIFFE ID from the TLS connection
 	satelliteName, ok := spiffe.GetSatelliteName(r.Context())
 	if !ok {
@@ -607,6 +616,10 @@ func (s *Server) SyncSatellite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !s.isSatelliteVersionCompatible(w, req.Version) {
+		return
+	}
+
 	// Check SPIFFE identity first for dual auth
 	var satelliteName string
 	if name, ok := spiffe.GetSatelliteName(r.Context()); ok {
@@ -695,6 +708,18 @@ func (s *Server) SyncSatellite(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) isSatelliteVersionCompatible(w http.ResponseWriter, satelliteVersion string) bool {
+	if err := version.Compatible(version.Version, satelliteVersion, s.maxMinorSkew); err != nil {
+		HandleAppError(w, &AppError{
+			Message: err.Error(),
+			Code:    http.StatusBadRequest,
+		})
+		return false
+	}
+
+	return true
 }
 
 func (s *Server) GetSatelliteStatus(w http.ResponseWriter, r *http.Request, satelliteName string) {

--- a/internal/groundcontrol/server/server.gen.go
+++ b/internal/groundcontrol/server/server.gen.go
@@ -267,7 +267,11 @@ type GroupSyncRequest struct {
 
 // HealthResponse defines model for HealthResponse.
 type HealthResponse struct {
-	Status HealthResponseStatus `json:"status,omitempty,omitzero"`
+	GitCommit string               `json:"git_commit,omitempty,omitzero"`
+	Status    HealthResponseStatus `json:"status,omitempty,omitzero"`
+
+	// Version Example: 1.2.3
+	Version string `json:"version,omitempty,omitzero"`
 }
 
 // HealthResponseStatus defines model for HealthResponse.Status.
@@ -424,6 +428,9 @@ type SatelliteStatusRequest struct {
 	RequestCreatedTime  time.Time           `json:"request_created_time,omitempty,omitzero"`
 	StateReportInterval string              `json:"state_report_interval,omitempty,omitzero"`
 	StorageUsedBytes    int64               `json:"storage_used_bytes,omitempty,omitzero"`
+
+	// Version Example: 1.2.3
+	Version string `json:"version,omitempty,omitzero"`
 }
 
 // SatelliteStatusResponse defines model for SatelliteStatusResponse.

--- a/internal/groundcontrol/server/server.go
+++ b/internal/groundcontrol/server/server.go
@@ -44,6 +44,9 @@ type Server struct {
 	// Satellite status
 	staleThreshold time.Duration
 
+	// Satellite compatibility
+	maxMinorSkew uint64
+
 	// Audit logger for security events
 	audit *auditlog.AuditLogger
 
@@ -168,6 +171,9 @@ func NewServer() *ServerResult {
 
 		// Satellite status
 		staleThreshold: cfg.Server.StaleThreshold,
+
+		// Satellite compatibility
+		maxMinorSkew: cfg.Compatibility.MaxMinorSkew,
 
 		// Audit logger
 		audit:                 auditLogger,

--- a/internal/satellite/state/registration_process.go
+++ b/internal/satellite/state/registration_process.go
@@ -14,6 +14,7 @@ import (
 	"github.com/container-registry/harbor-satellite/internal/logger"
 	satTLS "github.com/container-registry/harbor-satellite/internal/satellite/tls"
 	"github.com/container-registry/harbor-satellite/pkg/config"
+	"github.com/container-registry/harbor-satellite/pkg/version"
 	"github.com/rs/zerolog"
 )
 
@@ -216,6 +217,7 @@ func registerSatellite(groundControlURL, path, token string, tlsCfg config.TLSCo
 		return config.StateConfig{}, fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(version.HeaderName, version.Current())
 	response, err := client.Do(req)
 	if err != nil {
 		return config.StateConfig{}, fmt.Errorf("failed to send request: %w", err)

--- a/internal/satellite/state/registration_process_test.go
+++ b/internal/satellite/state/registration_process_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/container-registry/harbor-satellite/pkg/config"
+	"github.com/container-registry/harbor-satellite/pkg/version"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,4 +62,19 @@ func TestSanitizeAuditReason_TokenAppearsMultipleTimes(t *testing.T) {
 	got := sanitizeAuditReason(err, token)
 	require.Equal(t, 2, strings.Count(got, "[REDACTED]"))
 	require.NotContains(t, got, token)
+}
+
+func TestRegisterSatelliteSendsVersionHeader(t *testing.T) {
+	var gotVersion string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotVersion = r.Header.Get(version.HeaderName)
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"state":"http://registry/satellite/satellite-state/edge-01/state:latest","auth":{"url":"http://harbor","username":"robot","password":"secret"}}`))
+		require.NoError(t, err)
+	}))
+	defer srv.Close()
+
+	_, err := registerSatellite(srv.URL, ZeroTouchRegistrationRoute, "token", config.TLSConfig{}, true, testContext())
+	require.NoError(t, err)
+	require.Equal(t, "0.0.0", gotVersion)
 }

--- a/internal/satellite/state/report.go
+++ b/internal/satellite/state/report.go
@@ -17,6 +17,7 @@ import (
 
 type StatusReportParams struct {
 	Name                string        `json:"name"`
+	Version             string        `json:"version"`
 	Activity            string        `json:"activity"`
 	StateReportInterval string        `json:"state_report_interval"`
 	LatestStateDigest   string        `json:"latest_state_digest"`

--- a/internal/satellite/state/reporting_process.go
+++ b/internal/satellite/state/reporting_process.go
@@ -15,6 +15,7 @@ import (
 	"github.com/container-registry/harbor-satellite/internal/spiffe"
 	"github.com/container-registry/harbor-satellite/internal/utils"
 	"github.com/container-registry/harbor-satellite/pkg/config"
+	"github.com/container-registry/harbor-satellite/pkg/version"
 )
 
 const StatusReportRoute = "satellites/sync"
@@ -87,6 +88,7 @@ func (s *StatusReportingProcess) Execute(ctx context.Context) error {
 
 	req := &StatusReportParams{
 		Name:                satelliteName,
+		Version:             version.Current(),
 		StateReportInterval: heartbeatExpr,
 		RequestCreatedTime:  time.Now().UTC(),
 	}

--- a/internal/satellite/state/reporting_process_test.go
+++ b/internal/satellite/state/reporting_process_test.go
@@ -162,6 +162,7 @@ func TestExecute_CRIReporting(t *testing.T) {
 		err := p.Execute(ctx)
 		require.NoError(t, err)
 
+		require.Equal(t, "0.0.0", received.Version)
 		require.Contains(t, received.Activity, "docker(ok")
 
 		p.mu.Lock()

--- a/internal/satellite/state/spiffe_registration.go
+++ b/internal/satellite/state/spiffe_registration.go
@@ -11,6 +11,7 @@ import (
 	"github.com/container-registry/harbor-satellite/internal/logger"
 	"github.com/container-registry/harbor-satellite/internal/spiffe"
 	"github.com/container-registry/harbor-satellite/pkg/config"
+	"github.com/container-registry/harbor-satellite/pkg/version"
 	"github.com/rs/zerolog"
 )
 
@@ -113,6 +114,7 @@ func (s *SpiffeZtrProcess) registerWithSPIFFE(ctx context.Context, log *zerolog.
 	if err != nil {
 		return config.StateConfig{}, fmt.Errorf("create request: %w", err)
 	}
+	req.Header.Set(version.HeaderName, version.Current())
 
 	log.Debug().Str("url", ztrURL).Msg("Sending SPIFFE-authenticated ZTR request")
 	resp, err := httpClient.Do(req)

--- a/pkg/groundcontrol/client.gen.go
+++ b/pkg/groundcontrol/client.gen.go
@@ -271,7 +271,11 @@ type GroupSyncRequest struct {
 
 // HealthResponse defines model for HealthResponse.
 type HealthResponse struct {
-	Status HealthResponseStatus `json:"status,omitempty,omitzero"`
+	GitCommit string               `json:"git_commit,omitempty,omitzero"`
+	Status    HealthResponseStatus `json:"status,omitempty,omitzero"`
+
+	// Version Example: 1.2.3
+	Version string `json:"version,omitempty,omitzero"`
 }
 
 // HealthResponseStatus defines model for HealthResponse.Status.
@@ -428,6 +432,9 @@ type SatelliteStatusRequest struct {
 	RequestCreatedTime  time.Time           `json:"request_created_time,omitempty,omitzero"`
 	StateReportInterval string              `json:"state_report_interval,omitempty,omitzero"`
 	StorageUsedBytes    int64               `json:"storage_used_bytes,omitempty,omitzero"`
+
+	// Version Example: 1.2.3
+	Version string `json:"version,omitempty,omitzero"`
 }
 
 // SatelliteStatusResponse defines model for SatelliteStatusResponse.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,199 @@
+package version
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	DefaultVersion             = "0.0.0"
+	DefaultMaxMinorSkew uint64 = 2
+	HeaderName                 = "X-Harbor-Satellite-Version"
+)
+
+var (
+	Version   = DefaultVersion
+	GitCommit = "unknown"
+)
+
+type Info struct {
+	Version   string `json:"version"`
+	GitCommit string `json:"git_commit,omitempty"`
+}
+
+type SemVer struct {
+	Major uint64
+	Minor uint64
+	Patch uint64
+}
+
+func BuildInfo() Info {
+	return Info{
+		Version:   Current(),
+		GitCommit: GitCommit,
+	}
+}
+
+func Current() string {
+	return Normalize(Version)
+}
+
+func Normalize(v string) string {
+	v = strings.TrimSpace(v)
+	return strings.TrimPrefix(v, "v")
+}
+
+func Parse(v string) (SemVer, error) {
+	normalized := Normalize(v)
+	if normalized == "" {
+		return SemVer{}, fmt.Errorf("version is required")
+	}
+
+	core, err := stripSuffixes(normalized)
+	if err != nil {
+		return SemVer{}, err
+	}
+
+	parts := strings.Split(core, ".")
+	if len(parts) != 3 {
+		return SemVer{}, fmt.Errorf("invalid semver version %q: expected MAJOR.MINOR.PATCH", v)
+	}
+
+	major, err := parsePart(parts[0], "major", v)
+	if err != nil {
+		return SemVer{}, err
+	}
+	minor, err := parsePart(parts[1], "minor", v)
+	if err != nil {
+		return SemVer{}, err
+	}
+	patch, err := parsePart(parts[2], "patch", v)
+	if err != nil {
+		return SemVer{}, err
+	}
+
+	return SemVer{Major: major, Minor: minor, Patch: patch}, nil
+}
+
+func Compatible(groundControlVersion, satelliteVersion string, maxMinorSkew uint64) error {
+	gc, err := Parse(groundControlVersion)
+	if err != nil {
+		return fmt.Errorf("ground control version invalid: %w", err)
+	}
+
+	sat, err := Parse(satelliteVersion)
+	if err != nil {
+		return fmt.Errorf("satellite version invalid: %w", err)
+	}
+
+	if gc.Major != sat.Major {
+		return fmt.Errorf("incompatible satellite version %s with ground control version %s: major versions must match", satelliteVersion, groundControlVersion)
+	}
+
+	if minorDistance(gc.Minor, sat.Minor) > maxMinorSkew {
+		return fmt.Errorf("incompatible satellite version %s with ground control version %s: minor versions differ by more than %d release(s)", satelliteVersion, groundControlVersion, maxMinorSkew)
+	}
+
+	return nil
+}
+
+func minorDistance(a, b uint64) uint64 {
+	if a > b {
+		return a - b
+	}
+
+	return b - a
+}
+
+// stripSuffixes validates and removes the prerelease (-) and build (+) suffixes
+// from a SemVer string, returning the bare MAJOR.MINOR.PATCH core.
+func stripSuffixes(v string) (string, error) {
+	if idx := strings.IndexByte(v, '+'); idx >= 0 {
+		if err := validSuffixIdentifiers(v[idx+1:], false); err != nil {
+			return "", fmt.Errorf("invalid build metadata: %w", err)
+		}
+		v = v[:idx]
+	}
+
+	if idx := strings.IndexByte(v, '-'); idx >= 0 {
+		if err := validSuffixIdentifiers(v[idx+1:], true); err != nil {
+			return "", fmt.Errorf("invalid prerelease: %w", err)
+		}
+		v = v[:idx]
+	}
+
+	return v, nil
+}
+
+// validSuffixIdentifiers checks that a dot-separated prerelease or build suffix
+// is non-empty and each identifier consists of ASCII alphanumerics and hyphens.
+// Numeric prerelease identifiers must not contain leading zeroes.
+func validSuffixIdentifiers(s string, checkLeadingZeros bool) error {
+	if s == "" {
+		return fmt.Errorf("suffix must not be empty")
+	}
+
+	for _, part := range strings.Split(s, ".") {
+		if part == "" {
+			return fmt.Errorf("identifier must not be empty")
+		}
+		if !validIdentifier(part) {
+			return fmt.Errorf("identifier %q must consist of ASCII alphanumerics and hyphens", part)
+		}
+		if checkLeadingZeros && isNumeric(part) && len(part) > 1 && part[0] == '0' {
+			return fmt.Errorf("numeric identifier %q must not contain leading zeroes", part)
+		}
+	}
+
+	return nil
+}
+
+func validIdentifier(s string) bool {
+	hasAlphaNumeric := false
+	for _, r := range s {
+		if !isIdentifierRune(r) {
+			return false
+		}
+		if r != '-' {
+			hasAlphaNumeric = true
+		}
+	}
+
+	return hasAlphaNumeric
+}
+
+func isIdentifierRune(r rune) bool {
+	return r >= '0' && r <= '9' || r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r == '-'
+}
+
+func isNumeric(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+
+	return true
+}
+
+func parsePart(part, name, original string) (uint64, error) {
+	if part == "" {
+		return 0, fmt.Errorf("invalid semver version %q: empty %s version", original, name)
+	}
+	if len(part) > 1 && strings.HasPrefix(part, "0") {
+		return 0, fmt.Errorf("invalid semver version %q: %s version must not contain leading zeroes", original, name)
+	}
+	for _, r := range part {
+		if r < '0' || r > '9' {
+			return 0, fmt.Errorf("invalid semver version %q: %s version must be numeric", original, name)
+		}
+	}
+
+	value, err := strconv.ParseUint(part, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid semver version %q: parse %s version: %w", original, name, err)
+	}
+
+	return value, nil
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,113 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompatible(t *testing.T) {
+	tests := []struct {
+		name             string
+		groundControl    string
+		satellite        string
+		maxMinorSkew     uint64
+		wantErrSubstring string
+	}{
+		{
+			name:          "same version",
+			groundControl: "1.2.3",
+			satellite:     "1.2.4",
+			maxMinorSkew:  2,
+		},
+		{
+			name:          "tag with v prefix",
+			groundControl: "v1.4.0",
+			satellite:     "1.2.0",
+			maxMinorSkew:  2,
+		},
+		{
+			name:             "major mismatch",
+			groundControl:    "2.1.0",
+			satellite:        "1.1.0",
+			maxMinorSkew:     2,
+			wantErrSubstring: "major versions must match",
+		},
+		{
+			name:             "minor skew too large",
+			groundControl:    "1.5.0",
+			satellite:        "1.2.0",
+			maxMinorSkew:     2,
+			wantErrSubstring: "minor versions differ by more than 2 release(s)",
+		},
+		{
+			name:             "missing satellite version",
+			groundControl:    "1.0.0",
+			satellite:        "",
+			maxMinorSkew:     2,
+			wantErrSubstring: "version is required",
+		},
+		{
+			name:             "invalid satellite version",
+			groundControl:    "1.0.0",
+			satellite:        "1.0",
+			maxMinorSkew:     2,
+			wantErrSubstring: "expected MAJOR.MINOR.PATCH",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Compatible(tt.groundControl, tt.satellite, tt.maxMinorSkew)
+			if tt.wantErrSubstring == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErrSubstring)
+		})
+	}
+}
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		version string
+		wantErr bool
+	}{
+		{version: "1.2.3", wantErr: false},
+		{version: "v1.2.3", wantErr: false},
+		{version: "1.2.3-alpha.1", wantErr: false},
+		{version: "1.2.3-rc.1", wantErr: false},
+		{version: "1.2.3+build.5", wantErr: false},
+		{version: "1.2.3-alpha.1+build.5", wantErr: false},
+		{version: "1.2.3-alpha-1", wantErr: false},
+		{version: "1.2.3-4.5.6", wantErr: false},
+		{version: "", wantErr: true},
+		{version: "1.2", wantErr: true},
+		{version: "1.2.3.4", wantErr: true},
+		{version: "01.2.3", wantErr: true},
+		{version: "1.2.3-", wantErr: true},
+		{version: "1.2.3+", wantErr: true},
+		{version: "1.2.3--", wantErr: true},
+		{version: "1.2.3-alpha..1", wantErr: true},
+		{version: "1.2.3-alpha.", wantErr: true},
+		{version: "1.2.3-alpha_1", wantErr: true},
+		{version: "1.2.3+bad build", wantErr: true},
+		{version: "1.2.3+//", wantErr: true},
+		{version: "1.2.3-01", wantErr: true},
+		{version: "1.2.3-0", wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			_, err := Parse(tt.version)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -6,57 +6,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCompatible(t *testing.T) {
-	tests := []struct {
-		name             string
-		groundControl    string
-		satellite        string
-		maxMinorSkew     uint64
-		wantErrSubstring string
-	}{
-		{
-			name:          "same version",
-			groundControl: "1.2.3",
-			satellite:     "1.2.4",
-			maxMinorSkew:  2,
-		},
-		{
-			name:          "tag with v prefix",
-			groundControl: "v1.4.0",
-			satellite:     "1.2.0",
-			maxMinorSkew:  2,
-		},
-		{
-			name:             "major mismatch",
-			groundControl:    "2.1.0",
-			satellite:        "1.1.0",
-			maxMinorSkew:     2,
-			wantErrSubstring: "major versions must match",
-		},
-		{
-			name:             "minor skew too large",
-			groundControl:    "1.5.0",
-			satellite:        "1.2.0",
-			maxMinorSkew:     2,
-			wantErrSubstring: "minor versions differ by more than 2 release(s)",
-		},
-		{
-			name:             "missing satellite version",
-			groundControl:    "1.0.0",
-			satellite:        "",
-			maxMinorSkew:     2,
-			wantErrSubstring: "version is required",
-		},
-		{
-			name:             "invalid satellite version",
-			groundControl:    "1.0.0",
-			satellite:        "1.0",
-			maxMinorSkew:     2,
-			wantErrSubstring: "expected MAJOR.MINOR.PATCH",
-		},
-	}
+type compatibleCase struct {
+	name             string
+	groundControl    string
+	satellite        string
+	maxMinorSkew     uint64
+	wantErrSubstring string
+}
 
-	for _, tt := range tests {
+var compatibleCases = []compatibleCase{
+	{
+		name:          "same version",
+		groundControl: "1.2.3",
+		satellite:     "1.2.4",
+		maxMinorSkew:  2,
+	},
+	{
+		name:          "tag with v prefix",
+		groundControl: "v1.4.0",
+		satellite:     "1.2.0",
+		maxMinorSkew:  2,
+	},
+	{
+		name:             "major mismatch",
+		groundControl:    "2.1.0",
+		satellite:        "1.1.0",
+		maxMinorSkew:     2,
+		wantErrSubstring: "major versions must match",
+	},
+	{
+		name:             "minor skew too large",
+		groundControl:    "1.5.0",
+		satellite:        "1.2.0",
+		maxMinorSkew:     2,
+		wantErrSubstring: "minor versions differ by more than 2 release(s)",
+	},
+	{
+		name:             "missing satellite version",
+		groundControl:    "1.0.0",
+		satellite:        "",
+		maxMinorSkew:     2,
+		wantErrSubstring: "version is required",
+	},
+	{
+		name:             "invalid satellite version",
+		groundControl:    "1.0.0",
+		satellite:        "1.0",
+		maxMinorSkew:     2,
+		wantErrSubstring: "expected MAJOR.MINOR.PATCH",
+	},
+}
+
+func TestCompatible(t *testing.T) {
+	for _, tt := range compatibleCases {
 		t.Run(tt.name, func(t *testing.T) {
 			err := Compatible(tt.groundControl, tt.satellite, tt.maxMinorSkew)
 			if tt.wantErrSubstring == "" {

--- a/spec/ground-control/openapi.yaml
+++ b/spec/ground-control/openapi.yaml
@@ -1690,14 +1690,21 @@ components:
           format: date-time
     HealthResponse:
       type: object
-      title: HealthResponse contains the database health state.
+      title: HealthResponse contains the service health and build version.
       properties:
+        git_commit:
+          type: string
+          x-go-name: GitCommit
         status:
           type: string
           enum:
             - healthy
             - unhealthy
           x-go-name: Status
+        version:
+          type: string
+          example: 1.2.3
+          x-go-name: Version
     MessageResponse:
       type: object
       title: MessageResponse contains a human-readable operation result.
@@ -2345,6 +2352,10 @@ components:
           format: int64
           minimum: 0
           x-go-name: StorageUsedBytes
+        version:
+          type: string
+          example: 1.2.3
+          x-go-name: Version
     GroupSyncRequest:
       type: object
       title: GroupSyncRequest contains a group state artifact synchronized from


### PR DESCRIPTION
- Fixes: #245 

## Description

Satellite and Ground Control may be deployed at different versions, causing hard-to-debug failures. This PR introduces version compatibility checks between the two components.

- **`pkg/version`**: New shared package with semver parsing, compatibility validation (major must match, minor within configurable skew, default 2), and build-time version injection via goreleaser ldflags
- **Satellite**: Sends its version in the `X-Harbor-Satellite-Version` header on ZTR/SPIFFE registration and in the sync/heartbeat body; new health server (`--health-port` / `HEALTH_PORT`) exposes version and git commit
- **Ground Control**: Validates satellite version on ZTR, SPIFFE ZTR, and sync endpoints, rejecting incompatible versions with a clear 400 error; compatibility matrix configurable via `COMPATIBILITY_MAX_MINOR_SKEW`; `/health` now reports version and git commit
- **OpenAPI spec** updated for the new `version` fields, with generated code refreshed


## Additional context

Satellites must send their version on registration (`X-Harbor-Satellite-Version` header) or sync; otherwise Ground Control rejects them with a 400 "satellite version invalid" error. `GetSatelliteStatus` is intentionally not version-gated so the Ground Control UI is unaffected.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

