### PR TITLE
fix: Update error handling in migrator

### DIFF
--- a/cmd/groundcontrol/server/main.go
+++ b/cmd/groundcontrol/server/main.go
@@ -23,17 +23,14 @@ func main() {
 
 	if err := env.LoadGC(); err != nil {
 		log.Fatalf("failed to load environment: %v", err)
-		os.Exit(1)
 	}
 
 	if err := harborhealth.CheckHealth(); err != nil {
 		log.Fatalf("health check failed: %v", err)
-		os.Exit(1)
 	}
 
 	if err := migrator.DoMigrations(); err != nil {
 		log.Fatalf("failed to run migrations: %v", err)
-		os.Exit(1)
 	}
 
 	serverResult := server.NewServer()

--- a/cmd/groundcontrol/server/main.go
+++ b/cmd/groundcontrol/server/main.go
@@ -23,14 +23,19 @@ func main() {
 
 	if err := env.LoadGC(); err != nil {
 		log.Fatalf("failed to load environment: %v", err)
+		os.Exit(1)
 	}
 
-	err := harborhealth.CheckHealth()
-	if err != nil {
+	if err := harborhealth.CheckHealth(); err != nil {
 		log.Fatalf("health check failed: %v", err)
+		os.Exit(1)
 	}
 
-	migrator.DoMigrations()
+	if err := migrator.DoMigrations(); err != nil {
+		log.Fatalf("failed to run migrations: %v", err)
+		os.Exit(1)
+	}
+
 	serverResult := server.NewServer()
 	httpServer := serverResult.Server
 	tlsCfg := serverResult.TLSConfig

--- a/internal/groundcontrol/migrator/migrator.go
+++ b/internal/groundcontrol/migrator/migrator.go
@@ -3,6 +3,7 @@ package migrator
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"log"
 	"os"
 	"time"
@@ -12,23 +13,7 @@ import (
 	"github.com/pressly/goose/v3"
 )
 
-type DBConfig struct {
-	URL  string
-	Host string
-	Port string
-}
-
-func parseDBConfig() DBConfig {
-	cfg := env.GC.Database
-
-	return DBConfig{
-		URL:  cfg.URL(),
-		Host: cfg.Host,
-		Port: cfg.Port,
-	}
-}
-
-func waitForPostgresReady(db *sql.DB, timeout time.Duration) {
+func waitForPostgresReady(db *sql.DB, timeout time.Duration) error {
 	const retryInterval = 2 * time.Second
 
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -41,7 +26,7 @@ func waitForPostgresReady(db *sql.DB, timeout time.Duration) {
 
 		if err == nil {
 			log.Println("PostgreSQL is ready for queries.")
-			return
+			return nil
 		}
 
 		log.Printf("PostgreSQL is not ready: %v; retrying in %s", err, retryInterval)
@@ -49,15 +34,15 @@ func waitForPostgresReady(db *sql.DB, timeout time.Duration) {
 		select {
 		case <-time.After(retryInterval):
 		case <-timeoutCtx.Done():
-			log.Println("timed out waiting for PostgreSQL readiness")
-			return
+			log.Printf("timed out waiting for PostgreSQL readiness: %v", timeoutCtx.Err())
+			return timeoutCtx.Err()
 		}
 	}
 }
 
-func runMigrations(db *sql.DB) {
+func runMigrations(db *sql.DB) error {
 	migrationsPath := "/migrations"
-	if _, err := os.Stat(migrationsPath); os.IsNotExist(err) {
+	if _, err := os.Stat(migrationsPath); errors.Is(err, os.ErrNotExist) {
 		migrationsPath = "internal/groundcontrol/sql/schema"
 	}
 
@@ -66,20 +51,21 @@ func runMigrations(db *sql.DB) {
 		log.Fatalf("failed to create goose provider: %v", err)
 	}
 
-	ctx := context.Background()
-	if _, err := provider.Up(ctx); err != nil {
+	if _, err := provider.Up(context.Background()); err != nil {
 		log.Fatalf("failed to run migrations: %v", err)
 	}
 
 	log.Println("Migrations completed successfully.")
+	return nil
 }
 
-func DoMigrations() {
-	cfg := parseDBConfig()
+func DoMigrations() error {
+	cfg := env.GC.Database
 
-	db, err := sql.Open("postgres", cfg.URL)
+	db, err := sql.Open("postgres", cfg.URL())
 	if err != nil {
 		log.Fatalf("failed to open DB: %v", err)
+		return err
 	}
 	defer func() {
 		if err := db.Close(); err != nil {
@@ -87,6 +73,17 @@ func DoMigrations() {
 		}
 	}()
 
-	waitForPostgresReady(db, 60*time.Second)
-	runMigrations(db)
+	err = waitForPostgresReady(db, 60*time.Second)
+	if err != nil {
+		log.Fatalf("PostgreSQL is not ready: %v", err)
+		return err
+	}
+
+	err = runMigrations(db)
+	if err != nil {
+		log.Fatalf("failed to run migrations: %v", err)
+		return err
+	}
+
+	return nil
 }

--- a/internal/groundcontrol/migrator/migrator.go
+++ b/internal/groundcontrol/migrator/migrator.go
@@ -34,7 +34,7 @@ func waitForPostgresReady(db *sql.DB, timeout time.Duration) error {
 		select {
 		case <-time.After(retryInterval):
 		case <-timeoutCtx.Done():
-			log.Printf("timed out waiting for PostgreSQL readiness: %v", timeoutCtx.Err())
+			log.Println("timed out waiting for PostgreSQL readiness")
 			return timeoutCtx.Err()
 		}
 	}
@@ -42,17 +42,26 @@ func waitForPostgresReady(db *sql.DB, timeout time.Duration) error {
 
 func runMigrations(db *sql.DB) error {
 	migrationsPath := "/migrations"
-	if _, err := os.Stat(migrationsPath); errors.Is(err, os.ErrNotExist) {
-		migrationsPath = "internal/groundcontrol/sql/schema"
+	_, err := os.Stat(migrationsPath)
+	if err != nil {
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			migrationsPath = "internal/groundcontrol/sql/schema"
+		default:
+			log.Println("failed to access migrations path")
+			return err
+		}
 	}
 
 	provider, err := goose.NewProvider(goose.DialectPostgres, db, os.DirFS(migrationsPath))
 	if err != nil {
-		log.Fatalf("failed to create goose provider: %v", err)
+		log.Println("failed to create goose provider")
+		return err
 	}
 
 	if _, err := provider.Up(context.Background()); err != nil {
-		log.Fatalf("failed to run migrations: %v", err)
+		log.Println("failed to run migrations")
+		return err
 	}
 
 	log.Println("Migrations completed successfully.")
@@ -64,7 +73,7 @@ func DoMigrations() error {
 
 	db, err := sql.Open("postgres", cfg.URL())
 	if err != nil {
-		log.Fatalf("failed to open DB: %v", err)
+		log.Println("failed to open DB connection")
 		return err
 	}
 	defer func() {
@@ -75,13 +84,13 @@ func DoMigrations() error {
 
 	err = waitForPostgresReady(db, 60*time.Second)
 	if err != nil {
-		log.Fatalf("PostgreSQL is not ready: %v", err)
+		log.Println("PostgreSQL is not ready for queries")
 		return err
 	}
 
 	err = runMigrations(db)
 	if err != nil {
-		log.Fatalf("failed to run migrations: %v", err)
+		log.Println("failed to run migrations")
 		return err
 	}
 


### PR DESCRIPTION
- Fixes: #585

## Description

This PR improves Ground Control’s database migration startup flow by introducing bounded PostgreSQL readiness polling and explicit migration error handling.

## Changes

- Replaces manual readiness deadlines with a shared timeout context.
- Handles migration failures in the Ground Control entry point.
- Uses `errors.Is` when checking whether the migration directory exists.

## Additional Context

Previously, database ping attempts and retry delays were controlled independently. A ping or sleep could therefore extend readiness polling beyond its configured deadline.

Migration helpers also terminated internally without exposing failures to the startup flow. This made it difficult for the Ground Control entry point to explicitly enforce the required startup sequence:

```text
Load configuration
    → verify Harbor health
    → wait for PostgreSQL
    → run migrations
    → start Ground Control
```

The updated implementation keeps readiness polling within one timeout boundary and ensures startup stops when database readiness or migration execution fails.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Startup failures during health checks, database readiness checks, or migrations are now handled consistently, preventing the application from continuing in an unhealthy state.
  * Migration path errors are now distinguished more accurately, improving failure reporting.
  * PostgreSQL timeout and migration failures are surfaced to the application for clearer error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->