### PR TITLE
docs(website): fix broken .md links and add Table of Contents right sidebar

### DIFF
--- a/website/assets/css/main.css
+++ b/website/assets/css/main.css
@@ -538,12 +538,60 @@
   /* ---------- Docs Layout ---------- */
   .docs-layout {
     display: grid;
-    grid-template-columns: var(--sidebar-width) 1fr;
+    grid-template-columns: var(--sidebar-width) 1fr 220px;
     max-width: var(--max-width);
     margin: 0 auto;
     padding: calc(var(--navbar-height) + var(--space-2xl)) var(--space-xl) var(--space-3xl);
-    gap: var(--space-3xl);
+    gap: var(--space-2xl);
     min-height: 100vh;
+  }
+
+  /* ---------- Docs Table of Contents (Right Panel) ---------- */
+  .docs-toc {
+    position: sticky;
+    top: calc(var(--navbar-height) + var(--space-2xl));
+    height: fit-content;
+    max-height: calc(100vh - var(--navbar-height) - var(--space-3xl));
+    overflow-y: auto;
+    padding-left: var(--space-lg);
+    border-left: 1px solid oklch(0.2 0.04 260 / 0.08);
+  }
+
+  .docs-toc__title {
+    font-size: var(--text-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-ink-subtle);
+    margin-bottom: var(--space-md);
+  }
+
+  .docs-toc #TableOfContents ul {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+  }
+
+  .docs-toc #TableOfContents ul ul {
+    padding-left: var(--space-md);
+    margin-top: var(--space-xs);
+  }
+
+  .docs-toc #TableOfContents li {
+    margin-bottom: var(--space-xs);
+  }
+
+  .docs-toc #TableOfContents a {
+    font-size: var(--text-xs);
+    color: var(--color-ink-muted);
+    text-decoration: none;
+    transition: color 0.15s;
+    display: block;
+    line-height: 1.5;
+  }
+
+  .docs-toc #TableOfContents a:hover {
+    color: var(--color-teal);
   }
 
   /* ---------- Docs Sidebar ---------- */
@@ -1165,6 +1213,16 @@
   .hero__actions {
     justify-content: center;
   }
+
+@media (max-width: 1100px) {
+  .docs-layout {
+    grid-template-columns: var(--sidebar-width) 1fr;
+  }
+
+  .docs-toc {
+    display: none;
+  }
+}
 
   .hero__visual {
     order: -1;

--- a/website/assets/css/main.css
+++ b/website/assets/css/main.css
@@ -1199,6 +1199,16 @@
 /* ============================================================
    RESPONSIVE - Outside layers for specificity
    ============================================================ */
+@media (max-width: 1100px) {
+  .docs-layout {
+    grid-template-columns: var(--sidebar-width) 1fr;
+  }
+
+  .docs-toc {
+    display: none;
+  }
+}
+
 @media (max-width: 1024px) {
   .hero__container {
     grid-template-columns: 1fr;
@@ -1214,15 +1224,7 @@
     justify-content: center;
   }
 
-@media (max-width: 1100px) {
-  .docs-layout {
-    grid-template-columns: var(--sidebar-width) 1fr;
-  }
 
-  .docs-toc {
-    display: none;
-  }
-}
 
   .hero__visual {
     order: -1;

--- a/website/layouts/_default/_markup/render-link.html
+++ b/website/layouts/_default/_markup/render-link.html
@@ -1,18 +1,19 @@
 {{- $u := urls.Parse .Destination -}}
 {{- $href := $u.String -}}
 {{- if not $u.IsAbs -}}
-  {{- /* Try to get the page based on the path */ -}}
-  {{- $path := strings.TrimSuffix ".md" $u.Path -}}
-  {{- with .Page.GetPage $path -}}
-    {{- $href = .RelPermalink -}}
-    {{- if $u.Fragment -}}
-      {{- $href = printf "%s#%s" $href $u.Fragment -}}
-    {{- end -}}
-  {{- else -}}
-    {{- /* If GetPage fails, do a simple text replacement as fallback */ -}}
-    {{- if strings.HasSuffix $u.Path ".md" -}}
-      {{- $href = replace $href ".md" "/" -}}
-    {{- end -}}
-  {{- end -}}
+{{- /* Try to get the page based on the path */ -}}
+{{- $path := strings.TrimSuffix ".md" $u.Path -}}
+{{- with .Page.GetPage $path -}}
+{{- $href = .RelPermalink -}}
+{{- if $u.Fragment -}}
+{{- $href = printf "%s#%s" $href $u.Fragment -}}
 {{- end -}}
-<a href="{{ $href | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}{{ if $u.IsAbs }} target="_blank" rel="noopener noreferrer"{{ end }}>{{ .Text | safeHTML }}</a>
+{{- else -}}
+{{- /* If GetPage fails, do a simple text replacement as fallback */ -}}
+{{- if strings.HasSuffix $u.Path ".md" -}}
+{{- $href = replace $href ".md" "/" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+<a href="{{ $href | safeURL }}" {{ with .Title }} title="{{ . }}" {{ end }}{{ if $u.IsAbs }} target="_blank"
+  rel="noopener noreferrer" {{ end }}>{{ .Text | safeHTML }}</a>

--- a/website/layouts/_default/_markup/render-link.html
+++ b/website/layouts/_default/_markup/render-link.html
@@ -1,0 +1,18 @@
+{{- $u := urls.Parse .Destination -}}
+{{- $href := $u.String -}}
+{{- if not $u.IsAbs -}}
+  {{- /* Try to get the page based on the path */ -}}
+  {{- $path := strings.TrimSuffix ".md" $u.Path -}}
+  {{- with .Page.GetPage $path -}}
+    {{- $href = .RelPermalink -}}
+    {{- if $u.Fragment -}}
+      {{- $href = printf "%s#%s" $href $u.Fragment -}}
+    {{- end -}}
+  {{- else -}}
+    {{- /* If GetPage fails, do a simple text replacement as fallback */ -}}
+    {{- if strings.HasSuffix $u.Path ".md" -}}
+      {{- $href = replace $href ".md" "/" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+<a href="{{ $href | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}{{ if $u.IsAbs }} target="_blank" rel="noopener noreferrer"{{ end }}>{{ .Text | safeHTML }}</a>

--- a/website/layouts/_default/_markup/render-link.html
+++ b/website/layouts/_default/_markup/render-link.html
@@ -3,6 +3,14 @@
 {{- if not $u.IsAbs -}}
 {{- /* Try to get the page based on the path */ -}}
 {{- $path := strings.TrimSuffix ".md" $u.Path -}}
+{{- if strings.HasSuffix $path "_index" -}}
+  {{- $path = strings.TrimSuffix "_index" $path -}}
+  {{- if eq $path "" -}}
+    {{- $path = "." -}}
+  {{- else -}}
+    {{- $path = strings.TrimSuffix "/" $path -}}
+  {{- end -}}
+{{- end -}}
 {{- with .Page.GetPage $path -}}
 {{- $href = .RelPermalink -}}
 {{- if $u.Fragment -}}

--- a/website/layouts/docs/list.html
+++ b/website/layouts/docs/list.html
@@ -10,5 +10,6 @@
     <h1>{{ .Title }}</h1>
     {{ .Content }}
   </article>
+  {{- partial "docs-toc.html" . -}}
 </div>
 {{ end }}

--- a/website/layouts/docs/single.html
+++ b/website/layouts/docs/single.html
@@ -10,5 +10,6 @@
     <h1>{{ .Title }}</h1>
     {{ .Content }}
   </article>
+  {{- partial "docs-toc.html" . -}}
 </div>
 {{ end }}

--- a/website/layouts/partials/docs-toc.html
+++ b/website/layouts/partials/docs-toc.html
@@ -1,0 +1,6 @@
+{{- if and .TableOfContents (ne .TableOfContents "<nav id=\"TableOfContents\"></nav>") -}}
+<aside class="docs-toc">
+  <div class="docs-toc__title">On this page</div>
+  {{ .TableOfContents }}
+</aside>
+{{- end -}}


### PR DESCRIPTION
- Fixes: #606 

## Description
- **Fix Broken Markdown Links**: Added a Hugo link render hook at `website/layouts/_default/_markup/render-link.html`. This automatically converts Markdown `.md` links into Hugo permalinks (preventing 404 errors on the live site) without altering source `.md` files so GitHub repository previews remain intact.
- **Added Table of Contents (Right Panel)**: Created a `docs-toc.html` partial and updated `docs` layouts + CSS grid to render a sticky "On this page" right sidebar for quick navigation on long doc pages.
- **Responsive Layout**: Added media queries to cleanly hide the TOC sidebar on mobile and smaller viewports.

## Verification
- Tested locally with `hugo server`.
- Verified internal links (`/docs/installation/` -> `/docs/quickstart/`) navigate correctly without 404 errors.
- Verified external links (`https://spiffe.io`) open in a new tab with `target="_blank"`.
- Verified sticky TOC sidebar renders on desktop and hides on screens smaller than 1100px.

### Fixes proof -

https://github.com/user-attachments/assets/d392dbe3-6819-4579-b9ab-5f71b95caaee



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sticky, scrollable table of contents to documentation pages, with nested heading support.
  * Documentation navigation hides on smaller screens for a cleaner layout.
* **Improvements**
  * Improved Markdown link handling for relative paths, fragments, and fallback URL resolution.
  * External links now open safely in a new browser tab.
  * The table of contents appears only when relevant navigation is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->