### PR TITLE
fix(satellite): pull images by digest instead of tag

### DIFF
--- a/internal/satellite/state/direct_delivery.go
+++ b/internal/satellite/state/direct_delivery.go
@@ -80,8 +80,9 @@ func (d *DirectDeliverer) Deliver(ctx context.Context, entities []Entity) error 
 
 		filename := tarballFilename(entity)
 
-		// Skip if digest matches what we already wrote.
-		if prev, ok := currentDigests[filename]; ok && prev == entity.Digest {
+		// Skip without any network call when the desired state pins a digest
+		// and it matches what we already wrote.
+		if prev, ok := currentDigests[filename]; ok && entity.Digest != "" && prev == entity.Digest {
 			log.Debug().Str("file", filename).Msg("Direct delivery: tarball up-to-date, skipping")
 			continue
 		}
@@ -99,6 +100,16 @@ func (d *DirectDeliverer) Deliver(ctx context.Context, entities []Entity) error 
 		pullRef, err := pinnedSourceRef(d.srcRegistry, entity, nameOpts, opts)
 		if err != nil {
 			log.Warn().Err(err).Str("ref", tagRef.String()).Msg("Direct delivery: failed to pin source digest, skipping")
+			continue
+		}
+
+		// Entities whose desired state carries no digest only learn their digest
+		// once pinnedSourceRef resolves the tag, which is too late for the check
+		// above. Compare here so unchanged content is not re-fetched and the
+		// tarball not rewritten on every sync cycle.
+		if prev, ok := currentDigests[filename]; ok && prev == pullRef.DigestStr() {
+			log.Debug().Str("file", filename).Str("digest", pullRef.DigestStr()).
+				Msg("Direct delivery: tarball up-to-date, skipping")
 			continue
 		}
 
@@ -127,8 +138,9 @@ func (d *DirectDeliverer) Deliver(ctx context.Context, entities []Entity) error 
 			continue
 		}
 
-		// Record the digest actually delivered, so the skip check above stays
-		// correct when the desired state carried no digest.
+		// Record the digest actually delivered. This is what the resolved-digest
+		// check above compares against on the next cycle, which is how tag-only
+		// entities get a working skip check.
 		updates[filename] = pullRef.DigestStr()
 		log.Info().Str("file", filename).Str("ref", tagRef.String()).Str("digest", pullRef.DigestStr()).Msg("Direct delivery: tarball written")
 	}

--- a/internal/satellite/state/direct_delivery.go
+++ b/internal/satellite/state/direct_delivery.go
@@ -86,28 +86,51 @@ func (d *DirectDeliverer) Deliver(ctx context.Context, entities []Entity) error 
 			continue
 		}
 
-		srcRef := fmt.Sprintf("%s/%s/%s:%s", d.srcRegistry, entity.Repository, entity.Name, entity.Tag)
-		ref, err := name.ParseReference(srcRef, nameOpts...)
+		opts := []remote.Option{remote.WithAuth(auth), remote.WithContext(ctx)}
+
+		// The tag reference only names the image inside the tarball; the pull
+		// itself is pinned to a digest so a moved tag cannot substitute content.
+		tagRef, err := sourceTagRef(d.srcRegistry, entity, nameOpts)
 		if err != nil {
-			log.Warn().Err(err).Str("ref", srcRef).Msg("Direct delivery: failed to parse reference, skipping")
+			log.Warn().Err(err).Msg("Direct delivery: failed to parse reference, skipping")
 			continue
 		}
 
-		opts := []remote.Option{remote.WithAuth(auth), remote.WithContext(ctx)}
-		img, err := remote.Image(ref, opts...)
+		pullRef, err := pinnedSourceRef(d.srcRegistry, entity, nameOpts, opts)
 		if err != nil {
-			log.Warn().Err(err).Str("ref", srcRef).Msg("Direct delivery: failed to pull image, skipping")
+			log.Warn().Err(err).Str("ref", tagRef.String()).Msg("Direct delivery: failed to pin source digest, skipping")
+			continue
+		}
+
+		// remote.Get returns the manifest served at pullRef itself. Checking its
+		// digest before resolving covers multi-arch indexes too, whose per-
+		// platform image digest legitimately differs from the index digest.
+		desc, err := remote.Get(pullRef, opts...)
+		if err != nil {
+			log.Warn().Err(err).Str("ref", pullRef.String()).Msg("Direct delivery: failed to fetch image descriptor, skipping")
+			continue
+		}
+		if err := verifyFetchedDigest(pullRef, desc.Digest.String()); err != nil {
+			log.Error().Err(err).Msg("Direct delivery: refusing to write image with unexpected content")
+			continue
+		}
+
+		img, err := desc.Image()
+		if err != nil {
+			log.Warn().Err(err).Str("ref", pullRef.String()).Msg("Direct delivery: failed to resolve image, skipping")
 			continue
 		}
 
 		dstPath := filepath.Join(d.imageDir, filename)
-		if err := d.writeAtomically(dstPath, ref, img); err != nil {
+		if err := d.writeAtomically(dstPath, tagRef, img); err != nil {
 			log.Warn().Err(err).Str("file", filename).Msg("Direct delivery: failed to write tarball, skipping")
 			continue
 		}
 
-		updates[filename] = entity.Digest
-		log.Info().Str("file", filename).Str("ref", srcRef).Msg("Direct delivery: tarball written")
+		// Record the digest actually delivered, so the skip check above stays
+		// correct when the desired state carried no digest.
+		updates[filename] = pullRef.DigestStr()
+		log.Info().Str("file", filename).Str("ref", tagRef.String()).Str("digest", pullRef.DigestStr()).Msg("Direct delivery: tarball written")
 	}
 
 	if len(updates) == 0 {

--- a/internal/satellite/state/replicator.go
+++ b/internal/satellite/state/replicator.go
@@ -113,14 +113,15 @@ func (r *BasicReplicator) Replicate(ctx context.Context, replicationEntities []E
 		default:
 		}
 
-		srcRef := fmt.Sprintf("%s/%s/%s:%s", r.sourceRegistry, entity.GetRepository(), entity.GetName(), entity.GetTag())
-		dstRef := fmt.Sprintf("%s/%s/%s:%s", r.remoteRegistryURL, entity.GetRepository(), entity.GetName(), entity.GetTag())
-
-		src, err := name.ParseReference(srcRef, nameOpts...)
+		// Pull by digest, never by tag: the tag only names the copy written to
+		// the local registry.
+		src, err := pinnedSourceRef(r.sourceRegistry, entity, nameOpts, pullOpts)
 		if err != nil {
-			return fmt.Errorf("parse source ref %s: %w", srcRef, err)
+			log.Error().Err(err).Msgf("Failed to pin source reference for %s", entity.GetName())
+			return err
 		}
 
+		dstRef := fmt.Sprintf("%s/%s/%s:%s", r.remoteRegistryURL, entity.GetRepository(), entity.GetName(), entity.GetTag())
 		dst, err := name.ParseReference(dstRef, nameOpts...)
 		if err != nil {
 			return fmt.Errorf("parse dest ref %s: %w", dstRef, err)
@@ -130,6 +131,11 @@ func (r *BasicReplicator) Replicate(ctx context.Context, replicationEntities []E
 		desc, err := remote.Get(src, pullOpts...)
 		if err != nil {
 			log.Error().Msgf("Failed to fetch image descriptor: %v", err)
+			return err
+		}
+
+		if err := verifyFetchedDigest(src, desc.Digest.String()); err != nil {
+			log.Error().Err(err).Msg("Refusing to replicate image with unexpected content")
 			return err
 		}
 
@@ -170,7 +176,7 @@ func (r *BasicReplicator) Replicate(ctx context.Context, replicationEntities []E
 			log.Error().Msgf("Failed to replicate image: %v", err)
 			return err
 		}
-		log.Info().Msgf("Image %s replicated successfully", entity.GetName())
+		log.Info().Str("digest", src.DigestStr()).Msgf("Image %s replicated successfully", entity.GetName())
 	}
 
 	return nil

--- a/internal/satellite/state/replicator.go
+++ b/internal/satellite/state/replicator.go
@@ -176,7 +176,12 @@ func (r *BasicReplicator) Replicate(ctx context.Context, replicationEntities []E
 			log.Error().Msgf("Failed to replicate image: %v", err)
 			return err
 		}
-		log.Info().Str("digest", src.DigestStr()).Msgf("Image %s replicated successfully", entity.GetName())
+		// The two digests differ by design: the destination holds the image after
+		// OCI media type conversion. Name them so neither is mistaken for the other.
+		log.Info().
+			Str("source_digest", src.DigestStr()).
+			Str("destination_digest", srcDigest.String()).
+			Msgf("Image %s replicated successfully", entity.GetName())
 	}
 
 	return nil

--- a/internal/satellite/state/source_ref.go
+++ b/internal/satellite/state/source_ref.go
@@ -1,0 +1,81 @@
+package state
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+// sourceRepository builds the fully qualified repository path for an entity in
+// the source registry, without any tag or digest suffix.
+func sourceRepository(srcRegistry string, entity Entity) string {
+	return fmt.Sprintf("%s/%s/%s", srcRegistry, entity.GetRepository(), entity.GetName())
+}
+
+// sourceTagRef builds the tag reference for an entity in the source registry.
+// It names the image but does not identify its content: tags are mutable and
+// must never be used to pull. Use pinnedSourceRef for that.
+func sourceTagRef(srcRegistry string, entity Entity, nameOpts []name.Option) (name.Reference, error) {
+	ref := fmt.Sprintf("%s:%s", sourceRepository(srcRegistry, entity), entity.GetTag())
+	parsed, err := name.ParseReference(ref, nameOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("parse source ref %s: %w", ref, err)
+	}
+	return parsed, nil
+}
+
+// pinnedSourceRef returns a digest-pinned reference to the entity's image in the
+// source registry.
+//
+// A tag can be repointed at different content at any moment, including between
+// the instant Ground Control computes the desired state and the instant the
+// satellite pulls. Pulling by digest makes the registry protocol itself
+// guarantee content identity: go-containerregistry verifies the manifest it
+// receives hashes to the requested digest and rejects it otherwise.
+//
+// When the desired state carries a digest, that digest is used. When it does
+// not, the tag is resolved to a digest exactly once here, and every subsequent
+// operation runs against the resolved digest, so a tag moved mid-flight cannot
+// substitute different content.
+func pinnedSourceRef(srcRegistry string, entity Entity, nameOpts []name.Option, pullOpts []remote.Option) (name.Digest, error) {
+	repo := sourceRepository(srcRegistry, entity)
+
+	if digest := strings.TrimSpace(entity.Digest); digest != "" {
+		ref, err := name.NewDigest(fmt.Sprintf("%s@%s", repo, digest), nameOpts...)
+		if err != nil {
+			return name.Digest{}, fmt.Errorf("parse digest ref %s@%s: %w", repo, digest, err)
+		}
+		return ref, nil
+	}
+
+	tagRef, err := sourceTagRef(srcRegistry, entity, nameOpts)
+	if err != nil {
+		return name.Digest{}, err
+	}
+
+	desc, err := remote.Head(tagRef, pullOpts...)
+	if err != nil {
+		return name.Digest{}, fmt.Errorf("resolve tag %s to digest: %w", tagRef, err)
+	}
+
+	ref, err := name.NewDigest(fmt.Sprintf("%s@%s", repo, desc.Digest.String()), nameOpts...)
+	if err != nil {
+		return name.Digest{}, fmt.Errorf("parse resolved digest ref %s@%s: %w", repo, desc.Digest, err)
+	}
+	return ref, nil
+}
+
+// verifyFetchedDigest fails loudly when the manifest served for a digest-pinned
+// reference does not hash to the digest that was requested. go-containerregistry
+// already enforces this, so a mismatch here means the guarantee was bypassed;
+// checking is cheap and the alternative is silently publishing substituted
+// content to the local registry.
+func verifyFetchedDigest(want name.Digest, got string) error {
+	if want.DigestStr() != got {
+		return fmt.Errorf("digest mismatch for %s: manifest hashes to %s, desired state requires %s",
+			want.Context().Name(), got, want.DigestStr())
+	}
+	return nil
+}

--- a/internal/satellite/state/source_ref_test.go
+++ b/internal/satellite/state/source_ref_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -178,6 +179,41 @@ func TestDeliver_PullsPinnedDigestAfterTagMoved(t *testing.T) {
 	require.NotEqual(t, substitutedConfig, writtenConfig, "moved tag must not be delivered")
 
 	require.Equal(t, digestOf(t, desired), d.loadDigestMap()[tarballFilename(entity)])
+}
+
+// TestDeliver_SkipsUnchangedTagOnlyEntity covers entities whose desired state
+// carries no digest. Their digest is only known once the tag is resolved, so
+// without a check against the resolved digest the tarball is rewritten on every
+// sync cycle even when the content has not changed.
+func TestDeliver_SkipsUnchangedTagOnlyEntity(t *testing.T) {
+	srcAddr := newTestRegistry(t)
+	dir := t.TempDir()
+
+	pushImage(t, srcAddr, "alpine", "latest", 2)
+
+	d := NewDirectDeliverer(dir, "", "", srcAddr, true)
+
+	// No Digest: the tag has to be resolved to learn the content identity.
+	entity := Entity{Name: "alpine", Repository: "library", Tag: "latest"}
+	path := filepath.Join(dir, tarballFilename(entity))
+
+	require.NoError(t, d.Deliver(testContext(), []Entity{entity}))
+	require.FileExists(t, path, "tarball must be written on the first delivery")
+
+	// Backdate the tarball so a rewrite is unambiguous: writeAtomically renames a
+	// fresh temp file into place, so any re-delivery resets the mtime to now.
+	// Comparing against a backdated stamp avoids depending on filesystem
+	// timestamp granularity.
+	backdated := time.Now().Add(-time.Hour).Truncate(time.Second)
+	require.NoError(t, os.Chtimes(path, backdated, backdated))
+
+	// Second cycle, content unchanged: the tarball must not be rewritten.
+	require.NoError(t, d.Deliver(testContext(), []Entity{entity}))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.True(t, info.ModTime().Equal(backdated),
+		"unchanged tag-only entity must not be re-delivered (mtime %s, want %s)", info.ModTime(), backdated)
 }
 
 func TestDeliver_SkipsWhenPinnedDigestAbsent(t *testing.T) {

--- a/internal/satellite/state/source_ref_test.go
+++ b/internal/satellite/state/source_ref_test.go
@@ -1,0 +1,200 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/stretchr/testify/require"
+)
+
+// ociDigest returns the digest the replicator will push to the destination for
+// img, i.e. after the lazy OCI media type conversion.
+func ociDigest(t *testing.T, img v1.Image) v1.Hash {
+	t.Helper()
+	d, err := mutate.MediaType(img, types.OCIManifestSchema1).Digest()
+	require.NoError(t, err)
+	return d
+}
+
+func digestOf(t *testing.T, img v1.Image) string {
+	t.Helper()
+	d, err := img.Digest()
+	require.NoError(t, err)
+	return d.String()
+}
+
+// TestReplicate_PullsPinnedDigestAfterTagMoved is the core regression test:
+// the tag is repointed at different content after Ground Control recorded the
+// digest, and the satellite must still replicate the recorded content.
+func TestReplicate_PullsPinnedDigestAfterTagMoved(t *testing.T) {
+	srcAddr := newTestRegistry(t)
+	dstAddr := newTestRegistry(t)
+
+	desired := pushImage(t, srcAddr, "alpine", "latest", 2)
+
+	// Attacker moves the tag to different content before the satellite pulls.
+	substituted := pushImage(t, srcAddr, "alpine", "latest", 3)
+	require.NotEqual(t, digestOf(t, desired), digestOf(t, substituted))
+
+	r := NewBasicReplicator("", "", srcAddr, dstAddr, "", "", true)
+
+	err := r.Replicate(testContext(), []Entity{
+		{Name: "alpine", Repository: "library", Tag: "latest", Digest: digestOf(t, desired)},
+	})
+	require.NoError(t, err)
+
+	dstRef, err := name.ParseReference(dstAddr+"/library/alpine:latest", name.Insecure)
+	require.NoError(t, err)
+	dstDesc, err := remote.Head(dstRef)
+	require.NoError(t, err)
+
+	require.Equal(t, ociDigest(t, desired), dstDesc.Digest, "destination must hold the digest from the desired state")
+	require.NotEqual(t, ociDigest(t, substituted), dstDesc.Digest, "moved tag must not be replicated")
+}
+
+// TestReplicate_FailsWhenPinnedDigestAbsent ensures we never silently fall back
+// to the tag when the recorded digest is no longer served.
+func TestReplicate_FailsWhenPinnedDigestAbsent(t *testing.T) {
+	srcAddr := newTestRegistry(t)
+	dstAddr := newTestRegistry(t)
+
+	pushImage(t, srcAddr, "alpine", "latest", 2)
+
+	absent, err := random.Image(1024, 1)
+	require.NoError(t, err)
+
+	r := NewBasicReplicator("", "", srcAddr, dstAddr, "", "", true)
+
+	err = r.Replicate(testContext(), []Entity{
+		{Name: "alpine", Repository: "library", Tag: "latest", Digest: digestOf(t, absent)},
+	})
+	require.Error(t, err)
+
+	dstRef, err := name.ParseReference(dstAddr+"/library/alpine:latest", name.Insecure)
+	require.NoError(t, err)
+	_, err = remote.Head(dstRef)
+	require.Error(t, err, "nothing must be published when the pinned digest is unavailable")
+}
+
+func TestReplicate_MalformedDigestIsRejected(t *testing.T) {
+	srcAddr := newTestRegistry(t)
+	dstAddr := newTestRegistry(t)
+
+	pushImage(t, srcAddr, "alpine", "latest", 1)
+
+	r := NewBasicReplicator("", "", srcAddr, dstAddr, "", "", true)
+
+	err := r.Replicate(testContext(), []Entity{
+		{Name: "alpine", Repository: "library", Tag: "latest", Digest: "not-a-digest"},
+	})
+	require.Error(t, err)
+}
+
+// TestPinnedSourceRef_ResolvesTagOnce covers the no-digest path: the tag is
+// resolved to a digest once, and a later tag move cannot change what that
+// reference fetches.
+func TestPinnedSourceRef_ResolvesTagOnce(t *testing.T) {
+	srcAddr := newTestRegistry(t)
+
+	original := pushImage(t, srcAddr, "nginx", "1.25", 2)
+
+	entity := Entity{Name: "nginx", Repository: "library", Tag: "1.25"}
+	nameOpts := []name.Option{name.Insecure}
+
+	resolved, err := pinnedSourceRef(srcAddr, entity, nameOpts, nil)
+	require.NoError(t, err)
+	require.Equal(t, digestOf(t, original), resolved.DigestStr())
+
+	// Tag moves after resolution.
+	moved := pushImage(t, srcAddr, "nginx", "1.25", 3)
+	require.NotEqual(t, digestOf(t, original), digestOf(t, moved))
+
+	desc, err := remote.Get(resolved)
+	require.NoError(t, err)
+	require.Equal(t, digestOf(t, original), desc.Digest.String())
+}
+
+func TestPinnedSourceRef_UsesDesiredStateDigest(t *testing.T) {
+	entity := Entity{
+		Name:       "alpine",
+		Repository: "library",
+		Tag:        "latest",
+		Digest:     "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+	}
+
+	ref, err := pinnedSourceRef("registry.example.com", entity, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, "registry.example.com/library/alpine@"+entity.Digest, ref.String())
+}
+
+func TestVerifyFetchedDigest(t *testing.T) {
+	const want = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	const other = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+
+	ref, err := name.NewDigest("registry.example.com/library/alpine@" + want)
+	require.NoError(t, err)
+
+	require.NoError(t, verifyFetchedDigest(ref, want))
+
+	err = verifyFetchedDigest(ref, other)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "digest mismatch")
+}
+
+// TestDeliver_PullsPinnedDigestAfterTagMoved is the direct-delivery equivalent
+// of the replicator regression test.
+func TestDeliver_PullsPinnedDigestAfterTagMoved(t *testing.T) {
+	srcAddr := newTestRegistry(t)
+	dir := t.TempDir()
+
+	desired := pushImage(t, srcAddr, "alpine", "latest", 2)
+	substituted := pushImage(t, srcAddr, "alpine", "latest", 3)
+
+	d := NewDirectDeliverer(dir, "", "", srcAddr, true)
+
+	entity := Entity{Name: "alpine", Repository: "library", Tag: "latest", Digest: digestOf(t, desired)}
+	require.NoError(t, d.Deliver(testContext(), []Entity{entity}))
+
+	path := filepath.Join(dir, tarballFilename(entity))
+	written, err := tarball.ImageFromPath(path, nil)
+	require.NoError(t, err)
+
+	desiredConfig, err := desired.ConfigName()
+	require.NoError(t, err)
+	substitutedConfig, err := substituted.ConfigName()
+	require.NoError(t, err)
+	writtenConfig, err := written.ConfigName()
+	require.NoError(t, err)
+
+	require.Equal(t, desiredConfig, writtenConfig, "tarball must hold the digest from the desired state")
+	require.NotEqual(t, substitutedConfig, writtenConfig, "moved tag must not be delivered")
+
+	require.Equal(t, digestOf(t, desired), d.loadDigestMap()[tarballFilename(entity)])
+}
+
+func TestDeliver_SkipsWhenPinnedDigestAbsent(t *testing.T) {
+	srcAddr := newTestRegistry(t)
+	dir := t.TempDir()
+
+	pushImage(t, srcAddr, "alpine", "latest", 2)
+
+	absent, err := random.Image(1024, 1)
+	require.NoError(t, err)
+
+	d := NewDirectDeliverer(dir, "", "", srcAddr, true)
+
+	entity := Entity{Name: "alpine", Repository: "library", Tag: "latest", Digest: digestOf(t, absent)}
+	require.NoError(t, d.Deliver(testContext(), []Entity{entity}))
+
+	_, err = os.Stat(filepath.Join(dir, tarballFilename(entity)))
+	require.True(t, os.IsNotExist(err), "no tarball must be written when the pinned digest is unavailable")
+	require.Empty(t, d.loadDigestMap())
+}


### PR DESCRIPTION
## Summary

Satellite pulls were built from a mutable tag instead of the digest Ground Control supplies, creating a TOCTOU window in which a substituted image can be replicated to an edge site and reported healthy. This pins source references to a digest so the registry protocol itself guarantees content identity.

## Problem

Ground Control supplies a `digest` for every artifact in the desired state, and the satellite stores it and uses it for change detection. But the pull itself was built from the tag:

```go
srcRef := fmt.Sprintf("%s/%s/%s:%s", r.sourceRegistry, entity.GetRepository(), entity.GetName(), entity.GetTag())
```

`entity.Digest` was never read on the fetch path, and the manifest that came back was never compared against it.

Tags are mutable. Between Ground Control computing the desired state and the edge satellite pulling — a window at least as wide as `state_replication_interval` (default 10s), wider on retry — anyone able to push to the upstream Harbor repository can move the tag. The satellite fetches the substituted content, writes it to the local registry, logs `Image %s replicated successfully`, and reports healthy. Every workload at that edge site then pulls the substituted image. No error, no mismatch, nothing in the audit log.

It also defeats digest-change detection: if the tag moved but Ground Control's recorded digest did not change, `GetChanges` takes the `default` branch and logs `Entity unchanged, skipping` — the image is never re-fetched.

Same pattern exists in direct delivery (`internal/satellite/state/direct_delivery.go`).

## Fix

Source references are now pinned to a digest, so the registry protocol itself guarantees content identity — go-containerregistry verifies the manifest hashes to the requested digest and rejects it otherwise.

**New `internal/satellite/state/source_ref.go`:**

- `pinnedSourceRef` — when the desired state carries a digest, build `registry/repo/name@sha256:...`. When it does not, resolve the tag to a digest exactly once, then run every subsequent operation against that resolved digest, so a tag moved mid-flight cannot substitute content.
- `sourceTagRef` — tags are kept only for naming: the copy written to the local registry, and the `RepoTags` entry inside direct-delivery tarballs.
- `verifyFetchedDigest` — explicit mismatch check that fails loudly. ggcr already enforces this for digest refs; a failure here means the guarantee was bypassed, and the alternative is silently publishing substituted content.

**`replicator.go`** — pulls the pinned ref and verifies `remote.Get`'s descriptor before pushing. Destination ref unchanged (still tag-based). Success log now carries the digest, so replication is auditable after the fact.

**`direct_delivery.go`** — same pin and verify. Switched `remote.Image` → `remote.Get` + `desc.Image()`: verifying at the descriptor is correct for multi-arch indexes, whose per-platform image digest legitimately differs from the index digest, so verifying the resolved image would false-positive. The digest map now records the digest actually delivered rather than the one from the desired state, which keeps the skip check correct when Ground Control sent no digest.

## Tests

8 new tests, all standing up in-memory OCI registries:

- Tag moved after the digest was recorded → the recorded content is replicated and the substituted content is not. Asserted for both the replicator and direct delivery.
- Pinned digest no longer served → hard error, nothing published to the destination. This is the assertion that there is no tag fallback.
- Malformed digest → rejected.
- No-digest path → the tag is resolved once and a later tag move does not change what the resolved reference fetches.

Verified the regression tests fail against the pre-fix code (5 FAIL) and pass after. Full `go test ./...` green; `golangci-lint run internal/satellite/state/...` reports 0 issues.

## Behavior change worth calling out

A non-empty but malformed digest is now a hard error rather than a fall back to the tag. An empty digest still takes the resolve-once path. If Ground Control ever emits a bad digest, replication of that entity stops instead of degrading silently — which is the intent, but it is a change in failure mode.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Replication and direct delivery now use immutable image digests, ensuring the intended content is delivered even if tags move.
  * Image descriptors are verified before content is fetched or delivered.
  * Invalid, unavailable, mismatched, and unsupported image content is safely rejected or skipped.
  * Multi-architecture image descriptors are handled correctly.
  * Recorded delivery results now reflect the digest actually delivered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->