### PR TITLE
fix(config): enforce strict @every schedule format in validator

### DIFF
--- a/internal/satellite/scheduler/scheduler.go
+++ b/internal/satellite/scheduler/scheduler.go
@@ -172,5 +172,12 @@ func parseEveryExpr(expr string) (time.Duration, error) {
 		return 0, fmt.Errorf("unsupported format: must start with %q", prefix)
 	}
 
-	return time.ParseDuration(strings.TrimPrefix(expr, prefix))
+	d, err := time.ParseDuration(strings.TrimPrefix(expr, prefix))
+	if err != nil {
+		return 0, err
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("invalid interval: must be positive, got %s", d)
+	}
+	return d, nil
 }

--- a/internal/satellite/state/report.go
+++ b/internal/satellite/state/report.go
@@ -130,5 +130,12 @@ func parseEveryExpr(expr string) (time.Duration, error) {
 		return 0, fmt.Errorf("unsupported format: must start with %q", prefix)
 	}
 
-	return time.ParseDuration(strings.TrimPrefix(expr, prefix))
+	d, err := time.ParseDuration(strings.TrimPrefix(expr, prefix))
+	if err != nil {
+		return 0, err
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("invalid interval: must be positive, got %s", d)
+	}
+	return d, nil
 }

--- a/internal/satellite/state/report_test.go
+++ b/internal/satellite/state/report_test.go
@@ -100,6 +100,16 @@ func TestParseEveryExpr(t *testing.T) {
 			expr:    "30s",
 			wantErr: true,
 		},
+		{
+			name:    "zero duration",
+			expr:    "@every 0s",
+			wantErr: true,
+		},
+		{
+			name:    "negative duration",
+			expr:    "@every -1m",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -7,9 +7,9 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/container-registry/harbor-satellite/internal/satellite/registry"
-	"github.com/robfig/cron/v3"
 	"github.com/rs/zerolog"
 )
 
@@ -203,12 +203,16 @@ func enforceAuditRotation(f *SyslogAuditFile) []string {
 	return warnings
 }
 
-// isValidCronExpression checks the validity of a cron expression.
-func isValidCronExpression(cronExpression string) bool {
-	if _, err := cron.ParseStandard(cronExpression); err != nil {
+// isValidCronExpression checks if the schedule expression is a valid `@every <duration>` format.
+func isValidCronExpression(expr string) bool {
+	const prefix = "@every "
+	if !strings.HasPrefix(expr, prefix) {
 		return false
 	}
-
+	d, err := time.ParseDuration(strings.TrimPrefix(expr, prefix))
+	if err != nil || d <= 0 {
+		return false
+	}
 	return true
 }
 

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -28,8 +28,8 @@ func TestValidateAndEnforceDefaults(t *testing.T) {
 				AppConfig: AppConfig{
 					GroundControlURL:          URL("https://example.com"),
 					LogLevel:                  "info",
-					StateReplicationInterval:  "0 * * * *",
-					RegisterSatelliteInterval: "*/5 * * * *",
+					StateReplicationInterval:  "@every 1h",
+					RegisterSatelliteInterval: "@every 5m",
 				},
 				ZotConfigRaw: []byte(`{"distSpecVersion":"1.1.0"}`),
 			},
@@ -105,8 +105,8 @@ func TestValidateAndEnforceDefaults(t *testing.T) {
 			config: &Config{
 				AppConfig: AppConfig{
 					GroundControlURL:          URL("https://example.com"),
-					StateReplicationInterval:  "bad cron",
-					RegisterSatelliteInterval: "also bad",
+					StateReplicationInterval:  "0 * * * *",
+					RegisterSatelliteInterval: "@every 0s",
 				},
 				ZotConfigRaw: []byte(DefaultZotConfigJSON),
 			},

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -35,6 +35,14 @@ func TestValidateAndEnforceDefaults(t *testing.T) {
 			},
 			expectError:    false,
 			expectWarnings: true,
+			expectedConfig: &Config{
+				AppConfig: AppConfig{
+					GroundControlURL:          URL("https://example.com"),
+					LogLevel:                  "info",
+					StateReplicationInterval:  "@every 1h",
+					RegisterSatelliteInterval: "@every 5m",
+				},
+			},
 		},
 		{
 			name:           "nil config",


### PR DESCRIPTION
This PR fixes #472 by aligning the config validator to expect the `@every <duration>` schedule format that is used and expected by the scheduler. 

It removes the `robfig/cron` dependency from the validator and replaces it with standard `time.ParseDuration` checks.

Closes #472


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Validation**
  * Cron schedules now support positive `@every <duration>` intervals.
  * Invalid formats and non-positive durations are rejected.
  * Existing defaulting behavior remains unchanged for invalid satellite intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->