### PR TITLE
fix(state): handle deleted artifacts in satellite state replication

### DIFF
--- a/internal/satellite/state/replicator.go
+++ b/internal/satellite/state/replicator.go
@@ -59,6 +59,7 @@ type Entity struct {
 	Repository string `json:"repository"`
 	Tag        string `json:"tag"`
 	Digest     string `json:"digest"`
+	Deleted    bool   `json:"deleted,omitempty"`
 }
 
 func (e Entity) GetName() string {

--- a/internal/satellite/state/replicator.go
+++ b/internal/satellite/state/replicator.go
@@ -74,6 +74,10 @@ func (e Entity) GetTag() string {
 	return e.Tag
 }
 
+func (e Entity) Key() string {
+	return e.Repository + "|" + e.Name + "|" + e.Tag
+}
+
 // Replicate replicates images from the source registry to the local registry.
 // Before pulling, it checks which blobs already exist at the destination and
 // only downloads missing layers from source, saving bandwidth on crash recovery.

--- a/internal/satellite/state/state_process.go
+++ b/internal/satellite/state/state_process.go
@@ -185,7 +185,7 @@ func (f *FetchAndReplicateStateProcess) GetChanges(newState StateReader, log *ze
 	var entityToReplicate []Entity
 
 	if oldEntites == nil {
-		log.Warn().Msg("Old state has zero entities, replicating the complete state")
+		log.Warn().Msg("Old state has zero entities, replicating all non-deleted artifacts")
 		var nonDeletedEntities []Entity
 		for _, entity := range newEntites {
 			if !entity.Deleted {
@@ -197,13 +197,13 @@ func (f *FetchAndReplicateStateProcess) GetChanges(newState StateReader, log *ze
 
 	oldEntityMap := make(map[string]Entity)
 	for _, oldEntity := range oldEntites {
-		key := oldEntity.Name + "|" + oldEntity.Tag
+		key := oldEntity.Repository + "|" + oldEntity.Name + "|" + oldEntity.Tag
 		oldEntityMap[key] = oldEntity
 		log.Debug().Str("entity", key).Str("digest", oldEntity.Digest).Msg("Added old entity to lookup map")
 	}
 
 	for _, newEntity := range newEntites {
-		key := newEntity.Name + "|" + newEntity.Tag
+		key := newEntity.Repository + "|" + newEntity.Name + "|" + newEntity.Tag
 		oldEntity, exists := oldEntityMap[key]
 
 		if newEntity.Deleted {
@@ -234,7 +234,7 @@ func (f *FetchAndReplicateStateProcess) GetChanges(newState StateReader, log *ze
 
 	for _, oldEntity := range oldEntityMap {
 		if !oldEntity.Deleted {
-			key := oldEntity.Name + "|" + oldEntity.Tag
+			key := oldEntity.Repository + "|" + oldEntity.Name + "|" + oldEntity.Tag
 			log.Debug().Str("entity", key).Msg("Old entity no longer present, scheduling for deletion")
 			entityToDelete = append(entityToDelete, oldEntity)
 		}

--- a/internal/satellite/state/state_process.go
+++ b/internal/satellite/state/state_process.go
@@ -186,7 +186,13 @@ func (f *FetchAndReplicateStateProcess) GetChanges(newState StateReader, log *ze
 
 	if oldEntites == nil {
 		log.Warn().Msg("Old state has zero entities, replicating the complete state")
-		return entityToDelete, newEntites, newState
+		var nonDeletedEntities []Entity
+		for _, entity := range newEntites {
+			if !entity.Deleted {
+				nonDeletedEntities = append(nonDeletedEntities, entity)
+			}
+		}
+		return entityToDelete, nonDeletedEntities, newState
 	}
 
 	oldEntityMap := make(map[string]Entity)
@@ -200,8 +206,17 @@ func (f *FetchAndReplicateStateProcess) GetChanges(newState StateReader, log *ze
 		key := newEntity.Name + "|" + newEntity.Tag
 		oldEntity, exists := oldEntityMap[key]
 
+		if newEntity.Deleted {
+			if exists && !oldEntity.Deleted {
+				log.Debug().Str("entity", key).Msg("Deleted artifact, scheduling old entity for deletion")
+				entityToDelete = append(entityToDelete, oldEntity)
+			}
+			delete(oldEntityMap, key)
+			continue
+		}
+
 		switch {
-		case !exists:
+		case !exists || oldEntity.Deleted:
 			log.Debug().Str("entity", key).Msg("New entity not found in old state, scheduling for replication")
 			entityToReplicate = append(entityToReplicate, newEntity)
 		case newEntity.Digest != oldEntity.Digest:
@@ -218,9 +233,11 @@ func (f *FetchAndReplicateStateProcess) GetChanges(newState StateReader, log *ze
 	}
 
 	for _, oldEntity := range oldEntityMap {
-		key := oldEntity.Name + "|" + oldEntity.Tag
-		log.Debug().Str("entity", key).Msg("Old entity no longer present, scheduling for deletion")
-		entityToDelete = append(entityToDelete, oldEntity)
+		if !oldEntity.Deleted {
+			key := oldEntity.Name + "|" + oldEntity.Tag
+			log.Debug().Str("entity", key).Msg("Old entity no longer present, scheduling for deletion")
+			entityToDelete = append(entityToDelete, oldEntity)
+		}
 	}
 
 	return entityToDelete, entityToReplicate, newState
@@ -617,6 +634,7 @@ func FetchEntitiesFromState(state StateReader) []Entity {
 				Repository: artifact.GetRepository(),
 				Tag:        tag,
 				Digest:     artifact.GetDigest(),
+				Deleted:    artifact.IsDeleted(),
 			})
 		}
 	}

--- a/internal/satellite/state/state_process_test.go
+++ b/internal/satellite/state/state_process_test.go
@@ -205,6 +205,127 @@ func TestGetChanges(t *testing.T) {
 		require.Len(t, toReplicate, 1)
 		require.Equal(t, "sha256:new", toReplicate[0].Digest)
 	})
+
+	t.Run("deleted artifact schedules old entity for deletion", func(t *testing.T) {
+		oldEntities := []Entity{
+			{Name: "image1", Repository: "repo1", Tag: "v1", Digest: "sha256:abc"},
+		}
+
+		newState := &State{
+			Registry: "registry.example.com",
+			Artifacts: []Artifact{
+				{Name: "image1", Repository: "repo1", Tags: []string{"v1"}, Digest: "sha256:abc", Deleted: true},
+			},
+		}
+
+		toDelete, toReplicate, _ := process.GetChanges(newState, &logger, oldEntities)
+
+		require.Len(t, toDelete, 1)
+		require.Equal(t, "image1", toDelete[0].Name)
+		require.Empty(t, toReplicate)
+	})
+
+	t.Run("deleted artifact with no old entity skips", func(t *testing.T) {
+		newState := &State{
+			Registry: "registry.example.com",
+			Artifacts: []Artifact{
+				{Name: "image1", Repository: "repo1", Tags: []string{"v1"}, Digest: "sha256:abc", Deleted: true},
+			},
+		}
+
+		toDelete, toReplicate, _ := process.GetChanges(newState, &logger, nil)
+
+		require.Empty(t, toDelete)
+		require.Empty(t, toReplicate)
+	})
+
+	t.Run("deleted artifact with changed digest deletes old and does not replicate new", func(t *testing.T) {
+		oldEntities := []Entity{
+			{Name: "image1", Repository: "repo1", Tag: "v1", Digest: "sha256:old"},
+		}
+
+		newState := &State{
+			Registry: "registry.example.com",
+			Artifacts: []Artifact{
+				{Name: "image1", Repository: "repo1", Tags: []string{"v1"}, Digest: "sha256:new", Deleted: true},
+			},
+		}
+
+		toDelete, toReplicate, _ := process.GetChanges(newState, &logger, oldEntities)
+
+		require.Len(t, toDelete, 1)
+		require.Equal(t, "sha256:old", toDelete[0].Digest)
+		require.Empty(t, toReplicate)
+	})
+
+	t.Run("deleted artifacts with no old entities do not replicate", func(t *testing.T) {
+		newState := &State{
+			Registry: "registry.example.com",
+			Artifacts: []Artifact{
+				{Name: "image1", Repository: "repo1", Tags: []string{"v1"}, Digest: "sha256:abc", Deleted: true},
+				{Name: "image2", Repository: "repo2", Tags: []string{"v2"}, Digest: "sha256:def"},
+			},
+		}
+
+		toDelete, toReplicate, _ := process.GetChanges(newState, &logger, nil)
+
+		require.Empty(t, toDelete)
+		require.Len(t, toReplicate, 1)
+		require.Equal(t, "image2", toReplicate[0].Name)
+	})
+
+	t.Run("deleted artifact already deleted in old entity does not schedule for deletion again", func(t *testing.T) {
+		oldEntities := []Entity{
+			{Name: "image1", Repository: "repo1", Tag: "v1", Digest: "sha256:abc", Deleted: true},
+		}
+
+		newState := &State{
+			Registry: "registry.example.com",
+			Artifacts: []Artifact{
+				{Name: "image1", Repository: "repo1", Tags: []string{"v1"}, Digest: "sha256:abc", Deleted: true},
+			},
+		}
+
+		toDelete, toReplicate, _ := process.GetChanges(newState, &logger, oldEntities)
+
+		require.Empty(t, toDelete)
+		require.Empty(t, toReplicate)
+	})
+
+	t.Run("deleted artifact in old entity that is re-added in new state is scheduled for replication", func(t *testing.T) {
+		oldEntities := []Entity{
+			{Name: "image1", Repository: "repo1", Tag: "v1", Digest: "sha256:abc", Deleted: true},
+		}
+
+		newState := &State{
+			Registry: "registry.example.com",
+			Artifacts: []Artifact{
+				{Name: "image1", Repository: "repo1", Tags: []string{"v1"}, Digest: "sha256:abc", Deleted: false},
+			},
+		}
+
+		toDelete, toReplicate, _ := process.GetChanges(newState, &logger, oldEntities)
+
+		require.Empty(t, toDelete)
+		require.Len(t, toReplicate, 1)
+		require.Equal(t, "image1", toReplicate[0].Name)
+	})
+
+	t.Run("deleted artifact in old entity removed completely from new state does not schedule for deletion", func(t *testing.T) {
+		oldEntities := []Entity{
+			{Name: "image1", Repository: "repo1", Tag: "v1", Digest: "sha256:abc", Deleted: true},
+		}
+
+		newState := &State{
+			Registry: "registry.example.com",
+			Artifacts: []Artifact{},
+		}
+
+		toDelete, toReplicate, _ := process.GetChanges(newState, &logger, oldEntities)
+
+		require.Empty(t, toDelete)
+		require.Empty(t, toReplicate)
+	})
 }
 
 func TestContains(t *testing.T) {
@@ -250,6 +371,22 @@ func TestFetchEntitiesFromState(t *testing.T) {
 
 		entities := FetchEntitiesFromState(state)
 		require.Empty(t, entities)
+	})
+
+	t.Run("propagates deleted flag from artifacts", func(t *testing.T) {
+		state := &State{
+			Registry: "registry.example.com",
+			Artifacts: []Artifact{
+				{Name: "image1", Repository: "repo1", Tags: []string{"v1"}, Digest: "sha256:abc", Deleted: true},
+				{Name: "image2", Repository: "repo2", Tags: []string{"v2"}, Digest: "sha256:def", Deleted: false},
+			},
+		}
+
+		entities := FetchEntitiesFromState(state)
+
+		require.Len(t, entities, 2)
+		require.True(t, entities[0].Deleted)
+		require.False(t, entities[1].Deleted)
 	})
 }
 

--- a/internal/satellite/state/state_process_test.go
+++ b/internal/satellite/state/state_process_test.go
@@ -326,6 +326,27 @@ func TestGetChanges(t *testing.T) {
 		require.Empty(t, toDelete)
 		require.Empty(t, toReplicate)
 	})
+
+	t.Run("same name and tag in different repositories are tracked independently", func(t *testing.T) {
+		oldEntities := []Entity{
+			{Name: "nginx", Repository: "team-a/nginx", Tag: "latest", Digest: "sha256:aaa"},
+			{Name: "nginx", Repository: "team-b/nginx", Tag: "latest", Digest: "sha256:bbb"},
+		}
+
+		newState := &State{
+			Registry: "registry.example.com",
+			Artifacts: []Artifact{
+				{Name: "nginx", Repository: "team-a/nginx", Tags: []string{"latest"}, Digest: "sha256:aaa", Deleted: true},
+				{Name: "nginx", Repository: "team-b/nginx", Tags: []string{"latest"}, Digest: "sha256:bbb"},
+			},
+		}
+
+		toDelete, toReplicate, _ := process.GetChanges(newState, &logger, oldEntities)
+
+		require.Len(t, toDelete, 1)
+		require.Equal(t, "team-a/nginx", toDelete[0].Repository)
+		require.Empty(t, toReplicate)
+	})
 }
 
 func TestContains(t *testing.T) {


### PR DESCRIPTION
- Fixes: #621

## Description

This PR fixes an issue in Harbor Satellite state processing where artifacts marked as deleted (`deleted: true`) in Ground Control state manifests were being replicated/pulled to local satellite storage instead of being deleted.

### Summary of Changes
1. **`internal/satellite/state/replicator.go`**:
   - Added `Deleted bool` field to `Entity` struct with `json:"deleted,omitempty"` for backward compatibility with persisted state.
2. **`internal/satellite/state/state_process.go`**:
   - **`FetchEntitiesFromState`**: Propagated `artifact.IsDeleted()` into `Entity.Deleted`.
   - **`GetChanges`**:
     - Filtered out `entity.Deleted` on initial sync (`oldEntities == nil`) so deleted images are not pulled on first satellite sync.
     - Routed `newEntity.Deleted` with active `oldEntity` (`!oldEntity.Deleted`) to `entityToDelete` and skipped replication.
     - Guarded deletion scheduling with `!oldEntity.Deleted` to ensure deletion is idempotent and not repeatedly scheduled on subsequent reconciliation loops.
     - Handled re-added/re-published artifacts (`oldEntity.Deleted == true` and `newEntity.Deleted == false`) by allowing re-replication.
3. **`internal/satellite/state/state_process_test.go`**:
   - Added 7 unit test cases in `TestGetChanges` and `TestFetchEntitiesFromState` covering initial sync filtering, active entity deletion, loop idempotency, re-added artifact replication, and deleted flag propagation.

## Verification & Test Evidence

All unit tests pass cleanly across the workspace:
```bash
go test -v ./internal/satellite/state/...
# PASS ok github.com/container-registry/harbor-satellite/internal/satellite/state 0.239s
go test ./...
# PASS
```

## Additional context

- All commits are signed off per DCO requirements (`Signed-off-by`).
- Changes are fully backward compatible with persisted `state.json` (`json:"deleted,omitempty"`).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

