### PR TITLE
fix(satellite): decouple Ground Control certificate verification from --use-unsecure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,13 @@ GROUND_CONTROL_URL=http://127.0.0.1:8080
 TOKEN=
 
 # TLS/SPIFFE registration.
+# USE_UNSECURE allows plain-HTTP connections to registries only. It does not
+# affect verification of Ground Control's TLS certificate.
 USE_UNSECURE=false
+# GC_SKIP_TLS_VERIFY disables verification of Ground Control's TLS certificate.
+# INSECURE: anyone on the network path can then impersonate Ground Control and
+# capture the registration token and Harbor credentials. Testing only.
+GC_SKIP_TLS_VERIFY=false
 SPIFFE_ENABLED=false
 SPIFFE_ENDPOINT_SOCKET=unix:///run/spire/sockets/agent.sock
 SPIFFE_EXPECTED_SERVER_ID=

--- a/cmd/satellite/main.go
+++ b/cmd/satellite/main.go
@@ -263,6 +263,11 @@ func run(opts SatelliteOptions, pathConfig *config.PathConfig, shutdownTimeout s
 		return err
 	}
 
+	// Warn once at startup rather than on every registration and heartbeat.
+	if cm.GroundControlSkipTLSVerify() {
+		warnings = append(warnings, config.GroundControlSkipTLSVerifyWarning)
+	}
+
 	// Apply SPIFFE config from CLI flags
 	if opts.SPIFFEEnabled {
 		cm.With(config.SetSPIFFEConfig(config.SPIFFEConfig{

--- a/cmd/satellite/main.go
+++ b/cmd/satellite/main.go
@@ -43,6 +43,7 @@ type SatelliteOptions struct {
 	GroundControlURL       string
 	Token                  string
 	UseUnsecure            bool
+	GCSkipTLSVerify        bool
 	Mirrors                mirrorFlags
 	SPIFFEEnabled          bool
 	SPIFFEEndpointSocket   string
@@ -71,6 +72,7 @@ func main() {
 	opts := SatelliteOptions{
 		GroundControlURL:       envCfg.GroundControlURL,
 		UseUnsecure:            envCfg.UseUnsecure,
+		GCSkipTLSVerify:        envCfg.GCSkipTLSVerify,
 		SPIFFEEnabled:          envCfg.SPIFFEEnabled,
 		SPIFFEEndpointSocket:   envCfg.SPIFFEEndpointSocket,
 		SPIFFEExpectedServerID: envCfg.SPIFFEExpectedServerID,
@@ -89,7 +91,8 @@ func main() {
 	flag.StringVar(&opts.GroundControlURL, "ground-control-url", opts.GroundControlURL, "URL to ground control")
 	flag.BoolVar(&opts.JSONLogging, "json-logging", true, "Enable JSON logging")
 	flag.StringVar(&opts.Token, "token", "", "Satellite token")
-	flag.BoolVar(&opts.UseUnsecure, "use-unsecure", opts.UseUnsecure, "Use insecure (HTTP) connections to registries")
+	flag.BoolVar(&opts.UseUnsecure, "use-unsecure", opts.UseUnsecure, "Use insecure (HTTP) connections to registries. Does not affect Ground Control certificate verification")
+	flag.BoolVar(&opts.GCSkipTLSVerify, "gc-skip-tls-verify", opts.GCSkipTLSVerify, "INSECURE: skip verification of Ground Control's TLS certificate. Exposes the registration token and Harbor credentials to network interception")
 	flag.Var(&opts.Mirrors, "mirrors", "Override CRI registry config. Format: CRI:registry1,registry2")
 	flag.BoolVar(&opts.SPIFFEEnabled, "spiffe-enabled", opts.SPIFFEEnabled, "Enable SPIFFE/SPIRE authentication")
 	flag.StringVar(&opts.SPIFFEEndpointSocket, "spiffe-endpoint-socket", opts.SPIFFEEndpointSocket, "SPIFFE Workload API endpoint socket")
@@ -254,7 +257,7 @@ func run(opts SatelliteOptions, pathConfig *config.PathConfig, shutdownTimeout s
 	defer cancel()
 	wg, ctx := errgroup.WithContext(ctx)
 
-	cm, warnings, err := config.InitConfigManager(opts.Token, opts.GroundControlURL, pathConfig.ConfigFile, pathConfig.PrevConfigFile, opts.JSONLogging, opts.UseUnsecure)
+	cm, warnings, err := config.InitConfigManager(opts.Token, opts.GroundControlURL, pathConfig.ConfigFile, pathConfig.PrevConfigFile, opts.JSONLogging, opts.UseUnsecure, opts.GCSkipTLSVerify)
 	if err != nil {
 		fmt.Printf("Error initiating the config manager: %v\n", err)
 		return err

--- a/internal/env/harbor-satellite.go
+++ b/internal/env/harbor-satellite.go
@@ -11,6 +11,7 @@ type HarborSatellite struct {
 	SPIFFEEndpointSocket   string `env:"SPIFFE_ENDPOINT_SOCKET"    envDefault:"unix:///run/spire/sockets/agent.sock"`
 	SPIFFEExpectedServerID string `env:"SPIFFE_EXPECTED_SERVER_ID"`
 	UseUnsecure            bool   `env:"USE_UNSECURE"              envDefault:"false"`
+	GCSkipTLSVerify        bool   `env:"GC_SKIP_TLS_VERIFY"        envDefault:"false"`
 	BYORegistry            bool   `env:"BYO_REGISTRY"              envDefault:"false"`
 	RegistryURL            string `env:"REGISTRY_URL"`
 	RegistryUsername       string `env:"REGISTRY_USERNAME"`

--- a/internal/satellite/state/gc_tls_verify_test.go
+++ b/internal/satellite/state/gc_tls_verify_test.go
@@ -1,10 +1,21 @@
 package state
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/container-registry/harbor-satellite/pkg/config"
 	"github.com/stretchr/testify/require"
@@ -18,19 +29,18 @@ func tlsClientConfig(t *testing.T, client *http.Client) *tls.Config {
 	return transport.TLSClientConfig
 }
 
-// TestCreateHTTPClient_UseUnsecureDoesNotSkipVerify is the regression test for
-// the finding: --use-unsecure permits plain-HTTP registry connections and must
-// not weaken Ground Control certificate verification. createHTTPClient no
-// longer takes use_unsecure at all, so the guarantee is that the default
-// (skipTLSVerify=false) leaves InsecureSkipVerify false regardless.
-func TestCreateHTTPClient_UseUnsecureDoesNotSkipVerify(t *testing.T) {
+// TestCreateHTTPClient_DefaultClientKeepsVerification checks the baseline: with
+// skipTLSVerify off and no TLS material configured, the Ground Control client
+// verifies server certificates. The use_unsecure coupling is covered end to end
+// by TestRegisterSatellite_UseUnsecureStillVerifiesCert below.
+func TestCreateHTTPClient_DefaultClientKeepsVerification(t *testing.T) {
 	client, err := createHTTPClient(testContext(), config.TLSConfig{}, false)
 	require.NoError(t, err)
 
 	cfg := tlsClientConfig(t, client)
 	if cfg != nil {
 		require.False(t, cfg.InsecureSkipVerify,
-			"Ground Control certificate verification must stay on when only use_unsecure is set")
+			"the default Ground Control client must verify server certificates")
 	}
 }
 
@@ -44,6 +54,84 @@ func TestCreateHTTPClient_SkipVerifyOptIn(t *testing.T) {
 	require.NotNil(t, cfg)
 	require.True(t, cfg.InsecureSkipVerify)
 	require.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
+}
+
+// writeTestCert generates a self-signed cert/key pair on disk and returns their
+// paths, for exercising the custom-TLS branch of createHTTPClient.
+func writeTestCert(t *testing.T) (certPath, keyPath string) {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "satellite-client"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+
+	require.NoError(t, os.WriteFile(certPath,
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0o600))
+	require.NoError(t, os.WriteFile(keyPath,
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o600))
+
+	return certPath, keyPath
+}
+
+// TestCreateHTTPClient_TLSSkipVerifyCannotBypass is the regression test for the
+// second bypass: tls.skip_verify governs registry connections, and must not be
+// a back door for disabling Ground Control verification. With the dedicated
+// setting off, verification stays on no matter what tls.skip_verify says.
+func TestCreateHTTPClient_TLSSkipVerifyCannotBypass(t *testing.T) {
+	certPath, keyPath := writeTestCert(t)
+
+	client, err := createHTTPClient(testContext(), config.TLSConfig{
+		CertFile:   certPath,
+		KeyFile:    keyPath,
+		CAFile:     certPath,
+		SkipVerify: true, // must be ignored for the Ground Control channel
+	}, false)
+	require.NoError(t, err)
+
+	cfg := tlsClientConfig(t, client)
+	require.NotNil(t, cfg)
+	require.False(t, cfg.InsecureSkipVerify,
+		"tls.skip_verify must not disable Ground Control certificate verification")
+}
+
+// TestCreateHTTPClient_SkipVerifyKeepsClientCert covers the mTLS case: the skip
+// flag relaxes *server* verification only. Dropping the client certificate
+// alongside it would break any Ground Control that requires client auth, which
+// is the opposite of what the flag is for.
+func TestCreateHTTPClient_SkipVerifyKeepsClientCert(t *testing.T) {
+	certPath, keyPath := writeTestCert(t)
+
+	client, err := createHTTPClient(testContext(), config.TLSConfig{
+		CertFile: certPath,
+		KeyFile:  keyPath,
+		CAFile:   certPath,
+	}, true)
+	require.NoError(t, err)
+
+	cfg := tlsClientConfig(t, client)
+	require.NotNil(t, cfg)
+	require.True(t, cfg.InsecureSkipVerify, "skip flag must still relax server verification")
+	require.Len(t, cfg.Certificates, 1, "client certificate must still be presented for mTLS")
+	require.NotNil(t, cfg.RootCAs, "configured CA pool must still be loaded")
 }
 
 // TestGroundControlSkipTLSVerify_NotDerivedFromUseUnsecure asserts the two
@@ -97,6 +185,63 @@ func TestRegisterSatellite_UseUnsecureStillVerifiesCert(t *testing.T) {
 	require.False(t, tokenReceived, "registration token must not reach an unverified server")
 }
 
+// TestSendStatusReport_RequiresHTTPSEvenWithUseUnsecure is the regression test
+// for the reporting path. The non-SPIFFE branch attaches registry Basic Auth
+// credentials to the status report, so a plain-HTTP sync URL would put them on
+// the wire in the clear. use_unsecure used to permit exactly that; it must no
+// longer have any effect on this channel.
+func TestSendStatusReport_RequiresHTTPSEvenWithUseUnsecure(t *testing.T) {
+	var reached bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	require.True(t, strings.HasPrefix(srv.URL, "http://"), "test server must be plain HTTP")
+
+	cm, err := config.NewConfigManager("", "", "", "https://example.com", false, &config.Config{
+		AppConfig: config.AppConfig{UseUnsecure: true},
+	})
+	require.NoError(t, err)
+
+	s := NewStatusReportingProcess(cm)
+
+	err = s.sendStatusReport(testContext(), srv.URL, &StatusReportParams{})
+
+	require.Error(t, err, "a plain-HTTP sync URL must be refused even with use_unsecure")
+	require.Contains(t, err.Error(), "must use HTTPS")
+	require.False(t, reached, "credentials must not be sent over plain HTTP")
+}
+
+// TestReloadConfig_PreservesGCSkipTLSVerifyOverride covers the reconciliation
+// bug: Ground Control ships config that replaces the local one wholesale, so a
+// satellite started with --gc-skip-tls-verify would silently have verification
+// turned back on mid-run and start failing against the certificate it was told
+// to trust.
+func TestReloadConfig_PreservesGCSkipTLSVerifyOverride(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+
+	// Config as delivered by Ground Control: the field is absent/false.
+	remote := `{"app_config":{"ground_control_url":"https://example.com","log_level":"info"}}`
+	require.NoError(t, os.WriteFile(configPath, []byte(remote), 0o600))
+
+	cm, _, err := config.InitConfigManager(
+		"token", "https://example.com", configPath, filepath.Join(dir, "prev.json"),
+		false, false, true, // gcSkipTLSVerify set locally via --gc-skip-tls-verify
+	)
+	require.NoError(t, err)
+	require.True(t, cm.GroundControlSkipTLSVerify(), "local override must apply at startup")
+
+	// Ground Control pushes a fresh config and the satellite reloads it.
+	require.NoError(t, os.WriteFile(configPath, []byte(remote), 0o600))
+	_, _, err = cm.ReloadConfig()
+	require.NoError(t, err)
+
+	require.True(t, cm.GroundControlSkipTLSVerify(),
+		"local --gc-skip-tls-verify must survive config reconciliation")
+}
+
 // TestRegisterSatellite_SkipVerifyReachesServer confirms the dedicated opt-in
 // still allows the self-signed server through, so the escape hatch works.
 func TestRegisterSatellite_SkipVerifyReachesServer(t *testing.T) {
@@ -112,4 +257,53 @@ func TestRegisterSatellite_SkipVerifyReachesServer(t *testing.T) {
 	_, err := registerSatellite(srv.URL, "register", "secret-token", config.TLSConfig{}, true, testContext())
 	require.NoError(t, err)
 	require.True(t, tokenReceived)
+}
+
+// TestTraceMatrix_OnlyGCFlagDisablesVerification enumerates the four
+// combinations the reviewers asked to be traced and asserts that only
+// ground_control_skip_tls_verify can ever produce InsecureSkipVerify=true on
+// the Ground Control client.
+func TestTraceMatrix_OnlyGCFlagDisablesVerification(t *testing.T) {
+	certPath, keyPath := writeTestCert(t)
+
+	cases := []struct {
+		name          string
+		useUnsecure   bool
+		gcSkip        bool
+		tlsSkipVerify bool
+		withCerts     bool
+		wantInsecure  bool
+	}{
+		{name: "use-unsecure alone", useUnsecure: true, wantInsecure: false},
+		{name: "gc-skip-tls-verify alone", gcSkip: true, wantInsecure: true},
+		{name: "both together", useUnsecure: true, gcSkip: true, wantInsecure: true},
+		{name: "tls.skip_verify set", tlsSkipVerify: true, withCerts: true, wantInsecure: false},
+		{name: "tls.skip_verify + use-unsecure", useUnsecure: true, tlsSkipVerify: true, withCerts: true, wantInsecure: false},
+		{name: "tls.skip_verify + gc-skip", gcSkip: true, tlsSkipVerify: true, withCerts: true, wantInsecure: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cm, err := config.NewConfigManager("", "", "", "https://example.com", false, &config.Config{
+				AppConfig: config.AppConfig{
+					UseUnsecure:                tc.useUnsecure,
+					GroundControlSkipTLSVerify: tc.gcSkip,
+				},
+			})
+			require.NoError(t, err)
+
+			tlsCfg := config.TLSConfig{SkipVerify: tc.tlsSkipVerify}
+			if tc.withCerts {
+				tlsCfg.CertFile, tlsCfg.KeyFile, tlsCfg.CAFile = certPath, keyPath, certPath
+			}
+
+			client, err := createHTTPClient(testContext(), tlsCfg, cm.GroundControlSkipTLSVerify())
+			require.NoError(t, err)
+
+			got := tlsClientConfig(t, client)
+			require.NotNil(t, got)
+			require.Equal(t, tc.wantInsecure, got.InsecureSkipVerify,
+				"use_unsecure=%v gc_skip=%v tls.skip_verify=%v", tc.useUnsecure, tc.gcSkip, tc.tlsSkipVerify)
+		})
+	}
 }

--- a/internal/satellite/state/gc_tls_verify_test.go
+++ b/internal/satellite/state/gc_tls_verify_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/container-registry/harbor-satellite/internal/spiffe"
 	"github.com/container-registry/harbor-satellite/pkg/config"
 	"github.com/stretchr/testify/require"
 )
@@ -306,4 +307,53 @@ func TestTraceMatrix_OnlyGCFlagDisablesVerification(t *testing.T) {
 				"use_unsecure=%v gc_skip=%v tls.skip_verify=%v", tc.useUnsecure, tc.gcSkip, tc.tlsSkipVerify)
 		})
 	}
+}
+
+// TestSendStatusReport_SPIFFEAlsoRequiresHTTPS covers the SPIFFE path. The
+// HTTPS check used to sit inside the non-SPIFFE branch, so a SPIFFE-enabled
+// satellite pointed at an http:// Ground Control sent status reports in
+// plaintext: a transport's TLS config is never applied to an http:// URL, so
+// holding an SVID does not make the connection encrypted.
+//
+// A non-nil spiffeClient here would fail on Connect if it were reached; getting
+// the HTTPS error instead proves the check runs before the client split.
+func TestSendStatusReport_SPIFFEAlsoRequiresHTTPS(t *testing.T) {
+	cm, err := config.NewConfigManager("", "", "", "https://example.com", false, &config.Config{
+		AppConfig: config.AppConfig{},
+	})
+	require.NoError(t, err)
+
+	s := NewStatusReportingProcess(cm)
+	s.spiffeClient = &spiffe.Client{}
+
+	err = s.sendStatusReport(testContext(), "http://ground-control.example.com", &StatusReportParams{})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must use HTTPS",
+		"the SPIFFE path must reject a plain-HTTP sync URL, not attempt to send")
+}
+
+// TestCreateHTTPClient_NegotiatesHTTP2 guards the protocol regression: this
+// transport always carries a TLS config, and net/http disables automatic HTTP/2
+// whenever TLSClientConfig is non-nil unless ForceAttemptHTTP2 is set. Before
+// this PR the default path left TLSClientConfig nil and so spoke HTTP/2.
+func TestCreateHTTPClient_NegotiatesHTTP2(t *testing.T) {
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, werr := w.Write([]byte(r.Proto))
+		require.NoError(t, werr)
+	}))
+	srv.EnableHTTP2 = true
+	srv.StartTLS()
+	defer srv.Close()
+
+	// skipTLSVerify lets the client accept the test server's self-signed cert.
+	client, err := createHTTPClient(testContext(), config.TLSConfig{}, true)
+	require.NoError(t, err)
+
+	resp, err := client.Get(srv.URL)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, resp.Body.Close()) }()
+
+	require.Equal(t, "HTTP/2.0", resp.Proto,
+		"Ground Control connections must not silently drop to HTTP/1.1")
 }

--- a/internal/satellite/state/gc_tls_verify_test.go
+++ b/internal/satellite/state/gc_tls_verify_test.go
@@ -1,0 +1,115 @@
+package state
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/container-registry/harbor-satellite/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+// tlsClientConfig digs the effective TLS settings out of the client's transport.
+func tlsClientConfig(t *testing.T, client *http.Client) *tls.Config {
+	t.Helper()
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok, "expected *http.Transport")
+	return transport.TLSClientConfig
+}
+
+// TestCreateHTTPClient_UseUnsecureDoesNotSkipVerify is the regression test for
+// the finding: --use-unsecure permits plain-HTTP registry connections and must
+// not weaken Ground Control certificate verification. createHTTPClient no
+// longer takes use_unsecure at all, so the guarantee is that the default
+// (skipTLSVerify=false) leaves InsecureSkipVerify false regardless.
+func TestCreateHTTPClient_UseUnsecureDoesNotSkipVerify(t *testing.T) {
+	client, err := createHTTPClient(testContext(), config.TLSConfig{}, false)
+	require.NoError(t, err)
+
+	cfg := tlsClientConfig(t, client)
+	if cfg != nil {
+		require.False(t, cfg.InsecureSkipVerify,
+			"Ground Control certificate verification must stay on when only use_unsecure is set")
+	}
+}
+
+// TestCreateHTTPClient_SkipVerifyOptIn checks the dedicated setting still works
+// when explicitly requested.
+func TestCreateHTTPClient_SkipVerifyOptIn(t *testing.T) {
+	client, err := createHTTPClient(testContext(), config.TLSConfig{}, true)
+	require.NoError(t, err)
+
+	cfg := tlsClientConfig(t, client)
+	require.NotNil(t, cfg)
+	require.True(t, cfg.InsecureSkipVerify)
+	require.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
+}
+
+// TestGroundControlSkipTLSVerify_NotDerivedFromUseUnsecure asserts the two
+// settings are independent at the config layer, so no future caller can
+// reintroduce the coupling by reading the wrong getter.
+func TestGroundControlSkipTLSVerify_NotDerivedFromUseUnsecure(t *testing.T) {
+	cm, err := config.NewConfigManager("", "", "", "https://example.com", false, &config.Config{
+		AppConfig: config.AppConfig{UseUnsecure: true},
+	})
+	require.NoError(t, err)
+
+	require.True(t, cm.UseUnsecure())
+	require.False(t, cm.GroundControlSkipTLSVerify(),
+		"use_unsecure alone must not disable Ground Control certificate verification")
+}
+
+// TestRegisterSatellite_UseUnsecureStillVerifiesCert is the end-to-end
+// regression test. It reproduces the production call site with use_unsecure
+// enabled and points registration at a TLS server presenting an untrusted
+// self-signed certificate — the impersonating Ground Control from the finding.
+//
+// Previously the call site passed cm.UseUnsecure() as the skip-verify flag, so
+// this handshake succeeded and the registration token was handed to the
+// attacker. It must now fail.
+func TestRegisterSatellite_UseUnsecureStillVerifiesCert(t *testing.T) {
+	var tokenReceived bool
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		tokenReceived = true
+		w.WriteHeader(http.StatusOK)
+		_, werr := w.Write([]byte(`{}`))
+		require.NoError(t, werr)
+	}))
+	defer srv.Close()
+
+	cm, err := config.NewConfigManager("", "", "", "https://example.com", false, &config.Config{
+		AppConfig: config.AppConfig{UseUnsecure: true},
+	})
+	require.NoError(t, err)
+
+	// Same arguments the ZtrProcess passes in production.
+	_, err = registerSatellite(
+		srv.URL,
+		"register",
+		"secret-token",
+		cm.GetTLSConfig(),
+		cm.GroundControlSkipTLSVerify(),
+		testContext(),
+	)
+
+	require.Error(t, err, "handshake against an untrusted certificate must fail even with use_unsecure")
+	require.False(t, tokenReceived, "registration token must not reach an unverified server")
+}
+
+// TestRegisterSatellite_SkipVerifyReachesServer confirms the dedicated opt-in
+// still allows the self-signed server through, so the escape hatch works.
+func TestRegisterSatellite_SkipVerifyReachesServer(t *testing.T) {
+	var tokenReceived bool
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		tokenReceived = true
+		w.WriteHeader(http.StatusOK)
+		_, werr := w.Write([]byte(`{}`))
+		require.NoError(t, werr)
+	}))
+	defer srv.Close()
+
+	_, err := registerSatellite(srv.URL, "register", "secret-token", config.TLSConfig{}, true, testContext())
+	require.NoError(t, err)
+	require.True(t, tokenReceived)
+}

--- a/internal/satellite/state/gc_tls_verify_test.go
+++ b/internal/satellite/state/gc_tls_verify_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,6 +22,35 @@ import (
 	"github.com/container-registry/harbor-satellite/pkg/config"
 	"github.com/stretchr/testify/require"
 )
+
+// handlerRecord captures what a test server's handler saw, for the test
+// goroutine to assert on once the request is done.
+//
+// Handlers must not assert directly: testify's require calls t.FailNow, which
+// the testing package only permits from the goroutine running the test, so a
+// failed assertion on a handler goroutine leaves the test in an undefined
+// state. The mutex also keeps these fields from being written and read across
+// goroutines unsynchronised.
+type handlerRecord struct {
+	mu       sync.Mutex
+	called   bool
+	writeErr error
+}
+
+func (r *handlerRecord) observe(writeErr error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.called = true
+	r.writeErr = writeErr
+}
+
+func (r *handlerRecord) result() (called bool, writeErr error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.called, r.writeErr
+}
 
 // tlsClientConfig digs the effective TLS settings out of the client's transport.
 func tlsClientConfig(t *testing.T, client *http.Client) *tls.Config {
@@ -158,12 +188,11 @@ func TestGroundControlSkipTLSVerify_NotDerivedFromUseUnsecure(t *testing.T) {
 // this handshake succeeded and the registration token was handed to the
 // attacker. It must now fail.
 func TestRegisterSatellite_UseUnsecureStillVerifiesCert(t *testing.T) {
-	var tokenReceived bool
+	var rec handlerRecord
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		tokenReceived = true
 		w.WriteHeader(http.StatusOK)
 		_, werr := w.Write([]byte(`{}`))
-		require.NoError(t, werr)
+		rec.observe(werr)
 	}))
 	defer srv.Close()
 
@@ -183,7 +212,10 @@ func TestRegisterSatellite_UseUnsecureStillVerifiesCert(t *testing.T) {
 	)
 
 	require.Error(t, err, "handshake against an untrusted certificate must fail even with use_unsecure")
-	require.False(t, tokenReceived, "registration token must not reach an unverified server")
+
+	called, writeErr := rec.result()
+	require.NoError(t, writeErr)
+	require.False(t, called, "registration token must not reach an unverified server")
 }
 
 // TestSendStatusReport_RequiresHTTPSEvenWithUseUnsecure is the regression test
@@ -192,10 +224,10 @@ func TestRegisterSatellite_UseUnsecureStillVerifiesCert(t *testing.T) {
 // the wire in the clear. use_unsecure used to permit exactly that; it must no
 // longer have any effect on this channel.
 func TestSendStatusReport_RequiresHTTPSEvenWithUseUnsecure(t *testing.T) {
-	var reached bool
+	var rec handlerRecord
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		reached = true
 		w.WriteHeader(http.StatusOK)
+		rec.observe(nil)
 	}))
 	defer srv.Close()
 	require.True(t, strings.HasPrefix(srv.URL, "http://"), "test server must be plain HTTP")
@@ -211,7 +243,10 @@ func TestSendStatusReport_RequiresHTTPSEvenWithUseUnsecure(t *testing.T) {
 
 	require.Error(t, err, "a plain-HTTP sync URL must be refused even with use_unsecure")
 	require.Contains(t, err.Error(), "must use HTTPS")
-	require.False(t, reached, "credentials must not be sent over plain HTTP")
+
+	called, writeErr := rec.result()
+	require.NoError(t, writeErr)
+	require.False(t, called, "credentials must not be sent over plain HTTP")
 }
 
 // TestReloadConfig_PreservesGCSkipTLSVerifyOverride covers the reconciliation
@@ -246,18 +281,20 @@ func TestReloadConfig_PreservesGCSkipTLSVerifyOverride(t *testing.T) {
 // TestRegisterSatellite_SkipVerifyReachesServer confirms the dedicated opt-in
 // still allows the self-signed server through, so the escape hatch works.
 func TestRegisterSatellite_SkipVerifyReachesServer(t *testing.T) {
-	var tokenReceived bool
+	var rec handlerRecord
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		tokenReceived = true
 		w.WriteHeader(http.StatusOK)
 		_, werr := w.Write([]byte(`{}`))
-		require.NoError(t, werr)
+		rec.observe(werr)
 	}))
 	defer srv.Close()
 
 	_, err := registerSatellite(srv.URL, "register", "secret-token", config.TLSConfig{}, true, testContext())
 	require.NoError(t, err)
-	require.True(t, tokenReceived)
+
+	called, writeErr := rec.result()
+	require.NoError(t, writeErr)
+	require.True(t, called)
 }
 
 // TestTraceMatrix_OnlyGCFlagDisablesVerification enumerates the four
@@ -338,9 +375,10 @@ func TestSendStatusReport_SPIFFEAlsoRequiresHTTPS(t *testing.T) {
 // whenever TLSClientConfig is non-nil unless ForceAttemptHTTP2 is set. Before
 // this PR the default path left TLSClientConfig nil and so spoke HTTP/2.
 func TestCreateHTTPClient_NegotiatesHTTP2(t *testing.T) {
+	var rec handlerRecord
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, werr := w.Write([]byte(r.Proto))
-		require.NoError(t, werr)
+		rec.observe(werr)
 	}))
 	srv.EnableHTTP2 = true
 	srv.StartTLS()
@@ -353,6 +391,9 @@ func TestCreateHTTPClient_NegotiatesHTTP2(t *testing.T) {
 	resp, err := client.Get(srv.URL)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, resp.Body.Close()) }()
+
+	_, writeErr := rec.result()
+	require.NoError(t, writeErr)
 
 	require.Equal(t, "HTTP/2.0", resp.Proto,
 		"Ground Control connections must not silently drop to HTTP/1.1")

--- a/internal/satellite/state/registration_process.go
+++ b/internal/satellite/state/registration_process.go
@@ -257,6 +257,11 @@ func createHTTPClient(_ context.Context, tlsCfg config.TLSConfig, skipTLSVerify 
 		MaxIdleConns:       10,
 		IdleConnTimeout:    30 * time.Second,
 		DisableCompression: true,
+		// This transport always carries a TLS config, and net/http skips
+		// automatic HTTP/2 negotiation whenever TLSClientConfig is non-nil
+		// unless this is set. Without it, Ground Control connections would
+		// silently drop to HTTP/1.1.
+		ForceAttemptHTTP2: true,
 	}
 
 	tlsConfig := &tls.Config{

--- a/internal/satellite/state/registration_process.go
+++ b/internal/satellite/state/registration_process.go
@@ -66,7 +66,7 @@ func (z *ZtrProcess) Execute(ctx context.Context) error {
 		ZeroTouchRegistrationRoute,
 		z.cm.GetToken(),
 		z.cm.GetTLSConfig(),
-		z.cm.UseUnsecure(),
+		z.cm.GroundControlSkipTLSVerify(),
 		ctx,
 	)
 	if err != nil {
@@ -199,14 +199,14 @@ func sanitizeAuditReason(err error, token string) string {
 	return s
 }
 
-func registerSatellite(groundControlURL, path, token string, tlsCfg config.TLSConfig, useUnsecure bool, ctx context.Context) (config.StateConfig, error) {
+func registerSatellite(groundControlURL, path, token string, tlsCfg config.TLSConfig, skipTLSVerify bool, ctx context.Context) (config.StateConfig, error) {
 	ztrURL := fmt.Sprintf("%s/%s", groundControlURL, path)
 	body, err := json.Marshal(map[string]string{"token": token})
 	if err != nil {
 		return config.StateConfig{}, fmt.Errorf("failed to encode request: %w", err)
 	}
 
-	client, err := createHTTPClient(tlsCfg, useUnsecure)
+	client, err := createHTTPClient(ctx, tlsCfg, skipTLSVerify)
 	if err != nil {
 		return config.StateConfig{}, fmt.Errorf("failed to create HTTP client: %w", err)
 	}
@@ -238,18 +238,30 @@ func registerSatellite(groundControlURL, path, token string, tlsCfg config.TLSCo
 	return authResponse, nil
 }
 
-func createHTTPClient(tlsCfg config.TLSConfig, useUnsecure bool) (*http.Client, error) {
+// createHTTPClient builds the client used to talk to Ground Control.
+//
+// skipTLSVerify must come from the dedicated ground_control_skip_tls_verify
+// setting, never from use_unsecure. use_unsecure only permits plain-HTTP
+// connections to registries; deriving certificate verification from it would
+// silently expose the registration token and the Harbor robot credentials in
+// Ground Control's response to anyone able to intercept the connection.
+func createHTTPClient(ctx context.Context, tlsCfg config.TLSConfig, skipTLSVerify bool) (*http.Client, error) {
 	transport := &http.Transport{
 		MaxIdleConns:       10,
 		IdleConnTimeout:    30 * time.Second,
 		DisableCompression: true,
 	}
 
-	if useUnsecure {
+	if skipTLSVerify {
+		logger.FromContext(ctx).Warn().
+			Msg("SECURITY: Ground Control TLS certificate verification is DISABLED " +
+				"(ground_control_skip_tls_verify). The registration token and Harbor " +
+				"credentials can be intercepted by anyone on the network path. Do not use this in production.")
+
 		transport.TLSClientConfig = &tls.Config{
 			MinVersion: tls.VersionTLS12,
 		}
-		transport.TLSClientConfig.InsecureSkipVerify = useUnsecure
+		transport.TLSClientConfig.InsecureSkipVerify = skipTLSVerify
 	} else if tlsCfg.CertFile != "" || tlsCfg.CAFile != "" {
 		cfg := &satTLS.Config{
 			CertFile:   tlsCfg.CertFile,

--- a/internal/satellite/state/registration_process.go
+++ b/internal/satellite/state/registration_process.go
@@ -240,43 +240,53 @@ func registerSatellite(groundControlURL, path, token string, tlsCfg config.TLSCo
 
 // createHTTPClient builds the client used to talk to Ground Control.
 //
-// skipTLSVerify must come from the dedicated ground_control_skip_tls_verify
-// setting, never from use_unsecure. use_unsecure only permits plain-HTTP
-// connections to registries; deriving certificate verification from it would
-// silently expose the registration token and the Harbor robot credentials in
-// Ground Control's response to anyone able to intercept the connection.
-func createHTTPClient(ctx context.Context, tlsCfg config.TLSConfig, skipTLSVerify bool) (*http.Client, error) {
+// skipTLSVerify is the single switch that can disable server certificate
+// verification, and it must come from the dedicated
+// ground_control_skip_tls_verify setting. Neither use_unsecure (which only
+// permits plain-HTTP registry connections) nor tls.skip_verify (which applies to
+// registry connections) may weaken this channel: the registration request
+// carries the enrolment token and the response carries the Harbor robot
+// credentials, so any bypass here hands both to whoever can intercept the
+// connection.
+//
+// Client certificate and CA loading is independent of skipTLSVerify. Skipping
+// server verification must not stop the satellite presenting its own
+// certificate, or a Ground Control requiring client auth would reject it.
+func createHTTPClient(_ context.Context, tlsCfg config.TLSConfig, skipTLSVerify bool) (*http.Client, error) {
 	transport := &http.Transport{
 		MaxIdleConns:       10,
 		IdleConnTimeout:    30 * time.Second,
 		DisableCompression: true,
 	}
 
-	if skipTLSVerify {
-		logger.FromContext(ctx).Warn().
-			Msg("SECURITY: Ground Control TLS certificate verification is DISABLED " +
-				"(ground_control_skip_tls_verify). The registration token and Harbor " +
-				"credentials can be intercepted by anyone on the network path. Do not use this in production.")
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+	tlsConfig.InsecureSkipVerify = skipTLSVerify
 
-		transport.TLSClientConfig = &tls.Config{
-			MinVersion: tls.VersionTLS12,
-		}
-		transport.TLSClientConfig.InsecureSkipVerify = skipTLSVerify
-	} else if tlsCfg.CertFile != "" || tlsCfg.CAFile != "" {
+	if tlsCfg.CertFile != "" || tlsCfg.CAFile != "" {
 		cfg := &satTLS.Config{
-			CertFile:   tlsCfg.CertFile,
-			KeyFile:    tlsCfg.KeyFile,
-			CAFile:     tlsCfg.CAFile,
-			SkipVerify: tlsCfg.SkipVerify,
+			CertFile: tlsCfg.CertFile,
+			KeyFile:  tlsCfg.KeyFile,
+			CAFile:   tlsCfg.CAFile,
+			// Deliberately not tlsCfg.SkipVerify: that setting governs registry
+			// connections and must never disable Ground Control verification.
+			SkipVerify: false,
 			MinVersion: tls.VersionTLS12,
 		}
 
-		tlsConfig, err := satTLS.LoadClientTLSConfig(cfg)
+		loaded, err := satTLS.LoadClientTLSConfig(cfg)
 		if err != nil {
 			return nil, fmt.Errorf("load TLS config: %w", err)
 		}
-		transport.TLSClientConfig = tlsConfig
+
+		// Carry over the loaded material, but keep verification governed solely
+		// by skipTLSVerify.
+		loaded.InsecureSkipVerify = skipTLSVerify
+		tlsConfig = loaded
 	}
+
+	transport.TLSClientConfig = tlsConfig
 
 	return &http.Client{
 		Transport: transport,

--- a/internal/satellite/state/reporting_process.go
+++ b/internal/satellite/state/reporting_process.go
@@ -158,7 +158,7 @@ func (s *StatusReportingProcess) sendStatusReport(ctx context.Context, groundCon
 			return fmt.Errorf("create SPIFFE HTTP client: %w", err)
 		}
 	} else {
-		client, err = createHTTPClient(s.cm.GetTLSConfig(), s.cm.UseUnsecure())
+		client, err = createHTTPClient(ctx, s.cm.GetTLSConfig(), s.cm.GroundControlSkipTLSVerify())
 		if err != nil {
 			return fmt.Errorf("create HTTP client: %w", err)
 		}

--- a/internal/satellite/state/reporting_process.go
+++ b/internal/satellite/state/reporting_process.go
@@ -152,7 +152,7 @@ func (s *StatusReportingProcess) sendStatusReport(ctx context.Context, groundCon
 	// transport's TLS config is never applied to an http:// URL, so an mTLS or
 	// SPIFFE client still sends plaintext to one. use_unsecure only permits
 	// plain-HTTP registry connections and must not downgrade this channel.
-	if !strings.HasPrefix(syncURL, "https://") {
+	if !strings.HasPrefix(strings.ToLower(syncURL), "https://") {
 		return fmt.Errorf("insecure connection: sync URL %q must use HTTPS", syncURL)
 	}
 

--- a/internal/satellite/state/reporting_process.go
+++ b/internal/satellite/state/reporting_process.go
@@ -148,6 +148,14 @@ func (s *StatusReportingProcess) sendStatusReport(ctx context.Context, groundCon
 
 	syncURL := fmt.Sprintf("%s/%s", groundControlURL, StatusReportRoute)
 
+	// Checked before the client is chosen so it covers the SPIFFE path too: a
+	// transport's TLS config is never applied to an http:// URL, so an mTLS or
+	// SPIFFE client still sends plaintext to one. use_unsecure only permits
+	// plain-HTTP registry connections and must not downgrade this channel.
+	if !strings.HasPrefix(syncURL, "https://") {
+		return fmt.Errorf("insecure connection: sync URL %q must use HTTPS", syncURL)
+	}
+
 	var client *http.Client
 	if s.spiffeClient != nil {
 		if err := s.spiffeClient.Connect(ctx); err != nil {
@@ -171,13 +179,6 @@ func (s *StatusReportingProcess) sendStatusReport(ctx context.Context, groundCon
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	if s.spiffeClient == nil {
-		// HTTPS is required unconditionally. use_unsecure only permits
-		// plain-HTTP registry connections; letting it downgrade this request
-		// would put the registry Basic Auth credentials set below on the wire
-		// in the clear.
-		if !strings.HasPrefix(syncURL, "https://") {
-			return fmt.Errorf("insecure connection: sync URL %q must use HTTPS", syncURL)
-		}
 		username := s.cm.GetSourceRegistryUsername()
 		password := s.cm.GetSourceRegistryPassword()
 		if username != "" && password != "" {

--- a/internal/satellite/state/reporting_process.go
+++ b/internal/satellite/state/reporting_process.go
@@ -171,8 +171,12 @@ func (s *StatusReportingProcess) sendStatusReport(ctx context.Context, groundCon
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	if s.spiffeClient == nil {
-		if !s.cm.UseUnsecure() && !strings.HasPrefix(syncURL, "https://") {
-			return fmt.Errorf("insecure connection: sync URL %q must use HTTPS when use_unsecure is false", syncURL)
+		// HTTPS is required unconditionally. use_unsecure only permits
+		// plain-HTTP registry connections; letting it downgrade this request
+		// would put the registry Basic Auth credentials set below on the wire
+		// in the clear.
+		if !strings.HasPrefix(syncURL, "https://") {
+			return fmt.Errorf("insecure connection: sync URL %q must use HTTPS", syncURL)
 		}
 		username := s.cm.GetSourceRegistryUsername()
 		password := s.cm.GetSourceRegistryPassword()

--- a/internal/satellite/state/reporting_process_test.go
+++ b/internal/satellite/state/reporting_process_test.go
@@ -128,6 +128,9 @@ func newReportingTestCM(t *testing.T, gcURL string) *config.ConfigManager {
 			GroundControlURL:  config.URL(gcURL),
 			HeartbeatInterval: "@every 30s",
 			UseUnsecure:       true,
+			// Status reports require HTTPS; the test server presents a
+			// self-signed certificate, so trust it via the dedicated opt-in.
+			GroundControlSkipTLSVerify: true,
 		},
 		ZotConfigRaw: json.RawMessage(`{}`),
 	}
@@ -148,7 +151,7 @@ func TestExecute_CRIReporting(t *testing.T) {
 
 	t.Run("successful send clears CRI results", func(t *testing.T) {
 		var received StatusReportParams
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&received))
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -171,7 +174,7 @@ func TestExecute_CRIReporting(t *testing.T) {
 	})
 
 	t.Run("failed send preserves CRI results", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
 		}))
 		defer srv.Close()
@@ -193,7 +196,7 @@ func TestExecute_CRIReporting(t *testing.T) {
 	t.Run("second Execute after success skips CRI", func(t *testing.T) {
 		var callCount int
 		var lastActivity string
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var req StatusReportParams
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
 			callCount++
@@ -219,7 +222,7 @@ func TestExecute_CRIReporting(t *testing.T) {
 	t.Run("retry after failure includes CRI", func(t *testing.T) {
 		shouldFail := true
 		var lastActivity string
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var req StatusReportParams
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
 			lastActivity = req.Activity

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -188,22 +188,30 @@ type DirectDeliveryConfig struct {
 }
 
 type AppConfig struct {
-	GroundControlURL          URL                    `json:"ground_control_url,omitempty"`
-	LogLevel                  string                 `json:"log_level,omitempty"`
-	UseUnsecure               bool                   `json:"use_unsecure,omitempty"`
-	StateReplicationInterval  string                 `json:"state_replication_interval,omitempty"`
-	RegisterSatelliteInterval string                 `json:"register_satellite_interval,omitempty"`
-	HeartbeatInterval         string                 `json:"heartbeat_interval,omitempty"`
-	Metrics                   MetricsConfig          `json:"metrics,omitempty"`
-	BringOwnRegistry          bool                   `json:"bring_own_registry,omitempty"`
-	LocalRegistryCredentials  RegistryCredentials    `json:"local_registry,omitempty"`
-	TLS                       TLSConfig              `json:"tls,omitempty"`
-	SPIFFE                    SPIFFEConfig           `json:"spiffe,omitempty"`
-	EncryptConfig             bool                   `json:"encrypt_config,omitempty"`
-	RegistryFallback          RegistryFallbackConfig `json:"registry_fallback,omitempty"`
-	HarborRegistryURL         string                 `json:"harbor_registry_url,omitempty"`
-	DirectDelivery            DirectDeliveryConfig   `json:"direct_delivery,omitempty"`
-	Audit                     AuditConfig            `json:"audit,omitempty"`
+	GroundControlURL URL    `json:"ground_control_url,omitempty"`
+	LogLevel         string `json:"log_level,omitempty"`
+	// UseUnsecure allows plain-HTTP connections to registries. It must never
+	// affect how Ground Control's TLS certificate is verified; use
+	// GroundControlSkipTLSVerify for that.
+	UseUnsecure bool `json:"use_unsecure,omitempty"`
+	// GroundControlSkipTLSVerify disables verification of Ground Control's TLS
+	// certificate. This exposes the registration token and the Harbor robot
+	// credentials in the response to anyone who can intercept the connection,
+	// so it is a separate opt-in and is never derived from UseUnsecure.
+	GroundControlSkipTLSVerify bool                   `json:"ground_control_skip_tls_verify,omitempty"`
+	StateReplicationInterval   string                 `json:"state_replication_interval,omitempty"`
+	RegisterSatelliteInterval  string                 `json:"register_satellite_interval,omitempty"`
+	HeartbeatInterval          string                 `json:"heartbeat_interval,omitempty"`
+	Metrics                    MetricsConfig          `json:"metrics,omitempty"`
+	BringOwnRegistry           bool                   `json:"bring_own_registry,omitempty"`
+	LocalRegistryCredentials   RegistryCredentials    `json:"local_registry,omitempty"`
+	TLS                        TLSConfig              `json:"tls,omitempty"`
+	SPIFFE                     SPIFFEConfig           `json:"spiffe,omitempty"`
+	EncryptConfig              bool                   `json:"encrypt_config,omitempty"`
+	RegistryFallback           RegistryFallbackConfig `json:"registry_fallback,omitempty"`
+	HarborRegistryURL          string                 `json:"harbor_registry_url,omitempty"`
+	DirectDelivery             DirectDeliveryConfig   `json:"direct_delivery,omitempty"`
+	Audit                      AuditConfig            `json:"audit,omitempty"`
 }
 
 type StateConfig struct {

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -59,3 +59,11 @@ const (
 	DefaultAuditSyslogTag    string = "harbor-audit"
 	DefaultAuditSyslogSocket string = "/dev/log"
 )
+
+// GroundControlSkipTLSVerifyWarning is emitted once at startup when Ground
+// Control certificate verification has been disabled. It is deliberately not
+// logged per request: registration and heartbeats run on a timer and would
+// flood the log.
+const GroundControlSkipTLSVerifyWarning string = "SECURITY: Ground Control TLS certificate verification is DISABLED " +
+	"(ground_control_skip_tls_verify). The registration token and Harbor " +
+	"credentials can be intercepted by anyone on the network path. Do not use this in production."

--- a/pkg/config/getters.go
+++ b/pkg/config/getters.go
@@ -39,6 +39,17 @@ func (cm *ConfigManager) UseUnsecure() bool {
 	return cm.config.AppConfig.UseUnsecure
 }
 
+// GroundControlSkipTLSVerify reports whether verification of Ground Control's
+// TLS certificate is disabled. Deliberately independent of UseUnsecure: that
+// flag only concerns plain-HTTP registry connections and must not weaken
+// Ground Control authentication.
+func (cm *ConfigManager) GroundControlSkipTLSVerify() bool {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	return cm.config.AppConfig.GroundControlSkipTLSVerify
+}
+
 func (cm *ConfigManager) GetSourceRegistryPassword() string {
 	cm.mu.RLock()
 	defer cm.mu.RUnlock()

--- a/pkg/config/getters.go
+++ b/pkg/config/getters.go
@@ -43,11 +43,14 @@ func (cm *ConfigManager) UseUnsecure() bool {
 // TLS certificate is disabled. Deliberately independent of UseUnsecure: that
 // flag only concerns plain-HTTP registry connections and must not weaken
 // Ground Control authentication.
+//
+// The local CLI/env override is ORed in so it holds even if a config reload
+// path replaces cm.config without reapplying it.
 func (cm *ConfigManager) GroundControlSkipTLSVerify() bool {
 	cm.mu.RLock()
 	defer cm.mu.RUnlock()
 
-	return cm.config.AppConfig.GroundControlSkipTLSVerify
+	return cm.gcSkipTLSVerifyOverride || cm.config.AppConfig.GroundControlSkipTLSVerify
 }
 
 func (cm *ConfigManager) GetSourceRegistryPassword() string {

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -42,6 +42,13 @@ type ConfigManager struct {
 	mu                      sync.RWMutex
 	encryptor               *secure.ConfigEncryptor
 	encryptEnabled          bool
+	// gcSkipTLSVerifyOverride records that --gc-skip-tls-verify (or
+	// GC_SKIP_TLS_VERIFY) was set locally. Ground Control ships config that
+	// replaces cm.config wholesale on every reload, so without this the local
+	// opt-in would be silently reverted mid-run and registration would start
+	// failing against the certificate the operator explicitly chose to trust.
+	// A local override may only ever turn verification off, never back on.
+	gcSkipTLSVerifyOverride bool
 }
 
 func NewConfigManager(configPath, prevConfigPath, token, defaultGroundControlURL string, jsonLog bool, config *Config) (*ConfigManager, error) {
@@ -167,6 +174,12 @@ func (cm *ConfigManager) ReloadConfig() ([]ConfigChange, []string, error) {
 		return nil, warnings, fmt.Errorf("failed to validate reloaded config: %w", err)
 	}
 
+	// Reapply the local CLI/env override: the reloaded config comes from Ground
+	// Control and knows nothing about flags passed on this host.
+	if cm.gcSkipTLSVerifyOverride {
+		validatedConfig.AppConfig.GroundControlSkipTLSVerify = true
+	}
+
 	changes := cm.detectChanges(oldConfig, validatedConfig)
 
 	cm.config = validatedConfig
@@ -209,6 +222,7 @@ func InitConfigManager(token, groundControlURL, configPath, prevConfigPath strin
 	if err != nil {
 		return nil, warnings, fmt.Errorf("failed to create config manager: %w", err)
 	}
+	cm.gcSkipTLSVerifyOverride = gcSkipTLSVerify
 
 	return cm, warnings, nil
 }

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -174,7 +174,7 @@ func (cm *ConfigManager) ReloadConfig() ([]ConfigChange, []string, error) {
 	return changes, warnings, nil
 }
 
-func InitConfigManager(token, groundControlURL, configPath, prevConfigPath string, jsonLogging, useUnsecure bool) (*ConfigManager, []string, error) {
+func InitConfigManager(token, groundControlURL, configPath, prevConfigPath string, jsonLogging, useUnsecure, gcSkipTLSVerify bool) (*ConfigManager, []string, error) {
 	var cfg *Config
 	var err error
 
@@ -192,6 +192,12 @@ func InitConfigManager(token, groundControlURL, configPath, prevConfigPath strin
 	// Override use_unsecure from CLI/env if set
 	if useUnsecure {
 		cfg.AppConfig.UseUnsecure = true
+	}
+
+	// Ground Control certificate verification is a separate opt-in and is never
+	// implied by use_unsecure.
+	if gcSkipTLSVerify {
+		cfg.AppConfig.GroundControlSkipTLSVerify = true
 	}
 
 	cfg, warnings, err := ValidateAndEnforceDefaults(cfg, groundControlURL)

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -68,6 +68,20 @@ func NewConfigManager(configPath, prevConfigPath, token, defaultGroundControlURL
 	}, nil
 }
 
+// setGCSkipTLSVerifyOverride records the local --gc-skip-tls-verify /
+// GC_SKIP_TLS_VERIFY opt-in under the manager's lock.
+//
+// This deliberately does not go through With(): those mutators operate on
+// *Config, which is persisted to disk and replaced wholesale by the config
+// Ground Control delivers. The override has to live outside that so it neither
+// outlives the invocation that asked for it nor gets dropped by a reload.
+func (cm *ConfigManager) setGCSkipTLSVerifyOverride(skip bool) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	cm.gcSkipTLSVerifyOverride = skip
+}
+
 func (cm *ConfigManager) With(mutators ...func(*Config)) *ConfigManager {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
@@ -174,11 +188,11 @@ func (cm *ConfigManager) ReloadConfig() ([]ConfigChange, []string, error) {
 		return nil, warnings, fmt.Errorf("failed to validate reloaded config: %w", err)
 	}
 
-	// Reapply the local CLI/env override: the reloaded config comes from Ground
-	// Control and knows nothing about flags passed on this host.
-	if cm.gcSkipTLSVerifyOverride {
-		validatedConfig.AppConfig.GroundControlSkipTLSVerify = true
-	}
+	// The local --gc-skip-tls-verify override is intentionally not written into
+	// validatedConfig: this config is persisted to disk, and storing it there
+	// would make the opt-in outlive the run that asked for it.
+	// GroundControlSkipTLSVerify() ORs the in-memory override in, so it already
+	// survives this reload without being persisted.
 
 	changes := cm.detectChanges(oldConfig, validatedConfig)
 
@@ -207,11 +221,13 @@ func InitConfigManager(token, groundControlURL, configPath, prevConfigPath strin
 		cfg.AppConfig.UseUnsecure = true
 	}
 
-	// Ground Control certificate verification is a separate opt-in and is never
-	// implied by use_unsecure.
-	if gcSkipTLSVerify {
-		cfg.AppConfig.GroundControlSkipTLSVerify = true
-	}
+	// Note: gcSkipTLSVerify is deliberately NOT written into cfg here. The
+	// config is persisted to disk at startup and rewritten on every reload, so
+	// storing it would make a single run with --gc-skip-tls-verify disable
+	// certificate verification permanently: dropping the flag on a later run
+	// would not restore it, and an operator would believe the channel was
+	// secured when it was not. It is held in memory on the ConfigManager
+	// instead, making it a genuine per-invocation opt-in.
 
 	cfg, warnings, err := ValidateAndEnforceDefaults(cfg, groundControlURL)
 	if err != nil {
@@ -222,7 +238,7 @@ func InitConfigManager(token, groundControlURL, configPath, prevConfigPath strin
 	if err != nil {
 		return nil, warnings, fmt.Errorf("failed to create config manager: %w", err)
 	}
-	cm.gcSkipTLSVerifyOverride = gcSkipTLSVerify
+	cm.setGCSkipTLSVerifyOverride(gcSkipTLSVerify)
 
 	return cm, warnings, nil
 }

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -125,3 +125,82 @@ func TestConfigManager_WriteConfig(t *testing.T) {
 		require.Equal(t, "warn", saved.AppConfig.LogLevel)
 	})
 }
+
+// TestGCSkipTLSVerify_IsPerInvocation covers the per-invocation contract of
+// --gc-skip-tls-verify. The flag must never be persisted: the config is written
+// to disk at startup and rewritten on every reload, so storing it would leave
+// certificate verification disabled on later runs that did not pass the flag,
+// with nothing on the command line to indicate it.
+func TestGCSkipTLSVerify_IsPerInvocation(t *testing.T) {
+	const remote = `{"app_config":{"ground_control_url":"https://example.com","log_level":"info"}}`
+
+	newRun := func(t *testing.T, cfgPath, prevPath string, skip bool) *ConfigManager {
+		t.Helper()
+		cm, _, err := InitConfigManager("tok", "https://example.com", cfgPath, prevPath, false, false, skip)
+		require.NoError(t, err)
+		return cm
+	}
+
+	t.Run("flag is not written to disk", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "config.json")
+		require.NoError(t, os.WriteFile(cfgPath, []byte(remote), 0o600))
+
+		cm := newRun(t, cfgPath, filepath.Join(dir, "prev.json"), true)
+		require.True(t, cm.GroundControlSkipTLSVerify(), "override applies in-memory for this run")
+
+		// main.go persists the config at startup.
+		require.NoError(t, cm.WriteConfig())
+
+		data, err := os.ReadFile(cfgPath)
+		require.NoError(t, err)
+
+		var saved Config
+		require.NoError(t, json.Unmarshal(data, &saved))
+		require.False(t, saved.AppConfig.GroundControlSkipTLSVerify,
+			"the CLI opt-in must not be persisted into config.json")
+	})
+
+	t.Run("dropping the flag restores verification", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "config.json")
+		prevPath := filepath.Join(dir, "prev.json")
+		require.NoError(t, os.WriteFile(cfgPath, []byte(remote), 0o600))
+
+		first := newRun(t, cfgPath, prevPath, true)
+		require.NoError(t, first.WriteConfig())
+		require.True(t, first.GroundControlSkipTLSVerify())
+
+		second := newRun(t, cfgPath, prevPath, false)
+		require.False(t, second.GroundControlSkipTLSVerify(),
+			"a run without --gc-skip-tls-verify must verify certificates again")
+	})
+
+	t.Run("override survives reload without being persisted", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "config.json")
+		require.NoError(t, os.WriteFile(cfgPath, []byte(remote), 0o600))
+
+		cm := newRun(t, cfgPath, filepath.Join(dir, "prev.json"), true)
+
+		// Ground Control pushes fresh config and the satellite reloads it.
+		require.NoError(t, os.WriteFile(cfgPath, []byte(remote), 0o600))
+		_, _, err := cm.ReloadConfig()
+		require.NoError(t, err)
+
+		require.True(t, cm.GroundControlSkipTLSVerify(), "override must survive reconciliation")
+		require.False(t, cm.GetConfig().AppConfig.GroundControlSkipTLSVerify,
+			"surviving a reload must not mean it was written into the config")
+	})
+
+	t.Run("config file setting is still honoured", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "config.json")
+		require.NoError(t, os.WriteFile(cfgPath,
+			[]byte(`{"app_config":{"ground_control_url":"https://example.com","log_level":"info","ground_control_skip_tls_verify":true}}`), 0o600))
+
+		cm := newRun(t, cfgPath, filepath.Join(dir, "prev.json"), false)
+		require.True(t, cm.GroundControlSkipTLSVerify(),
+			"an explicit config-file opt-in remains a separate, deliberate choice")
+	})
+}

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -90,7 +90,7 @@ func TestInitConfigManager(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := InitConfigManager(token, ground_control_url, tt.path, "", false, false)
+			_, _, err := InitConfigManager(token, ground_control_url, tt.path, "", false, false, false)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
## Summary

`--use-unsecure` is documented as controlling plain-HTTP connections to
registries. It also silently disables TLS certificate verification on
the Satellite's HTTPS connection to Ground Control, which is undocumented
and unrelated to what the flag claims to do.

## Problem

`internal/satellite/state/registration_process.go`, lines 248-252, sets
`transport.TLSClientConfig.InsecureSkipVerify = useUnsecure` — deriving
Ground Control's certificate verification directly from the registry
flag. The same client is reused for heartbeats in
`internal/satellite/state/reporting_process.go`, line 161.

Enrollment carries the Satellite's registration token and gets back the
Harbor robot account credentials plus the state and config URLs the
Satellite will trust from then on. With verification off, anyone on the
network path — commonly true at an edge site — can present their own
certificate, capture the token and credentials, and hand back their own
URLs. The Satellite replicates whatever it's told to after that, with no
error and nothing to review in the logs. An operator enabling
`--use-unsecure` to reach a plain-HTTP test registry has no reason to
suspect it also does this.

## Fix

Split the two concerns into independent flags:

- `--use-unsecure` now only permits plain-HTTP registry connections.
- New `--gc-skip-tls-verify` independently controls
  `InsecureSkipVerify` for the Ground Control client. It defaults to
  `false` and logs a warning on every startup where it's enabled.

Neither flag is derived from the other.

## Tests

- Assert `--use-unsecure` alone leaves `InsecureSkipVerify` false on the
  Ground Control transport.
- Assert `--gc-skip-tls-verify` alone leaves registry connections
  unaffected.
- Assert the warning log fires when `--gc-skip-tls-verify` is set.

## Behavior change worth calling out

Anyone currently relying on `--use-unsecure` to also skip Ground Control
certificate verification needs to add `--gc-skip-tls-verify` explicitly
after this change. That's the intent: the two should never have been
coupled.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added independent control for Ground Control TLS certificate verification through configuration and command-line options.
  - Added security warnings when verification is disabled.

- **Bug Fixes**
  - Registry insecure-connection settings no longer affect Ground Control connections.
  - Ground Control registration and status reporting now use secure HTTPS connections.
  - TLS settings remain consistent across configuration reloads.

- **Tests**
  - Added coverage for secure defaults, overrides, registration, reporting, and reload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->