### PR TITLE
docs: add ADR-0010 for satellite eventing system

### DIFF
--- a/docs/decisions/0010-satellite-eventing-system.md
+++ b/docs/decisions/0010-satellite-eventing-system.md
@@ -325,11 +325,19 @@ call itself, so it stays non-blocking for the caller while guaranteeing
 **Shutdown ordering.** Reconfigure covers reload; process shutdown is a
 separate, one-way sequence: (1) stop accepting new events into the queue —
 further `Emit` calls from `Execute()` are dropped and logged rather than
-blocking; (2) cancel the `Emitter`'s own context; (3) wait for the dispatcher
-goroutine(s) and every in-flight `Transport.Emit` call to return; (4) only
-then call `Close` on every retained `Transport`. `Transport.Emit` is
-contractually required to return promptly once its context is cancelled —
-without that, a stuck transport could block shutdown indefinitely at step 3.
+blocking; (2) cancel the `Emitter`'s own context; (3) wait, up to a bounded
+grace period (e.g. 10s), for the dispatcher goroutine(s) and every in-flight
+`Transport.Emit` call to return; (4) call `Close` on every retained
+`Transport` — including one whose `Emit` is still running because the grace
+period elapsed. `Transport.Emit` is contractually required to return promptly
+once its context is cancelled, and a conformant implementation makes step 4
+always land in the "no in-flight `Emit`" case, so the grace period is not hit
+in practice. It exists as a bounded escape hatch for a misbehaving transport:
+the accepted trade-off is a narrow use-after-close window scoped to process
+termination only — unlike the `Reconfigure` race above, which is fully
+serialized and must never hit this case during normal operation — because the
+process is exiting regardless and nothing further depends on that `Emit`
+completing cleanly.
 
 ```go
 // internal/eventing/event.go (proposed)
@@ -346,10 +354,11 @@ type Event struct {
 // Content-Type: application/cloudevents+json.
 
 type Transport interface {
-    // Emit must return promptly once ctx is cancelled — shutdown waits on
-    // in-flight Emit calls before closing any Transport (see Shutdown
-    // ordering above), so a transport that ignores cancellation can stall
-    // satellite shutdown indefinitely.
+    // Emit must return promptly once ctx is cancelled. Shutdown waits for
+    // in-flight Emit calls up to a bounded grace period before closing any
+    // Transport (see Shutdown ordering above); an Emit that ignores
+    // cancellation forces that grace period every time and risks a
+    // use-after-close on the rare shutdown that hits it.
     Emit(ctx context.Context, e Event) error
     Close() error
 }
@@ -450,10 +459,15 @@ getter/modifier pattern as `GetAuditConfig()` (`pkg/config/getters.go:208`) and
   events that call already enqueued — a test cancels the caller's context
   immediately after enqueueing and asserts the event still delivers.
 * Shutdown follows the stated ordering (stop intake, cancel context, wait for
-  dispatcher and in-flight sends, then close transports): a test shuts down
-  mid-flight and asserts no `Transport.Emit` call is still running when the
-  last `Close` returns, and that a `Transport` whose `Emit` ignores context
-  cancellation cannot block shutdown past a bounded timeout.
+  dispatcher and in-flight sends, then close transports): a test shuts down a
+  conformant `Transport` (one that honors context cancellation) mid-flight
+  and asserts no `Emit` call is still running when the last `Close` returns,
+  and completion is well within the grace period. A second test shuts down a
+  deliberately non-conformant `Transport` (one whose `Emit` ignores context
+  cancellation) and asserts shutdown still completes at the grace-period
+  bound rather than hanging indefinitely — it does not assert the absence of
+  use-after-close in that specific case, since that's the documented,
+  accepted trade-off for a misbehaving transport during process termination.
 * Startup and `Reconfigure` both reject `eventing.enabled && webhook.enabled`
   with a missing, empty, or under-length `signing_secret_env` value; add
   tests for all three cases.

--- a/docs/decisions/0010-satellite-eventing-system.md
+++ b/docs/decisions/0010-satellite-eventing-system.md
@@ -295,22 +295,41 @@ delivery is already best-effort (see above).
 
 **Context lifetime.** `Emitter` owns a long-lived context created at satellite
 startup and cancelled at shutdown — it does not reuse `Execute()`'s per-cycle
-context. Enqueuing an event only copies its data into the queue; the dispatcher
-goroutine derives a fresh, bounded per-attempt timeout context from the
-`Emitter`'s own context for each call to `Transport.Emit`. This means a
-context cancellation or early return from one `Execute()` call cannot cancel
-delivery of events already sitting in the queue — only satellite shutdown
-(cancelling the `Emitter`'s own context) does.
+context. Enqueuing an event takes an immutable snapshot of the complete event,
+including `Data` and all nested maps and slices — not a shallow copy of the
+`Event` struct, since `Data` is a mutable `map[string]any` and a shallow copy
+would still let the caller mutate nested values after enqueue, changing the
+payload the dispatcher later sends or racing with it reading that payload
+concurrently. The dispatcher goroutine derives a fresh, bounded per-attempt
+timeout context from the `Emitter`'s own context for each call to
+`Transport.Emit`. This means a context cancellation or early return from one
+`Execute()` call cannot cancel delivery of events already sitting in the
+queue — only satellite shutdown (cancelling the `Emitter`'s own context) does.
 
 **Reconfigure vs. in-flight delivery.** Swapping the active `Transport`
 pointer under a lock (as above) is not enough on its own: a dispatcher
 goroutine can be mid-`Emit` (an in-flight webhook POST) on the old `Transport`
 at the moment `Reconfigure` runs. `Emitter` tracks in-flight `Emit` calls per
-`Transport` (a reference count, incremented before `Emit` and decremented
-after); `Reconfigure` swaps the pointer immediately so new dequeues use the
-new `Transport`, but defers calling `Close` on the old one until its
-in-flight count reaches zero. This keeps the swap non-blocking for the caller
-while guaranteeing `Close` never runs out from under an active send.
+`Transport` via a reference count, but the count alone is not race-free: if
+the dispatcher's pointer-read and increment aren't serialized against
+`Reconfigure`'s swap, a dispatcher can read the old pointer, be preempted,
+have `Reconfigure` observe a zero count and `Close` the old `Transport`, then
+resume and `Emit` on an already-closed transport — the exact use-after-close
+the design is meant to prevent. So the pointer read and the refcount
+increment on the dispatcher side, and the swap, zero-count check, and
+deferred `Close` on the `Reconfigure` side, all happen under the same mutex.
+Holding that mutex only guards the pointer/count bookkeeping, not the `Emit`
+call itself, so it stays non-blocking for the caller while guaranteeing
+`Close` never runs concurrently with an active send.
+
+**Shutdown ordering.** Reconfigure covers reload; process shutdown is a
+separate, one-way sequence: (1) stop accepting new events into the queue —
+further `Emit` calls from `Execute()` are dropped and logged rather than
+blocking; (2) cancel the `Emitter`'s own context; (3) wait for the dispatcher
+goroutine(s) and every in-flight `Transport.Emit` call to return; (4) only
+then call `Close` on every retained `Transport`. `Transport.Emit` is
+contractually required to return promptly once its context is cancelled —
+without that, a stuck transport could block shutdown indefinitely at step 3.
 
 ```go
 // internal/eventing/event.go (proposed)
@@ -327,6 +346,10 @@ type Event struct {
 // Content-Type: application/cloudevents+json.
 
 type Transport interface {
+    // Emit must return promptly once ctx is cancelled — shutdown waits on
+    // in-flight Emit calls before closing any Transport (see Shutdown
+    // ordering above), so a transport that ignores cancellation can stall
+    // satellite shutdown indefinitely.
     Emit(ctx context.Context, e Event) error
     Close() error
 }
@@ -414,11 +437,23 @@ getter/modifier pattern as `GetAuditConfig()` (`pkg/config/getters.go:208`) and
   without restart, mirroring `AuditConfig.Reconfigure` (`audit.go:254-269`); events
   enqueued immediately before a reload may still deliver via the old transport.
 * A `Reconfigure` call concurrent with an in-flight `Emit` must not close the
-  old `Transport` until that `Emit` returns — a race test that reconfigures
-  while a slow `Emit` is in progress must show no use-after-close.
+  old `Transport` until that `Emit` returns, and the pointer-read/increment on
+  the dispatcher side must be serialized against `Reconfigure`'s swap under
+  the same mutex — a race test that repeatedly reconfigures while dispatchers
+  are mid-`Emit` (`go test -race`, high iteration count) must show no
+  use-after-close.
+* Mutating an event's `Data` map (including nested maps/slices) after calling
+  `Emit` must not change what the dispatcher delivers — a test enqueues an
+  event, mutates the caller's original `Data` map, and asserts the delivered
+  payload reflects the pre-mutation state.
 * Cancelling one `Execute()` call's context must not cancel delivery of
   events that call already enqueued — a test cancels the caller's context
   immediately after enqueueing and asserts the event still delivers.
+* Shutdown follows the stated ordering (stop intake, cancel context, wait for
+  dispatcher and in-flight sends, then close transports): a test shuts down
+  mid-flight and asserts no `Transport.Emit` call is still running when the
+  last `Close` returns, and that a `Transport` whose `Emit` ignores context
+  cancellation cannot block shutdown past a bounded timeout.
 * Startup and `Reconfigure` both reject `eventing.enabled && webhook.enabled`
   with a missing, empty, or under-length `signing_secret_env` value; add
   tests for all three cases.

--- a/docs/decisions/0010-satellite-eventing-system.md
+++ b/docs/decisions/0010-satellite-eventing-system.md
@@ -6,7 +6,7 @@ consulted: [Harbor Satellite Users, Operators]
 informed: [Harbor Satellite Developers]
 ---
 
-# Satellite Eventing System,
+# Satellite Eventing System
 
 Tracks: [#117](https://github.com/container-registry/harbor-satellite/issues/117), [#58](https://github.com/container-registry/harbor-satellite/issues/58)
 
@@ -55,6 +55,13 @@ routing, or acting on them.
   (#58's "Local CLI/Shell/Container" action) is a code-execution risk and needs its
   own threat model before it ships.
 * Config must hot-reload like every other `AppConfig` section.
+* Every exit path of `Execute()` must be observable, not just the aggregate
+  error from `collectResults` — an early return (context cancellation, a
+  root-state fetch failure) is a real, common failure mode and must not
+  silently produce no event.
+* Delivery is best-effort, not exactly-once: a full queue can drop an event,
+  and a webhook retry can redeliver one. The design must say so explicitly
+  rather than imply a stronger guarantee than the queue/retry model provides.
 
 ## Considered Options
 
@@ -122,28 +129,37 @@ Out of scope (see Future Work):
 Events are emitted from the same points the replication cycle already passes
 through today — no new control flow is introduced, only observation points.
 
-```
+```text
 ┌───────────────────────────┐
 │      Scheduler tick        │
 └─────────────┬───────────────┘
               │
               ▼
 ┌─────────────────────────────────────────┐
-│ Execute(): start()                        │
+│ Execute(ctx) (err error): start()         │
 │ state_process.go:79-81                    │──emit──▶ ((sync.started))
+│ deferred emit of sync.completed/failed    │
+│ covers every return below, not just       │
+│ collectResults (see note)                 │
 └─────────────┬───────────────────────────────┘
               │
               ▼
-      ┌───────────────┐        missing creds        ┌────────────────────┐
-      │  CanExecute?   │────────────────────────────▶│  stop, no event     │
-      └───────┬────────┘                              └────────────────────┘
+      ┌────────────────┐   ctx cancelled (:87-91)
+      │  ctx.Done()?    │─────────────────────────▶ return ctx.Err()
+      └───────┬─────────┘
+              │ not yet
+              ▼
+      ┌────────────────┐   missing creds (:95-99)
+      │  CanExecute?    │─────────────────────────▶ return nil, no event
+      └───────┬─────────┘
               │ ok
               ▼
 ┌─────────────────────────────────────────┐
-│ fetchSatelliteRootState                   │
-│ state_process.go:102                      │──emit──▶ ((state.received))
+│ fetchSatelliteRootState /                 │
+│ Harbor-URL override                       │──emit──▶ ((state.received))
+│ state_process.go:102-114                  │──error──▶ return err
 └─────────────┬───────────────────────────────┘
-              │
+              │ ok
               ▼
 ┌─────────────────────────────────────────┐
 │ processGroupState per group               │
@@ -169,11 +185,18 @@ through today — no new control flow is introduced, only observation points.
 │ state_process.go:273-327                  │
 └─────────────┬───────────────────────────────┘
               │
+              ▼
+     Execute(ctx) returns (nil or err) ◀── ctx-cancel / fetch-error
+              │                             returns above also land here
        ┌──────┴───────┐
-   no error         error
+   nil err           non-nil err
        │                │
        ▼                ▼
 ((sync.completed))  ((sync.failed))
+
+  the deferred emit fires exactly once per Execute() call, on every
+  return path except the "missing creds" one (which is not a failure,
+  just not-yet-ready, and intentionally emits nothing)
 ```
 
 Delivery is decoupled from the sync cycle by a bounded queue: the process emits
@@ -181,7 +204,14 @@ into the queue and continues immediately, a single dispatcher goroutine per
 transport drains it, and a full queue drops the event (logged and counted) rather
 than applying backpressure to replication.
 
-```
+**Delivery is best-effort, not exactly-once.** A full queue drops an event
+(lost). A webhook retry after a delivered-but-unacknowledged POST redelivers
+the same event (duplicated). Satellite does not attempt durable, exactly-once
+delivery — CloudEvents itself permits redelivery of the same event. Each event
+is assigned one `id` at emission time, and a retry reuses that `id` rather than
+minting a new one, so receivers can deduplicate by `id` if they need to.
+
+```text
 ┌────────────┐        ┌─────────────────────────────────┐
 │ Scheduler   │───────▶│ FetchAndReplicateStateProcess    │
 └────────────┘        │ Execute(ctx)                     │
@@ -200,14 +230,14 @@ than applying backpressure to replication.
                        │ Webhook Transport                  │
                        └────────────────┬──────────────────┘
                                         │ POST CloudEvents JSON
-                                        │ (HMAC-signed)
+                                        │ (HMAC-signed, same id on retry)
                                         ▼
                        ┌─────────────────────────────────┐
                        │ External consumer                   │
                        │ (Argo Events / Knative / custom)    │
                        └────────────────┬──────────────────┘
-                                        │ 2xx, or non-2xx
-                                        │ (logged, bounded retry)
+                                        │ 2xx, or non-2xx (logged, bounded
+                                        │ retry — may duplicate on receiver)
                                         ▼
                                 (delivery result)
 ```
@@ -216,39 +246,94 @@ than applying backpressure to replication.
 
 | Event type | Trigger | Source | Payload highlights |
 |---|---|---|---|
-| `io.harborsatellite.state.sync.started` | `Execute()` begins, `CanExecute` passed | `state_process.go:79-99` | `satellite_id`, `cycle_id` |
-| `io.harborsatellite.state.received` | Root or group state artifact fetched | `state_process.go:102`, `:448` | `group`, `digest`, `artifact_count` |
-| `io.harborsatellite.artifact.synchronized` | Entity replicated | `replicator.go:152-173` | `group`, `repository`, `tag`, `digest`, `bytes`, `duration_ms` |
-| `io.harborsatellite.artifact.deleted` | Entity removed | `state_process.go:459` | `group`, `repository`, `tag`, `digest` |
-| `io.harborsatellite.config.updated` | Remote config digest changed | `state_process.go:329-411` | `digest_old`, `digest_new` |
-| `io.harborsatellite.state.sync.completed` | `collectResults` returns nil | `state_process.go:273-327` | `cycle_id`, `duration_ms`, `groups_synced` |
-| `io.harborsatellite.state.sync.failed` | `collectResults` returns an error | `state_process.go:273-327` | `cycle_id`, `error`, `groups_failed` |
+| `io.harborsatellite.state.sync.started` | `Execute()` begins, `CanExecute` passed | `state_process.go:79-99` | `satellite_id`, `cycle_id`, `schema_version` |
+| `io.harborsatellite.state.received` | Root or group state artifact fetched | `state_process.go:102`, `:448` | `cycle_id`, `group`, `digest`, `artifact_count`, `schema_version` |
+| `io.harborsatellite.artifact.synchronized` | Entity replicated | `replicator.go:152-173` | `cycle_id`, `group`, `repository`, `tag`, `digest`, `bytes`, `duration_ms`, `schema_version` |
+| `io.harborsatellite.artifact.deleted` | Entity removed | `state_process.go:459` | `cycle_id`, `group`, `repository`, `tag`, `digest`, `schema_version` |
+| `io.harborsatellite.config.updated` | Remote config digest changed | `state_process.go:329-411` | `cycle_id`, `digest_old`, `digest_new`, `schema_version` |
+| `io.harborsatellite.state.sync.completed` | `Execute()` returns nil, via a deferred emit (only reachable through `collectResults`) | `state_process.go:273-327` | `cycle_id`, `duration_ms`, `groups_synced`, `schema_version` |
+| `io.harborsatellite.state.sync.failed` | `Execute()` returns a non-nil error, via a deferred emit — covers context cancellation and root-state/Harbor-override fetch errors, not just `collectResults`'s aggregate error | `state_process.go:87-91`, `:102-114`, `:273-327` | `cycle_id`, `error`, `groups_failed` (omitted for early-return errors), `schema_version` |
+
+### Event Payload Schema and Correlation
+
+Every event's `Data` payload carries `cycle_id` — including the non-sync events
+(`state.received`, `artifact.*`, `config.updated`) — so a consumer can group
+everything that happened during one replication cycle back together after
+async, possibly reordered delivery, not just correlate the two sync bookend
+events.
+
+Every payload also carries `schema_version` (starting at `"1"`). Changes within
+a version must be additive only (new optional fields); a breaking change to an
+existing event's fields mints a new event `type` (e.g. a `.v2` suffix) rather
+than silently changing what existing consumers of the `v1` type receive. Field
+types, which fields are required, and per-field size limits are implementation
+detail to be pinned down in the PR that adds `internal/eventing`, not in this
+ADR — the schema-evolution rule above is what's being decided here.
 
 ### Emitter and Transport shape
 
 Mirrors `internal/logger/audit.go`'s `Transport` interface, with a context so a
-webhook POST respects cancellation on shutdown:
+webhook POST respects cancellation on shutdown. `Emitter` is the sibling of
+`AuditLogger`: it owns the bounded queue and dispatcher goroutine, and exposes
+`Reconfigure` the same way `AuditLogger.Reconfigure` does (`audit.go:254-269`)
+— build and verify the new `Transport` up front, swap it under a lock, close
+the old one after. The queue itself is untouched by a reconfigure: events
+already enqueued are delivered via whichever `Transport` is active when the
+dispatcher goroutine dequeues them, so a reload mid-cycle can route a small
+tail of in-flight events to the old transport. That's acceptable given
+delivery is already best-effort (see above).
 
 ```go
 // internal/eventing/event.go (proposed)
 type Event struct {
-    ID     string         // CloudEvents "id"
-    Source string         // CloudEvents "source": satellite name or SPIFFE ID
+    ID     string         // CloudEvents "id" — unique per emission, reused on retry
+    Source string         // CloudEvents "source" (URI-reference): satellite name or SPIFFE ID
     Type   string         // CloudEvents "type", e.g. "io.harborsatellite.artifact.synchronized"
-    Time   time.Time
-    Data   map[string]any // CloudEvents "data"
+    Time   time.Time      // CloudEvents "time"
+    Data   map[string]any // CloudEvents "data"; always includes cycle_id, schema_version
 }
+
+// The webhook transport serializes Event as CloudEvents v1.0 structured JSON
+// (specversion "1.0" added at encode time, not stored on Event) with
+// Content-Type: application/cloudevents+json.
 
 type Transport interface {
     Emit(ctx context.Context, e Event) error
     Close() error
 }
+
+type Emitter struct { /* bounded queue, dispatcher goroutine(s), current Transport */ }
+
+func (e *Emitter) Reconfigure(cfg EventingConfig) error // mirrors AuditLogger.Reconfigure
 ```
+
+### Webhook Transport Security
+
+* **Signing**: HMAC-SHA256 over the raw JSON request body, sent as
+  `X-Satellite-Signature-256: sha256=<hex>` (same convention as GitHub
+  webhooks).
+* **Replay protection**: an `X-Satellite-Timestamp` header (Unix seconds) is
+  included in the signed material (HMAC computed over `timestamp + "." +
+  body`, not the body alone). Receivers should reject requests outside a
+  5-minute window; a captured signed payload can't be replayed indefinitely.
+* **Transport**: HTTPS is required for any non-loopback URL; the webhook
+  transport refuses to start with a plain `http://` non-loopback URL, mirroring
+  how this project already gates other insecure options (e.g. `USE_UNSECURE`).
+* **Redirects**: the HTTP client does not follow redirects — an
+  attacker-controlled 3xx response redirecting a signed payload to a different
+  host is refused, not followed.
+* **Secret rotation**: `signing_secret_env` names one env var; rotating the
+  secret today means reloading with the new value (a hard cutover). Accepting
+  two active secrets during a rotation window is Future Work, not Phase 1.
 
 ### Config shape
 
 Slots into `AppConfig` next to `Audit`, following the existing
-`AuditConfig`/`SyslogAudit`/`OtelAudit` nesting (`pkg/config/config.go:190-207`):
+`AuditConfig`/`SyslogAudit`/`OtelAudit` nesting (`pkg/config/config.go:190-207`).
+`eventing.enabled` is the master switch, exactly like `AuditConfig.Enabled`:
+when `false`, the `Emitter` is a no-op regardless of `webhook.enabled`, so an
+operator can keep the webhook config on file and toggle all of eventing off
+with one flag:
 
 ```json
 "eventing": {
@@ -269,16 +354,28 @@ getter/modifier pattern as `GetAuditConfig()` (`pkg/config/getters.go:208`) and
 
 ## Validation
 
-* Event emitted exactly once per cycle for `sync.started`/`sync.completed`/
-  `sync.failed`, even with concurrent per-group goroutines (`go test -race`).
+* `sync.started`/`sync.completed`/`sync.failed` are each attempted exactly once
+  per `Execute()` call (one deferred emit per call), even with concurrent
+  per-group goroutines (`go test -race`) — but see the best-effort note below
+  for what happens between attempt and receiver.
+* `sync.failed` fires on every non-nil return from `Execute()`, not just
+  `collectResults`'s aggregate error: add a test that forces a context
+  cancellation and a `fetchSatelliteRootState` error and asserts both emit
+  `sync.failed`.
+* Delivery is best-effort, not exactly-once: a soak test against a receiver
+  that intermittently 5xxs must show duplicate deliveries share the same event
+  `id`, and a soak test against a sustained-down receiver must show dropped
+  events are logged and counted with memory staying bounded.
 * Emission never blocks `Execute()`: a deliberately slow or hung webhook receiver
   must not measurably change replication cycle latency beyond the bounded enqueue.
-* Queue-full behavior: dropped events are logged and counted, memory stays
-  bounded under a sustained-down receiver (soak test).
-* HMAC signature verified end-to-end against a reference receiver.
-* CloudEvents JSON validated against the CloudEvents SDK conformance checks.
+* HMAC signature verified end-to-end against a reference receiver, including
+  that a request outside the replay window (stale `X-Satellite-Timestamp`) is
+  rejected and a 3xx response from the receiver is not followed.
+* CloudEvents JSON validated against the CloudEvents SDK conformance checks,
+  including `specversion: "1.0"` and `Content-Type: application/cloudevents+json`.
 * Hot-reload: toggling `eventing.enabled` or changing the webhook URL takes effect
-  without restart, mirroring `AuditConfig.Reconfigure` (`audit.go:254-269`).
+  without restart, mirroring `AuditConfig.Reconfigure` (`audit.go:254-269`); events
+  enqueued immediately before a reload may still deliver via the old transport.
 
 ## Future Work
 

--- a/docs/decisions/0010-satellite-eventing-system.md
+++ b/docs/decisions/0010-satellite-eventing-system.md
@@ -1,0 +1,314 @@
+---
+status: proposed
+date: 2026-08-05
+deciders: [Harbor Satellite Development Team]
+consulted: [Harbor Satellite Users, Operators]
+informed: [Harbor Satellite Developers]
+---
+
+# Satellite Eventing System,
+
+Tracks: [#117](https://github.com/container-registry/harbor-satellite/issues/117), [#58](https://github.com/container-registry/harbor-satellite/issues/58)
+
+## Context and Problem Statement
+
+Operators who embed Harbor Satellite in a larger pipeline need to react to what a
+satellite is doing — a new artifact synchronized, a sync cycle failed, connectivity
+degraded — without polling logs or the Ground Control API. Issue #117 asks for an
+ADR precisely because the requirements are open-ended: rate-limit-aware transfer,
+connectivity-based transfer gating, and triggering a downstream deployment were all
+raised as candidate use cases, and they share no obvious contract. Issue #58 is more
+concrete: it lists Event Triggers (new state, sync started/completed/failed, artifact
+synchronized) and Actions (local CLI/shell/container, REST), and points at
+[CloudEvents](https://cloudevents.io/) / [CDEvents](https://cdevents.dev/) as
+candidate formats.
+
+Satellite already ships one production event pipeline: the audit logger
+(`internal/logger/audit.go`), which fans a fixed-schema `AuditEvent` out to
+pluggable `Transport`s (syslog, OTel) for security-relevant actions (login, ZTR,
+config change). It is not a fit for operational lifecycle signals — its
+`Operation`/`ResourceType`/`Outcome` vocabulary is deliberately closed
+(`audit.go:46-71`) and its purpose is a compliance trail, not a general
+publish/subscribe mechanism a workflow engine subscribes to.
+
+A maintainer raised a scoping concern directly on #117: building a full
+downstream-eventing/workflow system risks duplicating what CD platforms already
+solve, and Satellite's job is better framed as an edge proxy registry delivering
+artifacts, not an orchestrator. That concern is treated as a hard constraint below:
+this ADR scopes Satellite to **emitting** typed lifecycle events, not consuming,
+routing, or acting on them.
+
+## Decision Drivers
+
+* Must not duplicate or overload the audit logger's fixed security-event schema.
+* Must reuse the `Transport`/`Reconfigure` pattern already proven in production
+  (`internal/logger/audit.go`) rather than invent a new plugin shape.
+* Must not block the replication critical path
+  (`FetchAndReplicateStateProcess.Execute`, `internal/satellite/state/state_process.go:79`)
+  — event emission is best-effort and asynchronous.
+* Must not turn Satellite into a workflow engine or CD platform (maintainer
+  constraint from the #117 discussion) — Satellite emits, downstream systems decide
+  and act.
+* Output format should be consumable by generic eventing platforms (Argo Events,
+  Knative Eventing, or a plain webhook receiver) without bespoke integration work.
+* Executing local commands/containers as a reaction to a remote-influenced signal
+  (#58's "Local CLI/Shell/Container" action) is a code-execution risk and needs its
+  own threat model before it ships.
+* Config must hot-reload like every other `AppConfig` section.
+
+## Considered Options
+
+* Option 1: Extend the existing `AuditLogger`/`AuditEvent` to also carry
+  operational lifecycle events.
+* Option 2: New sibling event system (`internal/eventing`) reusing the audit
+  logger's `Transport`/`Reconfigure` pattern, with its own typed event vocabulary
+  and a CloudEvents-shaped wire format, emitted over an HTTP webhook transport.
+* Option 3: Adopt an external message broker (NATS/Kafka) as a new satellite
+  dependency.
+* Option 4: No structured events; consumers scrape structured `zerolog` output.
+
+## Decision Outcome
+
+Chosen option: "New sibling event system emitting CloudEvents over HTTP webhooks",
+because it reuses a pattern already validated in production, keeps the audit
+trail's schema closed and compliance-focused, needs no new satellite dependency or
+long-running broker process, and produces a wire format every mainstream eventing
+consumer already understands.
+
+### Consequences
+
+* Good, because it reuses the `Transport`/`Reconfigure`/hot-reload shape from the
+  audit logger — no new architectural concept needs review.
+* Good, because CloudEvents JSON means Argo Events, Knative Eventing, or a
+  five-line webhook receiver can consume events with no Satellite-specific client.
+* Good, because emission is decoupled from Satellite deciding what to do about
+  network conditions or rate limits — those stay separate features (#63) that may
+  consume these events later.
+* Neutral, because the first transport is HTTP webhook only; syslog/OTel event
+  transports and the local CLI/shell/container action from #58 are deferred (see
+  Future Work) pending a security review of arbitrary local execution.
+* Neutral, because per-artifact events require threading a reporter through
+  `BasicReplicator.Replicate` (`internal/satellite/state/replicator.go:107-177`),
+  which today only returns one aggregate error for the whole batch — a small
+  interface change, not a rewrite.
+* Bad, because a second best-effort delivery pipeline (webhook) is now part of
+  Satellite's runtime surface, with its own retry/backoff/queue-depth failure
+  modes to operate and test.
+
+## Scope
+
+In scope:
+
+* Emitting typed lifecycle events for: sync started, sync completed, sync failed,
+  new state received, artifact synchronized, artifact deleted, config updated.
+* One transport: HTTP webhook, CloudEvents v1.0 JSON, HMAC-signed.
+* Config: `EventingConfig` under `AppConfig`, hot-reloadable, following the
+  existing `AuditConfig` shape.
+
+Out of scope (see Future Work):
+
+* Any built-in action/workflow execution (shell, container, CD trigger) —
+  Satellite emits, it does not act.
+* Rate limiting or connectivity-aware transfer gating (#63) — a separate feature
+  that could subscribe to these events.
+* Ground Control-side events (this ADR covers the satellite process only; GC
+  already has its own audit trail).
+* syslog/OTel transports for these events (the audit logger already owns those
+  destinations for security events; revisit if operators ask for one unified
+  delivery pipeline instead of two).
+
+## Architecture
+
+Events are emitted from the same points the replication cycle already passes
+through today — no new control flow is introduced, only observation points.
+
+```
+┌───────────────────────────┐
+│      Scheduler tick        │
+└─────────────┬───────────────┘
+              │
+              ▼
+┌─────────────────────────────────────────┐
+│ Execute(): start()                        │
+│ state_process.go:79-81                    │──emit──▶ ((sync.started))
+└─────────────┬───────────────────────────────┘
+              │
+              ▼
+      ┌───────────────┐        missing creds        ┌────────────────────┐
+      │  CanExecute?   │────────────────────────────▶│  stop, no event     │
+      └───────┬────────┘                              └────────────────────┘
+              │ ok
+              ▼
+┌─────────────────────────────────────────┐
+│ fetchSatelliteRootState                   │
+│ state_process.go:102                      │──emit──▶ ((state.received))
+└─────────────┬───────────────────────────────┘
+              │
+              ▼
+┌─────────────────────────────────────────┐
+│ processGroupState per group               │
+│ state_process.go:130-135                  │
+└─────────────┬───────────────────────────────┘
+              │
+              ▼
+┌─────────────────────────────────────────┐
+│ GetChanges diff                           │
+│ state_process.go:179-227                  │
+└─────────────┬───────────────────────────────┘
+              │
+              ▼
+┌─────────────────────────────────────────┐
+│ Replicator.Replicate /                    │
+│ DeleteReplicationEntity                   │──emit──▶ ((artifact.synchronized
+│ replicator.go:107-177                     │           / artifact.deleted))
+└─────────────┬───────────────────────────────┘
+              │
+              ▼
+┌─────────────────────────────────────────┐
+│ collectResults                            │
+│ state_process.go:273-327                  │
+└─────────────┬───────────────────────────────┘
+              │
+       ┌──────┴───────┐
+   no error         error
+       │                │
+       ▼                ▼
+((sync.completed))  ((sync.failed))
+```
+
+Delivery is decoupled from the sync cycle by a bounded queue: the process emits
+into the queue and continues immediately, a single dispatcher goroutine per
+transport drains it, and a full queue drops the event (logged and counted) rather
+than applying backpressure to replication.
+
+```
+┌────────────┐        ┌─────────────────────────────────┐
+│ Scheduler   │───────▶│ FetchAndReplicateStateProcess    │
+└────────────┘        │ Execute(ctx)                     │
+                       └────────────────┬──────────────────┘
+                                        │ Emit(sync.started)
+                                        │ Emit(artifact.synchronized) x N
+                                        │ Emit(sync.completed | sync.failed)
+                                        ▼
+                       ┌─────────────────────────────────┐
+                       │ internal/eventing Emitter         │
+                       │ (bounded queue, non-blocking)      │
+                       └────────────────┬──────────────────┘
+                                        │ dispatcher goroutine drains queue
+                                        ▼
+                       ┌─────────────────────────────────┐
+                       │ Webhook Transport                  │
+                       └────────────────┬──────────────────┘
+                                        │ POST CloudEvents JSON
+                                        │ (HMAC-signed)
+                                        ▼
+                       ┌─────────────────────────────────┐
+                       │ External consumer                   │
+                       │ (Argo Events / Knative / custom)    │
+                       └────────────────┬──────────────────┘
+                                        │ 2xx, or non-2xx
+                                        │ (logged, bounded retry)
+                                        ▼
+                                (delivery result)
+```
+
+### Event Catalog (Phase 1)
+
+| Event type | Trigger | Source | Payload highlights |
+|---|---|---|---|
+| `io.harborsatellite.state.sync.started` | `Execute()` begins, `CanExecute` passed | `state_process.go:79-99` | `satellite_id`, `cycle_id` |
+| `io.harborsatellite.state.received` | Root or group state artifact fetched | `state_process.go:102`, `:448` | `group`, `digest`, `artifact_count` |
+| `io.harborsatellite.artifact.synchronized` | Entity replicated | `replicator.go:152-173` | `group`, `repository`, `tag`, `digest`, `bytes`, `duration_ms` |
+| `io.harborsatellite.artifact.deleted` | Entity removed | `state_process.go:459` | `group`, `repository`, `tag`, `digest` |
+| `io.harborsatellite.config.updated` | Remote config digest changed | `state_process.go:329-411` | `digest_old`, `digest_new` |
+| `io.harborsatellite.state.sync.completed` | `collectResults` returns nil | `state_process.go:273-327` | `cycle_id`, `duration_ms`, `groups_synced` |
+| `io.harborsatellite.state.sync.failed` | `collectResults` returns an error | `state_process.go:273-327` | `cycle_id`, `error`, `groups_failed` |
+
+### Emitter and Transport shape
+
+Mirrors `internal/logger/audit.go`'s `Transport` interface, with a context so a
+webhook POST respects cancellation on shutdown:
+
+```go
+// internal/eventing/event.go (proposed)
+type Event struct {
+    ID     string         // CloudEvents "id"
+    Source string         // CloudEvents "source": satellite name or SPIFFE ID
+    Type   string         // CloudEvents "type", e.g. "io.harborsatellite.artifact.synchronized"
+    Time   time.Time
+    Data   map[string]any // CloudEvents "data"
+}
+
+type Transport interface {
+    Emit(ctx context.Context, e Event) error
+    Close() error
+}
+```
+
+### Config shape
+
+Slots into `AppConfig` next to `Audit`, following the existing
+`AuditConfig`/`SyslogAudit`/`OtelAudit` nesting (`pkg/config/config.go:190-207`):
+
+```json
+"eventing": {
+  "enabled": false,
+  "webhook": {
+    "enabled": true,
+    "url": "https://example.com/hooks/harbor-satellite",
+    "timeout": "5s",
+    "signing_secret_env": "SATELLITE_EVENT_SIGNING_SECRET",
+    "queue_size": 256
+  }
+}
+```
+
+`GetEventingConfig()` / `SetEventingConfig(...)` follow the same one-liner
+getter/modifier pattern as `GetAuditConfig()` (`pkg/config/getters.go:208`) and
+`SetDirectDelivery` (`pkg/config/modifiers.go:121`).
+
+## Validation
+
+* Event emitted exactly once per cycle for `sync.started`/`sync.completed`/
+  `sync.failed`, even with concurrent per-group goroutines (`go test -race`).
+* Emission never blocks `Execute()`: a deliberately slow or hung webhook receiver
+  must not measurably change replication cycle latency beyond the bounded enqueue.
+* Queue-full behavior: dropped events are logged and counted, memory stays
+  bounded under a sustained-down receiver (soak test).
+* HMAC signature verified end-to-end against a reference receiver.
+* CloudEvents JSON validated against the CloudEvents SDK conformance checks.
+* Hot-reload: toggling `eventing.enabled` or changing the webhook URL takes effect
+  without restart, mirroring `AuditConfig.Reconfigure` (`audit.go:254-269`).
+
+## Future Work
+
+* Additional transports (syslog, OTel event export, message brokers) if operators
+  want one delivery pipeline instead of two.
+* An inbound control channel (a downstream system telling Satellite to throttle)
+  is explicitly out of scope here — this ADR is outbound-only. It would likely
+  piggyback on the existing remote config mechanism ([ADR-0003](0003-remote-config-injection.md))
+  rather than a new channel.
+* Local CLI/shell/container action execution (#58) — deferred pending a dedicated
+  threat model; if built, it must be opt-in, off by default, and restricted to an
+  operator-defined command allowlist rather than dynamic, remotely-influenced
+  commands.
+* Rate limiting / connectivity-aware transfer gating (#63) as a consumer of
+  `artifact.synchronized`'s `bytes`/`duration_ms` payload, not as part of this ADR.
+* Ground Control-side event emission (admin actions, satellite lifecycle
+  transitions per [ADR-0006](0006-satellite-lifecycle-states.md)) as a parallel,
+  separate ADR if requested.
+* Coordination with [ADR-0009](0009-transparent-oci-registry-proxy.md)'s proxy
+  admission decisions (allow/deny) as additional event types, once that ADR moves
+  past `proposed`.
+
+## References
+
+* [Issue #117 - ADR Entry for Eventing System](https://github.com/container-registry/harbor-satellite/issues/117)
+* [Issue #58 - Satellite Downstream Notifications](https://github.com/container-registry/harbor-satellite/issues/58)
+* [Issue #63 - Track and report upstream how many bytes were transferred](https://github.com/container-registry/harbor-satellite/issues/63) (related, not implemented here)
+* [CloudEvents Specification](https://cloudevents.io/)
+* [CDEvents](https://cdevents.dev/)
+* `internal/logger/audit.go` - existing `Transport`/`Reconfigure` precedent
+* [ADR-0003](0003-remote-config-injection.md) - Remote Config Injection
+* [ADR-0006](0006-satellite-lifecycle-states.md) - Satellite Lifecycle States
+* [ADR-0009](0009-transparent-oci-registry-proxy.md) - Transparent OCI Registry Proxy

--- a/docs/decisions/0010-satellite-eventing-system.md
+++ b/docs/decisions/0010-satellite-eventing-system.md
@@ -137,7 +137,7 @@ through today — no new control flow is introduced, only observation points.
               ▼
 ┌─────────────────────────────────────────┐
 │ Execute(ctx) (err error): start()         │
-│ state_process.go:79-81                    │──emit──▶ ((sync.started))
+│ state_process.go:79-81                    │
 │ deferred emit of sync.completed/failed    │
 │ covers every return below, not just       │
 │ collectResults (see note)                 │
@@ -146,13 +146,19 @@ through today — no new control flow is introduced, only observation points.
               ▼
       ┌────────────────┐   ctx cancelled (:87-91)
       │  ctx.Done()?    │─────────────────────────▶ return ctx.Err()
-      └───────┬─────────┘
-              │ not yet
-              ▼
+      └───────┬─────────┘                            (deferred sync.failed —
+              │ not yet                                no sync.started ever
+              ▼                                        fired for this cycle)
       ┌────────────────┐   missing creds (:95-99)
       │  CanExecute?    │─────────────────────────▶ return nil, no event
-      └───────┬─────────┘
-              │ ok
+      └───────┬─────────┘                            (neither started nor
+              │ ok                                    failed: not-yet-ready,
+              ▼                                        not a failure)
+┌─────────────────────────────────────────┐
+│ eligibility confirmed                     │──emit──▶ ((sync.started))
+│ state_process.go:100                      │
+└─────────────┬───────────────────────────────┘
+              │
               ▼
 ┌─────────────────────────────────────────┐
 │ fetchSatelliteRootState /                 │
@@ -194,9 +200,13 @@ through today — no new control flow is introduced, only observation points.
        ▼                ▼
 ((sync.completed))  ((sync.failed))
 
-  the deferred emit fires exactly once per Execute() call, on every
-  return path except the "missing creds" one (which is not a failure,
-  just not-yet-ready, and intentionally emits nothing)
+  the deferred completion emit fires exactly once per Execute() call, on
+  every return path except the "missing creds" one (which is not a
+  failure, just not-yet-ready, and intentionally emits nothing).
+  sync.started fires only once eligibility is confirmed, so a
+  ctx-cancelled cycle emits sync.failed with no preceding sync.started —
+  that pairing is not guaranteed, and consumers correlating by cycle_id
+  should not assume every sync.failed has a matching sync.started.
 ```
 
 Delivery is decoupled from the sync cycle by a bounded queue: the process emits
@@ -246,7 +256,7 @@ minting a new one, so receivers can deduplicate by `id` if they need to.
 
 | Event type | Trigger | Source | Payload highlights |
 |---|---|---|---|
-| `io.harborsatellite.state.sync.started` | `Execute()` begins, `CanExecute` passed | `state_process.go:79-99` | `satellite_id`, `cycle_id`, `schema_version` |
+| `io.harborsatellite.state.sync.started` | `CanExecute` passes (not at `Execute()` entry — see Architecture) | `state_process.go:100` | `satellite_id`, `cycle_id`, `schema_version` |
 | `io.harborsatellite.state.received` | Root or group state artifact fetched | `state_process.go:102`, `:448` | `cycle_id`, `group`, `digest`, `artifact_count`, `schema_version` |
 | `io.harborsatellite.artifact.synchronized` | Entity replicated | `replicator.go:152-173` | `cycle_id`, `group`, `repository`, `tag`, `digest`, `bytes`, `duration_ms`, `schema_version` |
 | `io.harborsatellite.artifact.deleted` | Entity removed | `state_process.go:459` | `cycle_id`, `group`, `repository`, `tag`, `digest`, `schema_version` |
@@ -282,6 +292,25 @@ already enqueued are delivered via whichever `Transport` is active when the
 dispatcher goroutine dequeues them, so a reload mid-cycle can route a small
 tail of in-flight events to the old transport. That's acceptable given
 delivery is already best-effort (see above).
+
+**Context lifetime.** `Emitter` owns a long-lived context created at satellite
+startup and cancelled at shutdown — it does not reuse `Execute()`'s per-cycle
+context. Enqueuing an event only copies its data into the queue; the dispatcher
+goroutine derives a fresh, bounded per-attempt timeout context from the
+`Emitter`'s own context for each call to `Transport.Emit`. This means a
+context cancellation or early return from one `Execute()` call cannot cancel
+delivery of events already sitting in the queue — only satellite shutdown
+(cancelling the `Emitter`'s own context) does.
+
+**Reconfigure vs. in-flight delivery.** Swapping the active `Transport`
+pointer under a lock (as above) is not enough on its own: a dispatcher
+goroutine can be mid-`Emit` (an in-flight webhook POST) on the old `Transport`
+at the moment `Reconfigure` runs. `Emitter` tracks in-flight `Emit` calls per
+`Transport` (a reference count, incremented before `Emit` and decremented
+after); `Reconfigure` swaps the pointer immediately so new dequeues use the
+new `Transport`, but defers calling `Close` on the old one until its
+in-flight count reaches zero. This keeps the swap non-blocking for the caller
+while guaranteeing `Close` never runs out from under an active send.
 
 ```go
 // internal/eventing/event.go (proposed)
@@ -325,6 +354,14 @@ func (e *Emitter) Reconfigure(cfg EventingConfig) error // mirrors AuditLogger.R
 * **Secret rotation**: `signing_secret_env` names one env var; rotating the
   secret today means reloading with the new value (a hard cutover). Accepting
   two active secrets during a rotation window is Future Work, not Phase 1.
+* **Fail-fast validation**: when `eventing.enabled && webhook.enabled`, the
+  env var named by `signing_secret_env` must resolve to a non-empty value of
+  at least 32 bytes (matching HMAC-SHA256 key-length guidance) at both
+  construction and every `Reconfigure`. A missing, empty, or short secret is a
+  startup/reload error, not a silent no-op — the same fail-fast rule the audit
+  logger already applies to its own transports ("audit logging is enabled but
+  no transport is configured", `audit.go:300`), so a misconfigured webhook
+  can't advertise itself as active while actually dropping every signature.
 
 ### Config shape
 
@@ -376,6 +413,15 @@ getter/modifier pattern as `GetAuditConfig()` (`pkg/config/getters.go:208`) and
 * Hot-reload: toggling `eventing.enabled` or changing the webhook URL takes effect
   without restart, mirroring `AuditConfig.Reconfigure` (`audit.go:254-269`); events
   enqueued immediately before a reload may still deliver via the old transport.
+* A `Reconfigure` call concurrent with an in-flight `Emit` must not close the
+  old `Transport` until that `Emit` returns — a race test that reconfigures
+  while a slow `Emit` is in progress must show no use-after-close.
+* Cancelling one `Execute()` call's context must not cancel delivery of
+  events that call already enqueued — a test cancels the caller's context
+  immediately after enqueueing and asserts the event still delivers.
+* Startup and `Reconfigure` both reject `eventing.enabled && webhook.enabled`
+  with a missing, empty, or under-length `signing_secret_env` value; add
+  tests for all three cases.
 
 ## Future Work
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -18,3 +18,4 @@ General information about architectural decision records is available at <https:
 - [ADR-0008](0008-parsec-harbor-integration-proposal.md) - PARSEC Harbor Integration Proposal
 - [ADR-0008](0008-parsec-integration-and-zero-trust-bootstrapping-flow.md) - PARSEC Integration & Zero-Trust Bootstrapping Flow
 - [ADR-0009](0009-transparent-oci-registry-proxy.md) - Policy-Enforcing Transparent OCI Registry Proxy with ORAS
+- [ADR-0010](0010-satellite-eventing-system.md) - Satellite Eventing System


### PR DESCRIPTION

## Summary
- Adds ADR-0010 proposing the eventing system requested in #117: satellite emits typed lifecycle events (sync started/completed/failed, artifact synced/deleted, config updated) as CloudEvents JSON over an HMAC-signed webhook, reusing the existing audit logger's Transport/Reconfigure pattern.

- Scoped to emission only (no built-in actions/workflow execution), per the maintainer discussion on #117 about not duplicating what CD platforms already solve.

Closes #117
Relates to #58

## Test plan
 None

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a decision record describing outbound operational lifecycle event notifications.
  * Documented synchronization, state, artifact, deletion, and configuration event types.
  * Defined CloudEvents JSON delivery through secure HTTPS webhooks with HMAC-SHA256 signing and best-effort asynchronous processing.
  * Added guidance for queue limits, delivery retries, event identifiers, configuration updates, secret rotation, replay protection, and schema evolution.
  * Added the decision record to the documentation index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->