### PR TITLE
fix(spiffe): fail fast on configuration mismatch in nospiffe builds

### DIFF
--- a/internal/groundcontrol/spiffe/middleware_stub.go
+++ b/internal/groundcontrol/spiffe/middleware_stub.go
@@ -29,7 +29,7 @@ func RequireSPIFFEAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotImplemented)
-		if err := json.NewEncoder(w).Encode(map[string]string{"error": "SPIFFE not available in this build"}); err != nil {
+		if err := json.NewEncoder(w).Encode(map[string]string{"error": "SPIFFE authentication is not compiled into this build. Please configure and use token-based authentication fallback instead."}); err != nil {
 			http.Error(w, "failed to encode response", http.StatusInternalServerError)
 		}
 	})

--- a/internal/groundcontrol/spiffe/provider_stub.go
+++ b/internal/groundcontrol/spiffe/provider_stub.go
@@ -7,12 +7,13 @@ import (
 	"crypto/tls"
 	"errors"
 
+	"github.com/container-registry/harbor-satellite/internal/env"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
 )
 
-var ErrSPIFFENotAvailable = errors.New("SPIFFE not available in this build")
+var ErrSPIFFENotAvailable = errors.New("SPIFFE support not compiled in (nospiffe build)")
 
 // Provider defines the interface for obtaining SPIFFE credentials.
 type Provider interface {
@@ -30,12 +31,23 @@ type Config struct {
 	EndpointSocket string
 }
 
-// LoadConfig returns config with SPIFFE disabled.
+// LoadConfig loads SPIFFE configuration from environment variables.
 func LoadConfig() *Config {
-	return &Config{Enabled: false}
+	cfg := env.GC.SPIFFE
+
+	return &Config{
+		Enabled:        cfg.Enabled,
+		TrustDomain:    cfg.TrustDomain,
+		ProviderType:   cfg.Provider,
+		EndpointSocket: cfg.EndpointSocket,
+	}
 }
 
-// NewProvider returns an error since SPIFFE is not available.
-func NewProvider(_ *Config) (Provider, error) {
-	return nil, ErrSPIFFENotAvailable
+// NewProvider returns a nil provider and no error if SPIFFE is disabled.
+// If SPIFFE is enabled in configuration, it returns ErrSPIFFENotAvailable because SPIFFE is not supported in this build.
+func NewProvider(cfg *Config) (Provider, error) {
+	if cfg.Enabled {
+		return nil, ErrSPIFFENotAvailable
+	}
+	return nil, nil
 }

--- a/internal/groundcontrol/spiffe/provider_stub_test.go
+++ b/internal/groundcontrol/spiffe/provider_stub_test.go
@@ -1,0 +1,47 @@
+//go:build nospiffe
+
+package spiffe
+
+import (
+	"testing"
+
+	"github.com/container-registry/harbor-satellite/internal/env"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProviderStub_LoadConfig(t *testing.T) {
+	// Keep track of the original configuration
+	previous := env.GC
+	defer func() {
+		env.GC = previous
+	}()
+
+	t.Setenv("SPIFFE_SERVER_ENABLED", "true")
+	t.Setenv("SPIFFE_TRUST_DOMAIN", "example.org")
+	t.Setenv("SPIFFE_PROVIDER", "sidecar")
+	t.Setenv("SPIFFE_ENDPOINT_SOCKET", "unix:///tmp/spire-agent/public/api.sock")
+
+	err := env.LoadGC()
+	require.NoError(t, err)
+
+	cfg := LoadConfig()
+	require.True(t, cfg.Enabled)
+	require.Equal(t, "example.org", cfg.TrustDomain)
+	require.Equal(t, "sidecar", cfg.ProviderType)
+	require.Equal(t, "unix:///tmp/spire-agent/public/api.sock", cfg.EndpointSocket)
+
+	// Verify NewProvider returns ErrSPIFFENotAvailable when Enabled is true
+	provider, err := NewProvider(cfg)
+	require.ErrorIs(t, err, ErrSPIFFENotAvailable)
+	require.Nil(t, provider)
+
+	// Verify NewProvider returns nil when Enabled is false
+	t.Setenv("SPIFFE_SERVER_ENABLED", "false")
+	err = env.LoadGC()
+	require.NoError(t, err)
+
+	cfg = LoadConfig()
+	provider, err = NewProvider(cfg)
+	require.NoError(t, err)
+	require.Nil(t, provider)
+}


### PR DESCRIPTION
This PR resolves #570 by refactoring the `nospiffe` build configuration checks. 

### Changes:
1. Updated `LoadConfig()` in `provider_stub.go` to parse the actual environment/file config.
2. Updated `NewProvider()` to fail-fast at startup with a clear `ErrSPIFFENotAvailable` error if the user has SPIFFE enabled but runs a `nospiffe` compiled binary.
3. Improved runtime message in `RequireSPIFFEAuth` to direct users to configure/use the token-based registration fallback instead.
4. Added `provider_stub_test.go` to test and cover these stub configurations when compiled with the `nospiffe` tag.

Closes #570


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved messaging when SPIFFE authentication is unavailable, including guidance to use token-based authentication instead.
  - Corrected behavior for builds without SPIFFE support: SPIFFE configuration is respected, and an explicit error is returned only when SPIFFE is enabled but unavailable.
  - When SPIFFE is disabled, the application now continues without reporting an unnecessary provider error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->