### PR TITLE
perf(groundcontrol): implement in-memory cache for satellite group states

### DIFF
--- a/internal/groundcontrol/server/config_handlers.go
+++ b/internal/groundcontrol/server/config_handlers.go
@@ -475,31 +475,15 @@ func (s *Server) SetSatelliteConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	groupList, err := q.SatelliteGroupList(r.Context(), sat.ID)
+	groupStates, err := s.getOrFillGroupStates(r.Context(), sat.ID, q)
 	if err != nil {
-		log.Printf("Could not get satellite group list: %v", err)
+		log.Printf("Could not get satellite group states: %v", err)
 		err := &AppError{
 			Message: "Error: Failed to Add satellite to config",
 			Code:    http.StatusInternalServerError,
 		}
 		HandleAppError(w, err)
 		return
-	}
-
-	// TODO: Store the groupStates in memory to survive hot reloads
-	var groupStates []string
-	for _, group := range groupList {
-		grp, err := q.GetGroupByID(r.Context(), group.GroupID)
-		if err != nil {
-			log.Printf("Error: Failed: %v", err)
-			err := &AppError{
-				Message: "Error: Failed to Add satellite to config",
-				Code:    http.StatusInternalServerError,
-			}
-			HandleAppError(w, err)
-			return
-		}
-		groupStates = append(groupStates, utils.AssembleGroupState(grp.GroupName))
 	}
 
 	err = createOrUpdateSatStateArtifact(r.Context(), sat.Name, groupStates, req.ConfigName)

--- a/internal/groundcontrol/server/group_cache_test.go
+++ b/internal/groundcontrol/server/group_cache_test.go
@@ -1,0 +1,84 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGroupStateCache(t *testing.T) {
+	s := &Server{} // Nil map originally
+
+	// Test lazy initialization and get/set
+	states, ok := s.getCachedGroupStates(1)
+	require.False(t, ok)
+	require.Nil(t, states)
+
+	s.setCachedGroupStates(1, []string{"state1", "state2"})
+	states, ok = s.getCachedGroupStates(1)
+	require.True(t, ok)
+	require.Equal(t, []string{"state1", "state2"}, states)
+
+	// Test invalidation
+	s.invalidateCachedGroupStates(1)
+	states, ok = s.getCachedGroupStates(1)
+	require.False(t, ok)
+
+	// Test clear
+	s.setCachedGroupStates(1, []string{"state1"})
+	s.setCachedGroupStates(2, []string{"state2"})
+	s.clearGroupStateCache()
+
+	states, ok = s.getCachedGroupStates(1)
+	require.False(t, ok)
+	states, ok = s.getCachedGroupStates(2)
+	require.False(t, ok)
+}
+
+func TestGetOrFillGroupStates(t *testing.T) {
+	server, mock := newMockServer(t)
+	
+	// Mock the DB queries on cache miss
+	mock.ExpectQuery("SELECT .+ FROM satellite_groups WHERE satellite_id").
+		WithArgs(int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"satellite_id", "group_id"}).AddRow(1, 10))
+		
+	mock.ExpectQuery("SELECT .+ FROM groups WHERE id").
+		WithArgs(int32(10)).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "group_name", "registry_url", "projects", "created_at", "updated_at"}).
+			AddRow(10, "test-group", "http://harbor", nil, time.Now(), time.Now()))
+
+	expectedStates := []string{"/satellite/group-state/test-group/state:latest"}
+
+	// First call (cache miss) -> queries DB
+	states, err := server.getOrFillGroupStates(context.Background(), 1, server.dbQueries)
+	require.NoError(t, err)
+	require.Equal(t, expectedStates, states)
+
+	// Second call (cache hit) -> does NOT query DB (no new expectations needed, mock will fail if any queries are executed)
+	states, err = server.getOrFillGroupStates(context.Background(), 1, server.dbQueries)
+	require.NoError(t, err)
+	require.Equal(t, expectedStates, states)
+
+	// Invalidate cache
+	server.invalidateCachedGroupStates(1)
+
+	// Third call (cache miss after invalidation) -> queries DB again
+	mock.ExpectQuery("SELECT .+ FROM satellite_groups WHERE satellite_id").
+		WithArgs(int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"satellite_id", "group_id"}).AddRow(1, 10))
+		
+	mock.ExpectQuery("SELECT .+ FROM groups WHERE id").
+		WithArgs(int32(10)).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "group_name", "registry_url", "projects", "created_at", "updated_at"}).
+			AddRow(10, "test-group", "http://harbor", nil, time.Now(), time.Now()))
+
+	states, err = server.getOrFillGroupStates(context.Background(), 1, server.dbQueries)
+	require.NoError(t, err)
+	require.Equal(t, expectedStates, states)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/groundcontrol/server/group_handlers.go
+++ b/internal/groundcontrol/server/group_handlers.go
@@ -306,6 +306,7 @@ func (s *Server) DeleteGroup(w http.ResponseWriter, r *http.Request, groupName s
 	}
 
 	committed = true
+	s.clearGroupStateCache()
 
 	err = utils.DeleteArtifact(utils.ConstructHarborDeleteURL(groupName, "group"))
 	if err != nil {

--- a/internal/groundcontrol/server/satellite_handlers.go
+++ b/internal/groundcontrol/server/satellite_handlers.go
@@ -1056,6 +1056,7 @@ func (s *Server) DeleteSatellite(w http.ResponseWriter, r *http.Request, satelli
 		return
 	}
 	committed = true
+	s.invalidateCachedGroupStates(sat.ID)
 
 	actor := "unknown"
 	if u, ok := GetUserFromContext(r.Context()); ok {
@@ -1258,6 +1259,7 @@ func (s *Server) AddSatelliteToGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	committed = true
+	s.invalidateCachedGroupStates(sat.ID)
 
 	WriteJSONResponse(w, http.StatusOK, map[string]string{"message": "Satellite successfully added to group"})
 }
@@ -1415,6 +1417,7 @@ func (s *Server) RemoveSatelliteFromGroup(w http.ResponseWriter, r *http.Request
 		return
 	}
 	committed = true
+	s.invalidateCachedGroupStates(sat.ID)
 
 	WriteJSONResponse(w, http.StatusOK, map[string]string{})
 }

--- a/internal/groundcontrol/server/server.go
+++ b/internal/groundcontrol/server/server.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	_ "github.com/lib/pq"
@@ -19,6 +20,7 @@ import (
 	auditlog "github.com/container-registry/harbor-satellite/internal/groundcontrol/logger"
 	"github.com/container-registry/harbor-satellite/internal/groundcontrol/middleware"
 	"github.com/container-registry/harbor-satellite/internal/groundcontrol/spiffe"
+	"github.com/container-registry/harbor-satellite/internal/groundcontrol/utils"
 )
 
 type Server struct {
@@ -52,6 +54,9 @@ type Server struct {
 	// from spoofing the audit source_ip. Enable only when GC sits behind a
 	// trusted reverse proxy.
 	trustForwardedHeaders bool
+
+	groupStateCache   map[int32][]string
+	groupStateCacheMu sync.RWMutex
 }
 
 // ServerTLSConfig holds TLS settings for the Ground Control HTTP server.
@@ -172,6 +177,8 @@ func NewServer() *ServerResult {
 		// Audit logger
 		audit:                 auditLogger,
 		trustForwardedHeaders: cfg.Audit.TrustForwardedHeaders,
+
+		groupStateCache: make(map[int32][]string),
 	}
 
 	// Bootstrap system admin user if not exists
@@ -259,4 +266,68 @@ func buildServerTLSConfigWithWatcher(cfg *ServerTLSConfig, cw *middleware.CertWa
 	}
 
 	return tlsConfig, nil
+}
+
+func (s *Server) getCachedGroupStates(satID int32) ([]string, bool) {
+	s.groupStateCacheMu.RLock()
+	defer s.groupStateCacheMu.RUnlock()
+	if s.groupStateCache == nil {
+		return nil, false
+	}
+	states, ok := s.groupStateCache[satID]
+	return states, ok
+}
+
+func (s *Server) setCachedGroupStates(satID int32, states []string) {
+	s.groupStateCacheMu.Lock()
+	defer s.groupStateCacheMu.Unlock()
+	if s.groupStateCache == nil {
+		s.groupStateCache = make(map[int32][]string)
+	}
+	s.groupStateCache[satID] = states
+}
+
+func (s *Server) invalidateCachedGroupStates(satID int32) {
+	s.groupStateCacheMu.Lock()
+	defer s.groupStateCacheMu.Unlock()
+	if s.groupStateCache == nil {
+		return
+	}
+	delete(s.groupStateCache, satID)
+}
+
+func (s *Server) clearGroupStateCache() {
+	s.groupStateCacheMu.Lock()
+	defer s.groupStateCacheMu.Unlock()
+	s.groupStateCache = make(map[int32][]string)
+}
+
+func (s *Server) getOrFillGroupStates(ctx context.Context, satID int32, q *database.Queries) ([]string, error) {
+	s.groupStateCacheMu.Lock()
+	defer s.groupStateCacheMu.Unlock()
+
+	if s.groupStateCache == nil {
+		s.groupStateCache = make(map[int32][]string)
+	}
+
+	if states, ok := s.groupStateCache[satID]; ok {
+		return states, nil
+	}
+
+	groupList, err := q.SatelliteGroupList(ctx, satID)
+	if err != nil {
+		return nil, err
+	}
+
+	groupStates := make([]string, 0, len(groupList))
+	for _, group := range groupList {
+		grp, err := q.GetGroupByID(ctx, group.GroupID)
+		if err != nil {
+			return nil, err
+		}
+		groupStates = append(groupStates, utils.AssembleGroupState(grp.GroupName))
+	}
+
+	s.groupStateCache[satID] = groupStates
+	return groupStates, nil
 }


### PR DESCRIPTION
This PR resolves #583 by implementing a thread-safe and nil-safe in-memory cache for satellite group states on the Ground Control `Server` struct.

### Changes:
1. Added `groupStateCache` map (`map[int32][]string`) and a `groupStateCacheMu` `sync.RWMutex` to the `Server` struct.
2. Checked the cache first in `SetSatelliteConfig()` and populated it on a cache miss.
3. Added cache invalidation logic on satellite/group modifications:
   - `DeleteSatellite`
   - `AddSatelliteToGroup`
   - `RemoveSatelliteFromGroup`
   - `DeleteGroup` (clears the cache)
4. Added `group_cache_test.go` verifying cache hits, lazy initialization, and invalidation.

Closes #583


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

