### PR TITLE
Fix path traversal in containerd registry mirror config (arbitrary file write as root)

### DIFF
--- a/internal/satellite/container_runtime/containerd.go
+++ b/internal/satellite/container_runtime/containerd.go
@@ -30,9 +30,44 @@ func setContainerdConfig(upstreamRegistries []string, localMirror string) (strin
 	return backupPath, nil
 }
 
+// registryCertsDir returns the certs.d directory for a registry, refusing any
+// name that does not land strictly inside baseDir.
+//
+// Registry names arrive from the configuration Ground Control delivers, and this
+// function feeds os.MkdirAll and os.Create in a code path documented as running
+// as root. A name such as "../../../../etc/cron.d" would otherwise create
+// directories and write a hosts.toml anywhere on the host. Config validation
+// rejects these names first (see validateRegistryName in pkg/config); this is
+// the second line of defence for callers that bypass it, such as the --mirrors
+// flag.
+func registryCertsDir(baseDir, registryURL string) (string, error) {
+	if strings.TrimSpace(registryURL) == "" || registryURL != strings.TrimSpace(registryURL) {
+		return "", fmt.Errorf("invalid registry name %q: must be a bare host[:port]", registryURL)
+	}
+	if strings.ContainsAny(registryURL, `/\`) {
+		return "", fmt.Errorf("invalid registry name %q: must not contain a path separator", registryURL)
+	}
+
+	cleanBase := filepath.Clean(baseDir)
+	dir := filepath.Join(cleanBase, registryURL)
+
+	// filepath.Join cleans its result, so ".." segments are already resolved
+	// here. Requiring a strict prefix also rejects "." and "..", which resolve
+	// to cleanBase itself and to its parent.
+	if dir == cleanBase || !strings.HasPrefix(dir, cleanBase+string(os.PathSeparator)) {
+		return "", fmt.Errorf("invalid registry name %q: resolves outside %s", registryURL, cleanBase)
+	}
+
+	return dir, nil
+}
+
 // writeContainerdHostToml creates or updates hosts.toml for a registry
 func writeContainerdHostToml(registryURL, localMirror string) error {
-	dir := filepath.Join(containerdCertsDir, registryURL)
+	dir, err := registryCertsDir(containerdCertsDir, registryURL)
+	if err != nil {
+		return err
+	}
+
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return fmt.Errorf("failed to create directory %s: %w", dir, err)
 	}

--- a/internal/satellite/container_runtime/containerd.go
+++ b/internal/satellite/container_runtime/containerd.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/container-registry/harbor-satellite/pkg/config"
 )
 
 const (
@@ -37,15 +38,12 @@ func setContainerdConfig(upstreamRegistries []string, localMirror string) (strin
 // function feeds os.MkdirAll and os.Create in a code path documented as running
 // as root. A name such as "../../../../etc/cron.d" would otherwise create
 // directories and write a hosts.toml anywhere on the host. Config validation
-// rejects these names first (see validateRegistryName in pkg/config); this is
-// the second line of defence for callers that bypass it, such as the --mirrors
-// flag.
+// (config.ValidateRegistryName) rejects these names first, but the --mirrors
+// flag reaches this function without going through that validation, so the
+// same hostname[:port] rule is enforced again here before the path is built.
 func registryCertsDir(baseDir, registryURL string) (string, error) {
-	if strings.TrimSpace(registryURL) == "" || registryURL != strings.TrimSpace(registryURL) {
-		return "", fmt.Errorf("invalid registry name %q: must be a bare host[:port]", registryURL)
-	}
-	if strings.ContainsAny(registryURL, `/\`) {
-		return "", fmt.Errorf("invalid registry name %q: must not contain a path separator", registryURL)
+	if err := config.ValidateRegistryName(registryURL); err != nil {
+		return "", fmt.Errorf("invalid registry name: %w", err)
 	}
 
 	cleanBase := filepath.Clean(baseDir)

--- a/internal/satellite/container_runtime/containerd_test.go
+++ b/internal/satellite/container_runtime/containerd_test.go
@@ -1,0 +1,105 @@
+package runtime
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRegistryCertsDir_Accepts covers registry names that must keep working.
+func TestRegistryCertsDir_Accepts(t *testing.T) {
+	base := "/etc/containerd/certs.d"
+
+	tests := []struct {
+		name     string
+		registry string
+		want     string
+	}{
+		{"plain host", "docker.io", "/etc/containerd/certs.d/docker.io"},
+		{"subdomain", "registry-1.docker.io", "/etc/containerd/certs.d/registry-1.docker.io"},
+		{"host with port", "localhost:5000", "/etc/containerd/certs.d/localhost:5000"},
+		{"ipv4 with port", "192.168.1.10:5000", "/etc/containerd/certs.d/192.168.1.10:5000"},
+		{"ipv6 literal", "[::1]:5000", "/etc/containerd/certs.d/[::1]:5000"},
+		{"unclean base is normalised", "docker.io", "/etc/containerd/certs.d/docker.io"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := registryCertsDir(base, tt.registry)
+			if err != nil {
+				t.Fatalf("registryCertsDir(%q, %q) returned error: %v", base, tt.registry, err)
+			}
+			if got != tt.want {
+				t.Errorf("registryCertsDir(%q, %q) = %q, want %q", base, tt.registry, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRegistryCertsDir_RejectsTraversal is the regression test for the path
+// traversal: a registry name supplied through Ground Control's config must never
+// resolve to a directory outside certs.d, because the caller runs os.MkdirAll
+// and os.Create on the result as root.
+func TestRegistryCertsDir_RejectsTraversal(t *testing.T) {
+	base := "/etc/containerd/certs.d"
+
+	tests := []struct {
+		name     string
+		registry string
+	}{
+		{"parent traversal to cron.d", "../../../../etc/cron.d"},
+		{"single parent segment", ".."},
+		{"current directory", "."},
+		{"absolute path", "/etc/cron.d"},
+		{"embedded traversal", "docker.io/../../../etc"},
+		{"trailing slash", "docker.io/"},
+		{"nested path", "docker.io/nested"},
+		{"backslash separator", `docker.io\..\..\etc`},
+		{"https scheme", "https://docker.io"},
+		{"http scheme", "http://docker.io"},
+		{"empty", ""},
+		{"whitespace only", "   "},
+		{"leading whitespace", " docker.io"},
+		{"trailing whitespace", "docker.io "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := registryCertsDir(base, tt.registry)
+			if err == nil {
+				t.Fatalf("registryCertsDir(%q, %q) = %q, want error", base, tt.registry, got)
+			}
+			if got != "" {
+				t.Errorf("registryCertsDir returned %q alongside an error, want empty string", got)
+			}
+		})
+	}
+}
+
+// TestRegistryCertsDir_StaysInsideBase asserts the containment property directly
+// rather than relying on the rejection list above being exhaustive.
+func TestRegistryCertsDir_StaysInsideBase(t *testing.T) {
+	base := t.TempDir()
+	prefix := filepath.Clean(base) + string(filepath.Separator)
+
+	registries := []string{
+		"docker.io",
+		"../escape",
+		"../../escape",
+		"a/../../escape",
+		"..",
+		".",
+		"/absolute",
+		"docker.io/../..",
+	}
+
+	for _, registry := range registries {
+		dir, err := registryCertsDir(base, registry)
+		if err != nil {
+			continue // rejected outright, which satisfies the property
+		}
+		if !strings.HasPrefix(dir, prefix) {
+			t.Errorf("registryCertsDir(%q, %q) = %q, which escapes %q", base, registry, dir, base)
+		}
+	}
+}

--- a/internal/satellite/container_runtime/containerd_test.go
+++ b/internal/satellite/container_runtime/containerd_test.go
@@ -70,6 +70,7 @@ func TestRegistryCertsDir_RejectsTraversal(t *testing.T) {
 		// that validation.
 		{"double colon", "foo::bar"},
 		{"unterminated ipv6", "[::1"},
+		{"bracketed ipv4", "[127.0.0.1]:5000"},
 		{"non numeric port", "localhost:abc"},
 		{"port with leading plus", "docker.io:+443"},
 	}

--- a/internal/satellite/container_runtime/containerd_test.go
+++ b/internal/satellite/container_runtime/containerd_test.go
@@ -8,29 +8,30 @@ import (
 
 // TestRegistryCertsDir_Accepts covers registry names that must keep working.
 func TestRegistryCertsDir_Accepts(t *testing.T) {
-	base := "/etc/containerd/certs.d"
+	defaultBase := "/etc/containerd/certs.d"
 
 	tests := []struct {
 		name     string
+		base     string
 		registry string
 		want     string
 	}{
-		{"plain host", "docker.io", "/etc/containerd/certs.d/docker.io"},
-		{"subdomain", "registry-1.docker.io", "/etc/containerd/certs.d/registry-1.docker.io"},
-		{"host with port", "localhost:5000", "/etc/containerd/certs.d/localhost:5000"},
-		{"ipv4 with port", "192.168.1.10:5000", "/etc/containerd/certs.d/192.168.1.10:5000"},
-		{"ipv6 literal", "[::1]:5000", "/etc/containerd/certs.d/[::1]:5000"},
-		{"unclean base is normalised", "docker.io", "/etc/containerd/certs.d/docker.io"},
+		{"plain host", defaultBase, "docker.io", "/etc/containerd/certs.d/docker.io"},
+		{"subdomain", defaultBase, "registry-1.docker.io", "/etc/containerd/certs.d/registry-1.docker.io"},
+		{"host with port", defaultBase, "localhost:5000", "/etc/containerd/certs.d/localhost:5000"},
+		{"ipv4 with port", defaultBase, "192.168.1.10:5000", "/etc/containerd/certs.d/192.168.1.10:5000"},
+		{"ipv6 literal", defaultBase, "[::1]:5000", "/etc/containerd/certs.d/[::1]:5000"},
+		{"unclean base is normalised", "/etc/containerd/certs.d/../certs.d", "docker.io", "/etc/containerd/certs.d/docker.io"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := registryCertsDir(base, tt.registry)
+			got, err := registryCertsDir(tt.base, tt.registry)
 			if err != nil {
-				t.Fatalf("registryCertsDir(%q, %q) returned error: %v", base, tt.registry, err)
+				t.Fatalf("registryCertsDir(%q, %q) returned error: %v", tt.base, tt.registry, err)
 			}
 			if got != tt.want {
-				t.Errorf("registryCertsDir(%q, %q) = %q, want %q", base, tt.registry, got, tt.want)
+				t.Errorf("registryCertsDir(%q, %q) = %q, want %q", tt.base, tt.registry, got, tt.want)
 			}
 		})
 	}
@@ -61,6 +62,16 @@ func TestRegistryCertsDir_RejectsTraversal(t *testing.T) {
 		{"whitespace only", "   "},
 		{"leading whitespace", " docker.io"},
 		{"trailing whitespace", "docker.io "},
+
+		// These contain no path separator or ".." segment, so they resolve to a
+		// directory inside base and previously passed here even though
+		// config.ValidateRegistryName already rejected them. Now enforced by
+		// this function too, since --mirrors reaches it without going through
+		// that validation.
+		{"double colon", "foo::bar"},
+		{"unterminated ipv6", "[::1"},
+		{"non numeric port", "localhost:abc"},
+		{"port with leading plus", "docker.io:+443"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/container-registry/harbor-satellite/internal/satellite/registry"
@@ -70,7 +72,11 @@ func ValidateAndEnforceDefaults(config *Config, defaultGroundControlURL string) 
 		return nil, warnings, tlsErr
 	}
 
-	warnings = append(warnings, validateRegistryFallbackConfig(config)...)
+	fbWarnings, fbErr := validateRegistryFallbackConfig(config)
+	warnings = append(warnings, fbWarnings...)
+	if fbErr != nil {
+		return nil, warnings, fbErr
+	}
 
 	warnings = append(warnings, validateAndEnforceAuditConfig(config)...)
 
@@ -315,7 +321,11 @@ func validateAndEnforceZotConfig(config *Config, bringOwnRegistry bool) ([]strin
 }
 
 // validateRegistryFallbackConfig validates registry fallback settings when enabled.
-func validateRegistryFallbackConfig(config *Config) []string {
+// An invalid registry name is a hard error: the name is used as a path element
+// under /etc/containerd/certs.d by a code path that runs as root, so accepting a
+// malformed one and carrying on would let remotely supplied configuration steer
+// privileged filesystem writes.
+func validateRegistryFallbackConfig(config *Config) ([]string, error) {
 	validRuntimes := map[string]bool{
 		"docker":     true,
 		"containerd": true,
@@ -326,7 +336,7 @@ func validateRegistryFallbackConfig(config *Config) []string {
 	var warnings []string
 	fb := config.AppConfig.RegistryFallback
 	if !fb.Enabled {
-		return warnings
+		return warnings, nil
 	}
 
 	if len(fb.Registries) == 0 {
@@ -335,8 +345,8 @@ func validateRegistryFallbackConfig(config *Config) []string {
 	}
 
 	for _, r := range config.AppConfig.RegistryFallback.Registries {
-		if strings.TrimSpace(r) == "" {
-			warnings = append(warnings, "registry_fallback contains an empty registry entry")
+		if err := validateRegistryName(r); err != nil {
+			return warnings, fmt.Errorf("invalid registry_fallback entry: %w", err)
 		}
 	}
 
@@ -348,7 +358,108 @@ func validateRegistryFallbackConfig(config *Config) []string {
 		}
 	}
 
-	return warnings
+	return warnings, nil
+}
+
+// validateRegistryName reports an error unless name is a bare registry host with
+// an optional port, such as "docker.io", "localhost:5000" or "[::1]:5000".
+//
+// The name is used verbatim as a directory name under /etc/containerd/certs.d
+// (see writeContainerdHostToml), so anything containing a path separator or a
+// ".." segment would escape that directory and redirect root-owned MkdirAll and
+// file writes elsewhere on the host. A registry host is the only meaningful
+// value here and no valid host contains a separator, so rejecting them costs
+// nothing and closes the traversal.
+//
+// A scheme prefix such as "https://" is rejected rather than stripped: it never
+// produced a usable certs.d directory, so failing loudly beats silently writing
+// a config containerd will not read.
+func validateRegistryName(name string) error {
+	if strings.TrimSpace(name) == "" {
+		return errors.New("registry entry is empty")
+	}
+	if name != strings.TrimSpace(name) {
+		return fmt.Errorf("registry entry %q has leading or trailing whitespace", name)
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("registry entry %q must be a bare host[:port] with no scheme or path separator", name)
+	}
+
+	host, port, hasPort := splitRegistryPort(name)
+	if hasPort {
+		if err := validateRegistryPort(name, port); err != nil {
+			return err
+		}
+	}
+
+	return validateRegistryHost(name, host)
+}
+
+// splitRegistryPort separates an optional ":port" suffix, accounting for
+// bracketed IPv6 literals whose address part contains colons of its own.
+func splitRegistryPort(name string) (host, port string, hasPort bool) {
+	if strings.HasPrefix(name, "[") {
+		end := strings.LastIndex(name, "]")
+		if end < 0 {
+			return name, "", false
+		}
+		if rest := name[end+1:]; strings.HasPrefix(rest, ":") {
+			return name[:end+1], rest[1:], true
+		}
+		return name, "", false
+	}
+
+	i := strings.LastIndex(name, ":")
+	if i < 0 {
+		return name, "", false
+	}
+	return name[:i], name[i+1:], true
+}
+
+func validateRegistryPort(name, port string) error {
+	n, err := strconv.Atoi(port)
+	if err != nil || n < 1 || n > 65535 {
+		return fmt.Errorf("registry entry %q has an invalid port %q", name, port)
+	}
+	return nil
+}
+
+func validateRegistryHost(name, host string) error {
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		if ip := net.ParseIP(host[1 : len(host)-1]); ip == nil {
+			return fmt.Errorf("registry entry %q is not a valid IPv6 literal", name)
+		}
+		return nil
+	}
+
+	if len(host) > 253 {
+		return fmt.Errorf("registry entry %q exceeds the maximum host length of 253 characters", name)
+	}
+
+	// Splitting on "." also rejects "." and "..", which produce empty labels.
+	for _, label := range strings.Split(host, ".") {
+		if err := validateHostLabel(name, label); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateHostLabel(name, label string) error {
+	if label == "" || len(label) > 63 {
+		return fmt.Errorf("registry entry %q has an invalid host label %q", name, label)
+	}
+	if strings.HasPrefix(label, "-") || strings.HasSuffix(label, "-") {
+		return fmt.Errorf("registry entry %q has a host label %q with a leading or trailing hyphen", name, label)
+	}
+	for _, c := range label {
+		isAlphanumeric := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+		if !isAlphanumeric && c != '-' {
+			return fmt.Errorf("registry entry %q has a host label %q with an invalid character %q", name, label, c)
+		}
+	}
+	return nil
 }
 
 // validateTLSConfig validates TLS configuration.

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -345,7 +345,7 @@ func validateRegistryFallbackConfig(config *Config) ([]string, error) {
 	}
 
 	for _, r := range config.AppConfig.RegistryFallback.Registries {
-		if err := validateRegistryName(r); err != nil {
+		if err := ValidateRegistryName(r); err != nil {
 			return warnings, fmt.Errorf("invalid registry_fallback entry: %w", err)
 		}
 	}
@@ -361,7 +361,7 @@ func validateRegistryFallbackConfig(config *Config) ([]string, error) {
 	return warnings, nil
 }
 
-// validateRegistryName reports an error unless name is a bare registry host with
+// ValidateRegistryName reports an error unless name is a bare registry host with
 // an optional port, such as "docker.io", "localhost:5000" or "[::1]:5000".
 //
 // The name is used verbatim as a directory name under /etc/containerd/certs.d
@@ -374,7 +374,7 @@ func validateRegistryFallbackConfig(config *Config) ([]string, error) {
 // A scheme prefix such as "https://" is rejected rather than stripped: it never
 // produced a usable certs.d directory, so failing loudly beats silently writing
 // a config containerd will not read.
-func validateRegistryName(name string) error {
+func ValidateRegistryName(name string) error {
 	if strings.TrimSpace(name) == "" {
 		return errors.New("registry entry is empty")
 	}
@@ -417,6 +417,17 @@ func splitRegistryPort(name string) (host, port string, hasPort bool) {
 }
 
 func validateRegistryPort(name, port string) error {
+	// strconv.Atoi accepts a leading '+' or '-' (e.g. "+443"), which is not a
+	// valid port. Require every character to be a digit before parsing.
+	if port == "" {
+		return fmt.Errorf("registry entry %q has an invalid port %q", name, port)
+	}
+	for _, c := range port {
+		if c < '0' || c > '9' {
+			return fmt.Errorf("registry entry %q has an invalid port %q", name, port)
+		}
+	}
+
 	n, err := strconv.Atoi(port)
 	if err != nil || n < 1 || n > 65535 {
 		return fmt.Errorf("registry entry %q has an invalid port %q", name, port)

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -437,7 +437,11 @@ func validateRegistryPort(name, port string) error {
 
 func validateRegistryHost(name, host string) error {
 	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
-		if ip := net.ParseIP(host[1 : len(host)-1]); ip == nil {
+		// Brackets are IPv6-only syntax. Accepting "[127.0.0.1]" would produce
+		// an invalid "https://[127.0.0.1]:5000" server URL downstream, so an
+		// address that parses as IPv4 is rejected here.
+		ip := net.ParseIP(host[1 : len(host)-1])
+		if ip == nil || ip.To4() != nil {
 			return fmt.Errorf("registry entry %q is not a valid IPv6 literal", name)
 		}
 		return nil

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -443,21 +444,26 @@ func TestValidateRegistryFallbackConfig(t *testing.T) {
 		}
 	})
 
-	t.Run("enabled with empty registry entry warns", func(t *testing.T) {
+	t.Run("enabled with empty registry entry is a hard error", func(t *testing.T) {
 		cfg := baseConfig()
 		cfg.AppConfig.RegistryFallback = RegistryFallbackConfig{
 			Enabled:    true,
 			Registries: []string{"docker.io", "  "},
 		}
-		_, warnings, err := ValidateAndEnforceDefaults(cfg, DefaultGroundControlURL)
-		require.NoError(t, err)
-		found := false
-		for _, w := range warnings {
-			if w == "registry_fallback contains an empty registry entry" {
-				found = true
-			}
+		_, _, err := ValidateAndEnforceDefaults(cfg, DefaultGroundControlURL)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid registry_fallback entry")
+	})
+
+	t.Run("enabled with traversing registry entry is a hard error", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.AppConfig.RegistryFallback = RegistryFallbackConfig{
+			Enabled:    true,
+			Registries: []string{"../../../../etc/cron.d"},
 		}
-		require.True(t, found, "expected empty registry warning")
+		_, _, err := ValidateAndEnforceDefaults(cfg, DefaultGroundControlURL)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid registry_fallback entry")
 	})
 
 	t.Run("enabled with unknown runtime warns", func(t *testing.T) {
@@ -762,6 +768,74 @@ func TestAuditConfig_Equal(t *testing.T) {
 		explicit.Syslog.Enabled = boolPtr(true)
 		require.True(t, fileCfg().Equal(explicit))
 	})
+}
+
+func TestValidateRegistryName(t *testing.T) {
+	accepted := []struct {
+		name  string
+		entry string
+	}{
+		{"plain host", "docker.io"},
+		{"subdomain", "registry-1.docker.io"},
+		{"single label", "localhost"},
+		{"host with port", "localhost:5000"},
+		{"fqdn with port", "harbor.example.com:443"},
+		{"ipv4 literal", "192.168.1.10"},
+		{"ipv4 literal with port", "192.168.1.10:5000"},
+		{"ipv6 literal", "[::1]"},
+		{"ipv6 literal with port", "[2001:db8::1]:5000"},
+		{"hyphen inside label", "my-registry.internal"},
+		{"digits only label", "123.45.67.89:5000"},
+	}
+
+	for _, tt := range accepted {
+		t.Run("accepts "+tt.name, func(t *testing.T) {
+			require.NoError(t, validateRegistryName(tt.entry))
+		})
+	}
+
+	rejected := []struct {
+		name  string
+		entry string
+	}{
+		// The traversal this validation exists to stop. Each of these would
+		// otherwise become a directory path under /etc/containerd/certs.d.
+		{"parent traversal", "../../../../etc/cron.d"},
+		{"single parent segment", ".."},
+		{"current directory", "."},
+		{"absolute path", "/etc/cron.d"},
+		{"embedded traversal", "docker.io/../../etc"},
+		{"trailing slash", "docker.io/"},
+		{"backslash separator", `docker.io\..\..\etc`},
+
+		{"empty", ""},
+		{"whitespace only", "   "},
+		{"leading whitespace", " docker.io"},
+		{"trailing whitespace", "docker.io "},
+		{"https scheme", "https://docker.io"},
+		{"http scheme", "http://docker.io"},
+		{"empty label", "docker..io"},
+		{"trailing dot", "docker.io."},
+		{"leading dot", ".docker.io"},
+		{"leading hyphen", "-docker.io"},
+		{"trailing hyphen", "docker-.io"},
+		{"underscore", "docker_registry.io"},
+		{"port out of range", "docker.io:70000"},
+		{"zero port", "docker.io:0"},
+		{"non numeric port", "docker.io:port"},
+		{"empty port", "docker.io:"},
+		{"null byte", "docker.io\x00"},
+		{"newline", "docker.io\nevil"},
+		{"unterminated ipv6", "[::1"},
+		{"malformed ipv6", "[not-an-ip]"},
+		{"label too long", strings.Repeat("a", 64) + ".io"},
+	}
+
+	for _, tt := range rejected {
+		t.Run("rejects "+tt.name, func(t *testing.T) {
+			require.Error(t, validateRegistryName(tt.entry), "entry %q must be rejected", tt.entry)
+		})
+	}
 }
 
 func intPtr(i int) *int    { return &i }

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -790,7 +790,7 @@ func TestValidateRegistryName(t *testing.T) {
 
 	for _, tt := range accepted {
 		t.Run("accepts "+tt.name, func(t *testing.T) {
-			require.NoError(t, validateRegistryName(tt.entry))
+			require.NoError(t, ValidateRegistryName(tt.entry))
 		})
 	}
 
@@ -824,6 +824,8 @@ func TestValidateRegistryName(t *testing.T) {
 		{"zero port", "docker.io:0"},
 		{"non numeric port", "docker.io:port"},
 		{"empty port", "docker.io:"},
+		{"port with leading plus", "docker.io:+443"},
+		{"port with leading minus", "docker.io:-443"},
 		{"null byte", "docker.io\x00"},
 		{"newline", "docker.io\nevil"},
 		{"unterminated ipv6", "[::1"},
@@ -833,7 +835,7 @@ func TestValidateRegistryName(t *testing.T) {
 
 	for _, tt := range rejected {
 		t.Run("rejects "+tt.name, func(t *testing.T) {
-			require.Error(t, validateRegistryName(tt.entry), "entry %q must be rejected", tt.entry)
+			require.Error(t, ValidateRegistryName(tt.entry), "entry %q must be rejected", tt.entry)
 		})
 	}
 }

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -830,6 +830,10 @@ func TestValidateRegistryName(t *testing.T) {
 		{"newline", "docker.io\nevil"},
 		{"unterminated ipv6", "[::1"},
 		{"malformed ipv6", "[not-an-ip]"},
+		// Brackets are IPv6-only syntax; a bracketed IPv4 address would become
+		// an invalid "https://[127.0.0.1]:5000" server URL downstream.
+		{"bracketed ipv4", "[127.0.0.1]"},
+		{"bracketed ipv4 with port", "[127.0.0.1]:5000"},
 		{"label too long", strings.Repeat("a", 64) + ".io"},
 	}
 


### PR DESCRIPTION
## Summary

Fixes a path traversal vulnerability where a malicious or compromised Ground Control could supply a registry name (e.g. `../../../../etc/cron.d`) that gets used directly as a directory name under `/etc/containerd/certs.d`. Since the value was never validated as a real hostname, it could climb out of the intended directory and cause the Satellite to create arbitrary directories and overwrite arbitrary `hosts.toml` files anywhere on the filesystem, as root.

## Root Cause

`writeContainerdHostToml` (`internal/satellite/container_runtime/containerd.go:35-44`) joined the attacker-influenced registry URL directly into a filesystem path via `filepath.Join(containerdCertsDir, registryURL)` and then called `os.MkdirAll` / `os.Create` on the result.

The only existing validation, `validateRegistryFallbackConfig` (`pkg/config/validate.go:337-341`), just checked for empty/whitespace strings — it never confirmed the value was actually a hostname.

## Fix

- `validateRegistryFallbackConfig` now validates each registry entry against a strict `hostname[:port]` pattern and rejects anything else — including any value containing `/` or `..` — as a **hard error** instead of a warning.
- Added a defence-in-depth check in `writeContainerdHostToml`: after joining the path, it resolves the result and confirms it's still contained within `/etc/containerd/certs.d`, refusing to write otherwise.
- Added table-driven tests covering valid hostnames, hostnames with ports, and rejected traversal/malformed inputs.

## Impact if Unpatched

A compromised Ground Control, a tampered Satellite config, or an intercepted enrollment exchange (`--use-unsecure`) could be leveraged into arbitrary privileged file writes on any edge device in the fleet — a foothold for privilege escalation and persistence, and a much larger blast radius than the registry-mirroring feature was ever meant to have.

## Files Changed

- `pkg/config/validate.go` — strict hostname validation, hard error on failure
- `internal/satellite/container_runtime/containerd.go` — defence-in-depth path containment check
- `pkg/config/validate_test.go` — new tests (accept/reject cases)
- `internal/satellite/container_runtime/containerd_test.go` — new test confirming traversal payload is rejected before any filesystem write

## Testing

- [x] New unit tests in `pkg/config/validate_test.go` for the hostname validator (accept/reject cases)
- [x] New unit test in `internal/satellite/container_runtime/containerd_test.go` confirming a traversal payload is rejected before any filesystem write occurs
- [x] Manually verified a benign registry name (`docker.io`) still creates the expected `hosts.toml` under `/etc/containerd/certs.d/docker.io/`

## Related

- Validation gap originally flagged in: `pkg/config/validate.go`, lines 337–341
- Vulnerable write path: `internal/satellite/container_runtime/containerd.go`, lines 35–44

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registry validation to reject malformed, ambiguous, or unsafe registry entries.
  * Added support for valid hostnames, ports, IPv4 addresses, and IPv6 literals.
  * Prevented registry certificate paths from escaping the configured certificates directory.
  * Invalid registry fallback values now produce clear validation errors instead of warnings.

* **Tests**
  * Added coverage for valid registry formats, invalid inputs, traversal attempts, and path containment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->