### PR TITLE
fix(spiffe): refuse client creation on missing expected server ID

### DIFF
--- a/internal/satellite/satellite.go
+++ b/internal/satellite/satellite.go
@@ -83,7 +83,11 @@ func (s *Satellite) Run(ctx context.Context) error {
 	stateScheduler.Start(ctx)
 
 	// Create status report scheduler with pending CRI results
-	statusReportProcess := state.NewStatusReportingProcess(s.cm)
+	statusReportProcess, err := state.NewStatusReportingProcess(s.cm)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to create status report process")
+		return err
+	}
 	if len(s.criResults) > 0 {
 		statusReportProcess.SetPendingCRIResults(s.criResults)
 	}

--- a/internal/satellite/state/reporting_process.go
+++ b/internal/satellite/state/reporting_process.go
@@ -29,7 +29,7 @@ type StatusReportingProcess struct {
 	criReported  bool
 }
 
-func NewStatusReportingProcess(cm *config.ConfigManager) *StatusReportingProcess {
+func NewStatusReportingProcess(cm *config.ConfigManager) (*StatusReportingProcess, error) {
 	p := &StatusReportingProcess{
 		name: config.StatusReportJobName,
 		mu:   &sync.Mutex{},
@@ -43,12 +43,13 @@ func NewStatusReportingProcess(cm *config.ConfigManager) *StatusReportingProcess
 			EndpointSocket:   spiffeCfg.EndpointSocket,
 			ExpectedServerID: spiffeCfg.ExpectedServerID,
 		})
-		if err == nil {
-			p.spiffeClient = client
+		if err != nil {
+			return nil, fmt.Errorf("create SPIFFE client: %w", err)
 		}
+		p.spiffeClient = client
 	}
 
-	return p
+	return p, nil
 }
 
 // SetPendingCRIResults stores CRI config results to be sent in the first heartbeat.

--- a/internal/satellite/state/reporting_process_test.go
+++ b/internal/satellite/state/reporting_process_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -256,3 +257,83 @@ func TestExecute_CRIReporting(t *testing.T) {
 		p.mu.Unlock()
 	})
 }
+
+func TestNewStatusReportingProcess(t *testing.T) {
+	t.Run("SPIFFE disabled succeeds", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg := &config.Config{
+			AppConfig: config.AppConfig{
+				SPIFFE: config.SPIFFEConfig{
+					Enabled: false,
+				},
+			},
+		}
+		cm, err := config.NewConfigManager(
+			filepath.Join(dir, "config.json"),
+			filepath.Join(dir, "prev.json"),
+			"token", "http://gc", false, cfg,
+		)
+		require.NoError(t, err)
+
+		proc, err := NewStatusReportingProcess(cm)
+		require.NoError(t, err)
+		require.NotNil(t, proc)
+		require.Nil(t, proc.spiffeClient)
+	})
+
+	t.Run("SPIFFE enabled with expected server ID", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg := &config.Config{
+			AppConfig: config.AppConfig{
+				SPIFFE: config.SPIFFEConfig{
+					Enabled:          true,
+					ExpectedServerID: "spiffe://example.org/gc/main",
+				},
+			},
+		}
+		cm, err := config.NewConfigManager(
+			filepath.Join(dir, "config.json"),
+			filepath.Join(dir, "prev.json"),
+			"token", "http://gc", false, cfg,
+		)
+		require.NoError(t, err)
+
+		proc, err := NewStatusReportingProcess(cm)
+		if err != nil {
+			require.Contains(t, err.Error(), "SPIFFE not available")
+			require.Nil(t, proc)
+		} else {
+			require.NotNil(t, proc)
+			require.NotNil(t, proc.spiffeClient)
+		}
+	})
+
+	t.Run("SPIFFE enabled without expected server ID fails", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg := &config.Config{
+			AppConfig: config.AppConfig{
+				SPIFFE: config.SPIFFEConfig{
+					Enabled:          true,
+					ExpectedServerID: "",
+				},
+			},
+		}
+		cm, err := config.NewConfigManager(
+			filepath.Join(dir, "config.json"),
+			filepath.Join(dir, "prev.json"),
+			"token", "http://gc", false, cfg,
+		)
+		require.NoError(t, err)
+
+		proc, err := NewStatusReportingProcess(cm)
+		require.Error(t, err)
+		require.Nil(t, proc)
+		if err != nil {
+			errStr := err.Error()
+			isExpectedServerIDErr := strings.Contains(errStr, "expected server ID must be configured")
+			isSpiffeNotAvailableErr := strings.Contains(errStr, "SPIFFE not available")
+			require.True(t, isExpectedServerIDErr || isSpiffeNotAvailableErr, "unexpected error: %s", errStr)
+		}
+	})
+}
+

--- a/internal/spiffe/client.go
+++ b/internal/spiffe/client.go
@@ -48,13 +48,13 @@ func NewClient(cfg Config) (*Client, error) {
 		return nil, fmt.Errorf("SPIFFE is not enabled")
 	}
 
-	var serverID spiffeid.ID
-	if cfg.ExpectedServerID != "" {
-		var err error
-		serverID, err = spiffeid.FromString(cfg.ExpectedServerID)
-		if err != nil {
-			return nil, fmt.Errorf("invalid expected server ID %q: %w", cfg.ExpectedServerID, err)
-		}
+	if cfg.ExpectedServerID == "" {
+		return nil, fmt.Errorf("expected server ID must be configured when SPIFFE is enabled")
+	}
+
+	serverID, err := spiffeid.FromString(cfg.ExpectedServerID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid expected server ID %q: %w", cfg.ExpectedServerID, err)
 	}
 
 	return &Client{
@@ -126,12 +126,7 @@ func (c *Client) GetTLSConfig() (*tls.Config, error) {
 		return nil, fmt.Errorf("client not connected")
 	}
 
-	var authorizer tlsconfig.Authorizer
-	if !c.expectedServerID.IsZero() {
-		authorizer = tlsconfig.AuthorizeID(c.expectedServerID)
-	} else {
-		authorizer = tlsconfig.AuthorizeAny()
-	}
+	authorizer := tlsconfig.AuthorizeID(c.expectedServerID)
 
 	return tlsconfig.MTLSClientConfig(c.x509Source, c.x509Source, authorizer), nil
 }

--- a/internal/spiffe/client_test.go
+++ b/internal/spiffe/client_test.go
@@ -1,0 +1,65 @@
+//go:build !nospiffe
+
+package spiffe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClient(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr string
+	}{
+		{
+			name: "SPIFFE disabled",
+			cfg: Config{
+				Enabled: false,
+			},
+			wantErr: "SPIFFE is not enabled",
+		},
+		{
+			name: "SPIFFE enabled, empty ExpectedServerID",
+			cfg: Config{
+				Enabled:          true,
+				ExpectedServerID: "",
+			},
+			wantErr: "expected server ID must be configured when SPIFFE is enabled",
+		},
+		{
+			name: "SPIFFE enabled, invalid ExpectedServerID",
+			cfg: Config{
+				Enabled:          true,
+				ExpectedServerID: "not-a-valid-spiffe-id",
+			},
+			wantErr: "invalid expected server ID",
+		},
+		{
+			name: "SPIFFE enabled, valid ExpectedServerID",
+			cfg: Config{
+				Enabled:          true,
+				ExpectedServerID: "spiffe://example.org/gc/main",
+			},
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewClient(tt.cfg)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+				require.Nil(t, client)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, client)
+				require.Equal(t, tt.cfg.EndpointSocket, client.socketPath)
+				require.Equal(t, tt.cfg.ExpectedServerID, client.expectedServerID.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR resolves #589 by enforcing that `ExpectedServerID` is non-empty when SPIFFE is enabled on the satellite side.

### Changes:
1. Updated `NewClient(cfg Config)` in `internal/spiffe/client.go` to return an error if SPIFFE is enabled but `ExpectedServerID` is empty.
2. Cleaned up `GetTLSConfig()` in `internal/spiffe/client.go` to remove the insecure `tlsconfig.AuthorizeAny()` fallback path.
3. Added `client_test.go` to cover config validation and error scenarios.

Closes #589


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened SPIFFE-enabled connection security by requiring a valid expected server identity.
  * Connections now reject servers that do not match the configured identity instead of accepting any server.

* **Tests**
  * Added coverage for disabled SPIFFE, missing or invalid identities, and valid client configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->