### PR TITLE
chore: remove obsolete go-swagger tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,7 +5,6 @@ vars:
   GOLANGCILINT_VERSION: "v2.12.2"
   GOVULNCHECK_VERSION: "v1.1.4"
   GORELEASER_VERSION: "v2.9.0"
-  GO_SWAGGER_VERSION: "v0.35.0"
   OAPI_CODEGEN_VERSION: "de2d8b2b0afb287198554eb305bb0d2687d26a85"
   OAPI_CODEGEN_RELEASE_VERSION: "v2.8.0"
   PLATFORMS_LINUX: "amd64 arm64 ppc64le s390x riscv64"
@@ -72,31 +71,6 @@ tasks:
     desc: Run vulnerability check and export to file
     cmds:
       - task: _lint:vulnerability-check-report
-
-  swagger:install:
-    desc: Install pinned go-swagger binary
-    env:
-      GOBIN: "{{.BIN_DIR}}"
-    cmds:
-      - mkdir -p {{.BIN_DIR}}
-      - go install github.com/go-swagger/go-swagger/cmd/swagger@{{.GO_SWAGGER_VERSION}}
-    status:
-      - test -x {{.BIN_DIR}}/swagger
-      - "{{.BIN_DIR}}/swagger version | grep -q '{{.GO_SWAGGER_VERSION}}'"
-
-  swagger:generate:
-    desc: Generate Ground Control OpenAPI specs
-    dir: "{{.ROOT_DIR}}/ground-control"
-    cmds:
-      - task: swagger:install
-      - "{{.BIN_DIR}}/swagger generate spec -i meta.yml -o swagger.yml"
-      - "{{.BIN_DIR}}/swagger flatten --format yaml --with-flatten=remove-unused -o swagger-flatten.yml swagger.yml"
-    sources:
-      - meta.yml
-      - "**/*.go"
-    generates:
-      - swagger.yml
-      - swagger-flatten.yml
 
   generate:ground-control:
     desc: Generate Ground Control OpenAPI server and client code

--- a/taskfiles/README.md
+++ b/taskfiles/README.md
@@ -46,13 +46,13 @@ task e2e
 
 ## Code Generation Tasks
 
-Ground Control API code is generated from `spec/ground-control/openapi.yaml` with oapi-codegen. This is the only supported generation workflow.
+Ground Control API code is generated from `spec/groundcontrol/openapi.yaml` with oapi-codegen. This is the only supported generation workflow.
 
 | Command | Description |
 |---------|-------------|
-| `task generate:ground-control` | Generate Ground Control OpenAPI server and client code |
-| `task generate:ground-control-server` | Generate server code into `internal/groundcontrol/server/server.gen.go` |
-| `task generate:ground-control-client` | Generate client code into `pkg/groundcontrol/client.gen.go` |
+| `task generate:groundcontrol` | Generate Ground Control OpenAPI server and client code |
+| `task generate:groundcontrol-server` | Generate server code into `internal/groundcontrol/server/server.gen.go` |
+| `task generate:groundcontrol-client` | Generate client code into `pkg/groundcontrol/client.gen.go` |
 
 ## Publish Tasks
 

--- a/taskfiles/README.md
+++ b/taskfiles/README.md
@@ -44,6 +44,16 @@ task e2e
 | `task vuln` | Run govulncheck (filters known issues) |
 | `task vuln-report` | Run govulncheck and export to file |
 
+## Code Generation Tasks
+
+Ground Control API code is generated from `spec/ground-control/openapi.yaml` with oapi-codegen. This is the only supported generation workflow.
+
+| Command | Description |
+|---------|-------------|
+| `task generate:ground-control` | Generate Ground Control OpenAPI server and client code |
+| `task generate:ground-control-server` | Generate server code into `internal/groundcontrol/server/server.gen.go` |
+| `task generate:ground-control-client` | Generate client code into `pkg/groundcontrol/client.gen.go` |
+
 ## Publish Tasks
 
 | Command | Description |


### PR DESCRIPTION
The Taskfile had two API generation workflows pointing opposite ways. go-swagger reads Go annotations and writes a spec, oapi-codegen reads the spec and writes Go. Since Ground Control moved to spec-first, the go-swagger tasks have just been sitting there with no way to tell which one is the real path.

They also cannot run. swagger:generate sets dir to ground-control and reads meta.yml, and neither is in the repo anymore.

Removed GO_SWAGGER_VERSION, swagger:install and swagger:generate. Nothing referenced them. Added a code generation section to the taskfiles README since it documented build, lint, publish and e2e but not generation.

Checked with `task generate:ground-control` that both generated files come back byte identical without go-swagger installed, so the removed path really was unused.

Left the swaggo/http-swagger line in go.mod alone, that is a different project and it is indirect.

Closes #590

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for the OpenAPI code-generation workflow.
  * Documented commands for generating server and client code.

* **Chores**
  * Removed obsolete Swagger installation and generation tasks from the task runner configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->