### PR TITLE
fix(harbor): refactor client initialization to return error instead of panic

### DIFF
--- a/internal/groundcontrol/harbor/client.go
+++ b/internal/groundcontrol/harbor/client.go
@@ -10,11 +10,12 @@ import (
 
 var (
 	client     *v2client.HarborAPI
+	clientErr  error
 	clientOnce sync.Once
 )
 
-// Returns Harbor v2 client
-func GetClient() *v2client.HarborAPI {
+// GetClient returns the Harbor v2 client or an error if initialization fails.
+func GetClient() (*v2client.HarborAPI, error) {
 	clientOnce.Do(func() {
 		cfg := env.GC.Harbor
 		clientConfig := &harbor.ClientSetConfig{
@@ -22,16 +23,20 @@ func GetClient() *v2client.HarborAPI {
 			Username: cfg.Username,
 			Password: cfg.Password,
 		}
-		client = GetClientByConfig(clientConfig)
+		client, clientErr = GetClientByConfig(clientConfig)
 	})
 
-	return client
+	if clientErr != nil {
+		return nil, clientErr
+	}
+	return client, nil
 }
 
-func GetClientByConfig(clientConfig *harbor.ClientSetConfig) *v2client.HarborAPI {
+// GetClientByConfig initializes and returns the Harbor client set using the configuration.
+func GetClientByConfig(clientConfig *harbor.ClientSetConfig) (*v2client.HarborAPI, error) {
 	cs, err := harbor.NewClientSet(clientConfig)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return cs.V2()
+	return cs.V2(), nil
 }

--- a/internal/groundcontrol/harbor/client_test.go
+++ b/internal/groundcontrol/harbor/client_test.go
@@ -1,0 +1,21 @@
+package harbor
+
+import (
+	"testing"
+
+	"github.com/goharbor/go-client/pkg/harbor"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetClientByConfig_ErrorOnInvalidConfig(t *testing.T) {
+	// Provide an invalid URL that fails parsing in NewClientSet
+	invalidConfig := &harbor.ClientSetConfig{
+		URL:      "://invalid-url",
+		Username: "admin",
+		Password: "password",
+	}
+
+	client, err := GetClientByConfig(invalidConfig)
+	require.Error(t, err, "expected error on invalid config URL")
+	require.Nil(t, client, "expected client to be nil on error")
+}

--- a/internal/groundcontrol/harbor/project.go
+++ b/internal/groundcontrol/harbor/project.go
@@ -11,7 +11,10 @@ import (
 )
 
 func GetProject(ctx context.Context, name string) (bool, error) {
-	client := GetClient()
+	client, err := GetClient()
+	if err != nil {
+		return false, fmt.Errorf("getting harbor client: %w", err)
+	}
 	proj, err := client.Project.HeadProject(ctx, &project.HeadProjectParams{
 		ProjectName: name,
 	})
@@ -26,7 +29,10 @@ func GetProject(ctx context.Context, name string) (bool, error) {
 }
 
 func CreateSatelliteProject(ctx context.Context) (bool, error) {
-	client := GetClient()
+	client, err := GetClient()
+	if err != nil {
+		return false, fmt.Errorf("getting harbor client: %w", err)
+	}
 	var (
 		public  = true
 		storage = int64(-1)

--- a/internal/groundcontrol/harbor/replication.go
+++ b/internal/groundcontrol/harbor/replication.go
@@ -9,7 +9,10 @@ import (
 )
 
 func ListReplication(ctx context.Context, opts ListParams) ([]*models.ReplicationPolicy, error) {
-	client := GetClient()
+	client, err := GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("getting harbor client: %w", err)
+	}
 	response, err := client.Replication.ListReplicationPolicies(
 		ctx,
 		&replication.ListReplicationPoliciesParams{

--- a/internal/groundcontrol/harbor/robot.go
+++ b/internal/groundcontrol/harbor/robot.go
@@ -21,7 +21,10 @@ func GetRobotDetails(r *robot.CreateRobotCreated) (int64, string, string, int64)
 }
 
 func IsRobotPresent(ctx context.Context, name string) (bool, error) {
-	client := GetClient()
+	client, err := GetClient()
+	if err != nil {
+		return false, fmt.Errorf("getting harbor client: %w", err)
+	}
 
 	name = fmt.Sprintf("name=%s", name)
 	response, err := client.Robot.ListRobot(
@@ -42,7 +45,10 @@ func IsRobotPresent(ctx context.Context, name string) (bool, error) {
 }
 
 func ListRobots(ctx context.Context, opts ListParams) (*robot.ListRobotOK, error) {
-	client := GetClient()
+	client, err := GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("getting harbor client: %w", err)
+	}
 	response, err := client.Robot.ListRobot(
 		ctx,
 		&robot.ListRobotParams{
@@ -59,7 +65,10 @@ func ListRobots(ctx context.Context, opts ListParams) (*robot.ListRobotOK, error
 }
 
 func DeleteRobotAccount(ctx context.Context, robotID int64) (*robot.DeleteRobotOK, error) {
-	client := GetClient()
+	client, err := GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("getting harbor client: %w", err)
+	}
 	response, err := client.Robot.DeleteRobot(
 		ctx,
 		&robot.DeleteRobotParams{
@@ -73,7 +82,10 @@ func DeleteRobotAccount(ctx context.Context, robotID int64) (*robot.DeleteRobotO
 }
 
 func RefreshRobotAccount(ctx context.Context, secret string, robotID int64) (*robot.RefreshSecOK, error) {
-	client := GetClient()
+	client, err := GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("getting harbor client: %w", err)
+	}
 	response, err := client.Robot.RefreshSec(
 		ctx,
 		&robot.RefreshSecParams{
@@ -90,7 +102,10 @@ func RefreshRobotAccount(ctx context.Context, secret string, robotID int64) (*ro
 }
 
 func UpdateRobotAccount(ctx context.Context, opts *models.Robot) (*robot.UpdateRobotOK, error) {
-	client := GetClient()
+	client, err := GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("getting harbor client: %w", err)
+	}
 	response, err := client.Robot.UpdateRobot(
 		ctx,
 		&robot.UpdateRobotParams{
@@ -105,7 +120,10 @@ func UpdateRobotAccount(ctx context.Context, opts *models.Robot) (*robot.UpdateR
 }
 
 func GetRobotAccount(ctx context.Context, id int64) (*models.Robot, error) {
-	client := GetClient()
+	client, err := GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("getting harbor client: %w", err)
+	}
 	response, err := client.Robot.GetRobotByID(
 		ctx,
 		&robot.GetRobotByIDParams{
@@ -119,7 +137,10 @@ func GetRobotAccount(ctx context.Context, id int64) (*models.Robot, error) {
 }
 
 func CreateRobotAccount(ctx context.Context, opts *models.RobotCreate) (*robot.CreateRobotCreated, error) {
-	client := GetClient()
+	client, err := GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("getting harbor client: %w", err)
+	}
 	response, err := client.Robot.CreateRobot(
 		ctx,
 		&robot.CreateRobotParams{


### PR DESCRIPTION
This PR resolves #552 by refactoring Harbor client initialization to safely propagate errors up the call stack rather than panicking and crashing the process.

### Changes:
1. Updated `GetClient` and `GetClientByConfig` to return `(*v2client.HarborAPI, error)`.
2. Handled client initialization errors across all helper functions in `project.go`, `replication.go`, and `robot.go`.
3. Added a new unit test `TestGetClientByConfig_ErrorOnInvalidConfig` to assert correct error propagation on failure.

Closes #552


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Harbor connection setup errors are now reported clearly instead of causing failures or being hidden.
  * Project, replication, and robot operations stop safely when Harbor initialization fails.
  * Invalid Harbor configurations now return an error without creating a client.

* **Tests**
  * Added coverage for invalid Harbor URL configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->