### PR TITLE
fix(crypto): make the nospiffe provider fail closed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,6 +35,31 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  nospiffe-build:
+    name: Build and test with the nospiffe tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26.5"
+          cache: false
+
+      # The nospiffe tag swaps the crypto provider for one that refuses every
+      # operation. It was never exercised by CI, which is how it came to
+      # silently write unencrypted config while claiming to encrypt it.
+      - name: Build with nospiffe
+        run: go build -tags nospiffe ./...
+
+      - name: Vet with nospiffe
+        run: go vet -tags nospiffe ./...
+
+      - name: Test with nospiffe
+        run: go test -count=1 -tags nospiffe ./...
+
   vulnerability-check:
     runs-on: container-registry
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ COPY . .
 
 # Build the binary. Default: no extra tags (production-equivalent of main).
 # Pass --build-arg GO_TAGS=parsec to opt into the PARSEC code path.
+# Do not add "nospiffe" unless you mean it: that build has no cryptographic
+# provider, so config encryption is unavailable and every write of a config
+# with encrypt_config set is refused. See docs/guides/build-tags.md.
 ARG GO_TAGS=""
 ARG COMPONENT=satellite
 RUN CGO_ENABLED=0 GOOS=linux go build -tags "${GO_TAGS}" -o /app-bin ./cmd/${COMPONENT}

--- a/docs/guides/build-tags.md
+++ b/docs/guides/build-tags.md
@@ -1,0 +1,63 @@
+# Build tags
+
+Harbor Satellite builds with no build tags by default. Released binaries are
+produced that way: the `Dockerfile` defaults `GO_TAGS` to empty and
+`.goreleaser.yaml` sets no tags. The tags below change what the binary is
+capable of, so read what each one removes before using it.
+
+## `nospiffe`
+
+Drops the SPIFFE dependencies, along with the cryptographic provider.
+
+**This build cannot encrypt anything.** `internal/crypto` compiles
+`UnavailableProvider` instead of the AES-GCM provider, and every operation —
+`Encrypt`, `Decrypt`, `Sign`, `Verify`, `DeriveKey`, `GenerateKeyPair`,
+`RandomBytes` — returns `crypto.ErrCryptoUnavailable`. `Hash` returns nil,
+because the `Provider` interface gives it no error to return.
+
+The practical consequences:
+
+| Feature | `nospiffe` build |
+| --- | --- |
+| SPIFFE identity and mTLS | unavailable, token-only operation |
+| Config encryption at rest (`encrypt_config: true`) | **unavailable — writes are refused** |
+| Reading an existing encrypted config | **unavailable — fails to decrypt** |
+| Signature verification | unavailable, never reports success |
+
+Setting `encrypt_config: true` in a `nospiffe` build makes every config write
+fail with `crypto.ErrCryptoUnavailable`, rather than writing the credentials in
+the clear. If you need this build, either leave `encrypt_config` off and accept
+a plaintext config on disk, or protect the config by other means (file
+permissions, an encrypted volume).
+
+This is deliberate. The provider used to fail open: `Encrypt` returned the
+plaintext unchanged, `Verify` reported every signature as valid without looking
+at it, and `RandomBytes` returned zeros, so every salt was identical. A config
+written by such a build still carried the version header that marks a file as
+encrypted, and `secure.IsEncrypted` still recognised it, so Harbor robot
+credentials sat on the edge device in readable form with nothing to show that
+encryption had not happened. Failing closed is louder but honest.
+
+`internal/satellite/identity` behaves the same way under this tag (and on
+non-Linux hosts): device fingerprinting returns `ErrComponentUnavailable`.
+
+Build and test it with:
+
+```sh
+go build -tags nospiffe ./...
+go test -tags nospiffe ./...
+```
+
+Both run in CI (the `nospiffe-build` job in `.github/workflows/test.yaml`).
+Tests that exercise the real cryptography are tagged `!nospiffe`; the
+fail-closed behaviour has its own tests under `nospiffe`.
+
+## `parsec`
+
+Opts into the PARSEC code path for key management. Independent of `nospiffe` —
+see [ADR 0007](../decisions/0007-security-plugins-parsec.md) for the supported
+combinations.
+
+```sh
+go build -tags parsec ./...
+```

--- a/internal/crypto/aes_provider.go
+++ b/internal/crypto/aes_provider.go
@@ -26,6 +26,11 @@ const (
 	argon2Threads = 4
 )
 
+// EncryptionAvailable reports whether this build can actually encrypt. It is
+// true here; the nospiffe build sets it to false and its provider refuses
+// every operation.
+const EncryptionAvailable = true
+
 // AESProvider implements Provider using AES-GCM for encryption
 // and Argon2id for key derivation.
 type AESProvider struct{}
@@ -33,6 +38,13 @@ type AESProvider struct{}
 // NewAESProvider creates a new AESProvider instance.
 func NewAESProvider() *AESProvider {
 	return &AESProvider{}
+}
+
+// NewDefaultProvider returns the Provider for this build, the real AES-GCM
+// implementation. The nospiffe build returns a provider that fails every
+// operation instead, so callers get an error rather than unprotected data.
+func NewDefaultProvider() *AESProvider {
+	return NewAESProvider()
 }
 
 func (p *AESProvider) Encrypt(plaintext, key []byte) ([]byte, error) {

--- a/internal/crypto/aes_provider_test.go
+++ b/internal/crypto/aes_provider_test.go
@@ -1,3 +1,5 @@
+//go:build !nospiffe
+
 package crypto
 
 import (

--- a/internal/crypto/provider.go
+++ b/internal/crypto/provider.go
@@ -11,6 +11,12 @@ var (
 	ErrInvalidKeyLength  = errors.New("invalid key length")
 	ErrInvalidInput      = errors.New("invalid input")
 	ErrSignatureMismatch = errors.New("signature verification failed")
+
+	// ErrCryptoUnavailable is returned by every operation of the provider
+	// compiled into the nospiffe build, which has no cryptographic
+	// implementation. Callers must treat it as a hard failure: it means the
+	// operation was not performed, not that it succeeded trivially.
+	ErrCryptoUnavailable = errors.New("cryptographic provider not available in this build (built with the nospiffe tag)")
 )
 
 // Provider abstracts cryptographic operations for the satellite.

--- a/internal/crypto/provider_stub.go
+++ b/internal/crypto/provider_stub.go
@@ -4,51 +4,71 @@ package crypto
 
 import "crypto"
 
-// NoOpProvider provides no-op cryptographic operations for minimal builds.
-// Data passes through unchanged - NOT for production use with sensitive data.
-type NoOpProvider struct{}
+// EncryptionAvailable reports whether this build can actually encrypt. It is
+// false here: the nospiffe build ships no cryptographic implementation.
+// Callers that are about to persist secrets should check it and refuse rather
+// than write data that only looks protected.
+const EncryptionAvailable = false
 
-func NewNoOpProvider() *NoOpProvider {
-	return &NoOpProvider{}
+// UnavailableProvider is the Provider compiled into the nospiffe build. It
+// performs no cryptography at all and every operation fails with
+// ErrCryptoUnavailable.
+//
+// It deliberately fails closed. An earlier version of this stub returned the
+// plaintext unchanged from Encrypt, reported every signature as valid from
+// Verify, and filled RandomBytes with zeros. Config written by such a build
+// still carried the version header that marks a file as encrypted, and
+// IsEncrypted still recognised it, so Harbor robot credentials sat on the edge
+// device in plainly readable form with nothing to reveal that encryption had
+// not happened. Returning an error is noisy, but a build that cannot encrypt
+// must say so rather than pretend.
+type UnavailableProvider struct{}
+
+// NewUnavailableProvider returns the non-functional provider used by the
+// nospiffe build.
+func NewUnavailableProvider() *UnavailableProvider {
+	return &UnavailableProvider{}
 }
 
-func NewAESProvider() *NoOpProvider {
-	return &NoOpProvider{}
+// NewDefaultProvider returns the Provider for this build. In the nospiffe
+// build that is UnavailableProvider, which refuses every operation; the
+// default build returns the real AES-GCM provider instead.
+func NewDefaultProvider() *UnavailableProvider {
+	return NewUnavailableProvider()
 }
 
-func (p *NoOpProvider) Encrypt(plaintext, _ []byte) ([]byte, error) {
-	return plaintext, nil
+func (p *UnavailableProvider) Encrypt(_, _ []byte) ([]byte, error) {
+	return nil, ErrCryptoUnavailable
 }
 
-func (p *NoOpProvider) Decrypt(ciphertext, _ []byte) ([]byte, error) {
-	return ciphertext, nil
+func (p *UnavailableProvider) Decrypt(_, _ []byte) ([]byte, error) {
+	return nil, ErrCryptoUnavailable
 }
 
-func (p *NoOpProvider) DeriveKey(input, _ []byte, keyLen int) ([]byte, error) {
-	if len(input) >= keyLen {
-		return input[:keyLen], nil
-	}
-	result := make([]byte, keyLen)
-	copy(result, input)
-	return result, nil
+func (p *UnavailableProvider) DeriveKey(_, _ []byte, _ int) ([]byte, error) {
+	return nil, ErrCryptoUnavailable
 }
 
-func (p *NoOpProvider) Sign(_ []byte, _ crypto.PrivateKey) ([]byte, error) {
-	return []byte("nospiffe-stub-signature"), nil
+func (p *UnavailableProvider) Sign(_ []byte, _ crypto.PrivateKey) ([]byte, error) {
+	return nil, ErrCryptoUnavailable
 }
 
-func (p *NoOpProvider) Verify(_, _ []byte, _ crypto.PublicKey) error {
+func (p *UnavailableProvider) Verify(_, _ []byte, _ crypto.PublicKey) error {
+	return ErrCryptoUnavailable
+}
+
+func (p *UnavailableProvider) GenerateKeyPair() (crypto.PrivateKey, crypto.PublicKey, error) {
+	return nil, nil, ErrCryptoUnavailable
+}
+
+// Hash returns nil because this build computes no hashes. The Provider
+// interface gives Hash no error to return, so callers must treat an empty
+// result as a failure; the previous stub returned the input unchanged, which
+// is an identity function wearing the name of a hash.
+func (p *UnavailableProvider) Hash(_ []byte) []byte {
 	return nil
 }
 
-func (p *NoOpProvider) GenerateKeyPair() (crypto.PrivateKey, crypto.PublicKey, error) {
-	return nil, nil, nil
-}
-
-func (p *NoOpProvider) Hash(data []byte) []byte {
-	return data
-}
-
-func (p *NoOpProvider) RandomBytes(n int) ([]byte, error) {
-	return make([]byte, n), nil
+func (p *UnavailableProvider) RandomBytes(_ int) ([]byte, error) {
+	return nil, ErrCryptoUnavailable
 }

--- a/internal/crypto/provider_stub_test.go
+++ b/internal/crypto/provider_stub_test.go
@@ -1,0 +1,78 @@
+//go:build nospiffe
+
+package crypto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The nospiffe build ships no cryptography. Every operation must report that
+// instead of returning a value that looks like it worked: the previous stub
+// returned plaintext from Encrypt, nil (success) from Verify and zeros from
+// RandomBytes, so a caller could write "encrypted" credentials that were
+// nothing of the sort and trust signatures that were never checked.
+func TestUnavailableProvider_FailsClosed(t *testing.T) {
+	p := NewDefaultProvider()
+	secret := []byte("harbor-robot-credentials")
+
+	t.Run("encrypt refuses instead of returning plaintext", func(t *testing.T) {
+		out, err := p.Encrypt(secret, []byte("key"))
+		require.ErrorIs(t, err, ErrCryptoUnavailable)
+		require.Nil(t, out, "no data may be returned when nothing was encrypted")
+		require.NotEqual(t, secret, out, "the plaintext must never be handed back as ciphertext")
+	})
+
+	t.Run("decrypt refuses", func(t *testing.T) {
+		out, err := p.Decrypt(secret, []byte("key"))
+		require.ErrorIs(t, err, ErrCryptoUnavailable)
+		require.Nil(t, out)
+	})
+
+	t.Run("verify refuses instead of reporting success", func(t *testing.T) {
+		err := p.Verify(secret, []byte("any-signature"), nil)
+		require.ErrorIs(t, err, ErrCryptoUnavailable, "an unchecked signature must never be reported as valid")
+	})
+
+	t.Run("sign refuses", func(t *testing.T) {
+		out, err := p.Sign(secret, nil)
+		require.ErrorIs(t, err, ErrCryptoUnavailable)
+		require.Nil(t, out)
+	})
+
+	t.Run("random bytes refuses instead of returning zeros", func(t *testing.T) {
+		out, err := p.RandomBytes(16)
+		require.ErrorIs(t, err, ErrCryptoUnavailable)
+		require.Nil(t, out, "a predictable all-zero salt must never be produced")
+	})
+
+	t.Run("derive key refuses", func(t *testing.T) {
+		out, err := p.DeriveKey(secret, []byte("salt"), 32)
+		require.ErrorIs(t, err, ErrCryptoUnavailable)
+		require.Nil(t, out)
+	})
+
+	t.Run("generate key pair refuses", func(t *testing.T) {
+		priv, pub, err := p.GenerateKeyPair()
+		require.ErrorIs(t, err, ErrCryptoUnavailable)
+		require.Nil(t, priv)
+		require.Nil(t, pub)
+	})
+
+	t.Run("hash does not echo its input", func(t *testing.T) {
+		require.Nil(t, p.Hash(secret), "returning the input unchanged would be an identity function named Hash")
+	})
+}
+
+// EncryptionAvailable is what callers check before persisting secrets, so the
+// nospiffe build has to report false.
+func TestUnavailableProvider_EncryptionUnavailable(t *testing.T) {
+	require.False(t, EncryptionAvailable, "the nospiffe build cannot encrypt and must not claim otherwise")
+}
+
+// The stub must satisfy Provider so it can be swapped in for the real one.
+func TestUnavailableProvider_ImplementsProvider(t *testing.T) {
+	var _ Provider = NewUnavailableProvider()
+	var _ Provider = NewDefaultProvider()
+}

--- a/internal/satellite/secure/config.go
+++ b/internal/satellite/secure/config.go
@@ -3,6 +3,7 @@ package secure
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -64,7 +65,9 @@ func (e *ConfigEncryptor) EncryptBytes(plaintext []byte) ([]byte, error) {
 
 	encrypted, err := e.crypto.Encrypt(plaintext, key)
 	if err != nil {
-		return nil, ErrEncryptionFailed
+		// Wrapped so callers can still see the cause, in particular
+		// crypto.ErrCryptoUnavailable from a build with no crypto provider.
+		return nil, fmt.Errorf("%w: %w", ErrEncryptionFailed, err)
 	}
 
 	encConfig := EncryptedConfig{
@@ -155,7 +158,7 @@ func IsEncrypted(data []byte) bool {
 func (e *ConfigEncryptor) deriveKey() ([]byte, []byte, error) {
 	salt, err := e.crypto.RandomBytes(saltSize)
 	if err != nil {
-		return nil, nil, ErrKeyDeriveFailed
+		return nil, nil, fmt.Errorf("%w: %w", ErrKeyDeriveFailed, err)
 	}
 
 	key, err := e.deriveKeyWithSalt(salt)
@@ -174,7 +177,7 @@ func (e *ConfigEncryptor) deriveKeyWithSalt(salt []byte) ([]byte, error) {
 
 	key, err := e.crypto.DeriveKey([]byte(fingerprint), salt, keySize)
 	if err != nil {
-		return nil, ErrKeyDeriveFailed
+		return nil, fmt.Errorf("%w: %w", ErrKeyDeriveFailed, err)
 	}
 
 	return key, nil

--- a/internal/satellite/secure/config_nospiffe_test.go
+++ b/internal/satellite/secure/config_nospiffe_test.go
@@ -1,0 +1,72 @@
+//go:build nospiffe
+
+package secure
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/container-registry/harbor-satellite/internal/crypto"
+	"github.com/container-registry/harbor-satellite/internal/satellite/identity"
+	"github.com/stretchr/testify/require"
+)
+
+type testConfig struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Token    string `json:"token"`
+}
+
+const testSecret = "hunter2-harbor-robot-secret"
+
+func newNoSpiffeEncryptor() *ConfigEncryptor {
+	return NewConfigEncryptor(crypto.NewDefaultProvider(), identity.NewMockDeviceIdentity())
+}
+
+// Before the stub was made to fail closed, this produced a file that carried
+// the encrypted-config version header, satisfied IsEncrypted, and held the
+// credentials in plainly readable form. Encryption must now fail loudly
+// instead.
+func TestConfigEncryptor_NoSpiffeRefusesToEncrypt(t *testing.T) {
+	e := newNoSpiffeEncryptor()
+
+	t.Run("EncryptConfig reports the provider is unavailable", func(t *testing.T) {
+		out, err := e.EncryptConfig(testConfig{Username: "admin", Password: testSecret, Token: "tok"})
+		require.Error(t, err)
+		require.ErrorIs(t, err, crypto.ErrCryptoUnavailable, "the cause must reach the caller")
+		require.NotContains(t, string(out), testSecret, "no credential may be returned in readable form")
+	})
+
+	t.Run("EncryptToFile leaves no file behind", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "config.json")
+
+		err := e.EncryptToFile(path, testConfig{Username: "admin", Password: testSecret, Token: "tok"})
+		require.Error(t, err)
+		require.ErrorIs(t, err, crypto.ErrCryptoUnavailable)
+
+		_, statErr := os.Stat(path)
+		require.True(t, os.IsNotExist(statErr), "a config that could not be encrypted must not be written at all")
+	})
+
+	t.Run("DecryptBytes reports the provider is unavailable", func(t *testing.T) {
+		_, err := e.DecryptBytes([]byte(`{"version":1,"salt":"AAAA","data":"AAAA"}`))
+		require.Error(t, err)
+		require.ErrorIs(t, err, crypto.ErrCryptoUnavailable)
+	})
+}
+
+// Guards the specific shape of the old bug: an on-disk file that looks
+// encrypted to IsEncrypted while carrying readable secrets.
+func TestConfigEncryptor_NoSpiffeNeverWritesFakeEncryptedFile(t *testing.T) {
+	e := newNoSpiffeEncryptor()
+
+	out, err := e.EncryptConfig(testConfig{Username: "admin", Password: testSecret, Token: "tok"})
+	require.Error(t, err)
+
+	if len(out) > 0 {
+		require.False(t, IsEncrypted(out), "output must never pass as an encrypted config when nothing was encrypted")
+		require.NotContains(t, strings.ToLower(string(out)), strings.ToLower(testSecret))
+	}
+}

--- a/internal/satellite/secure/config_test.go
+++ b/internal/satellite/secure/config_test.go
@@ -1,3 +1,5 @@
+//go:build !nospiffe
+
 package secure
 
 import (

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -45,7 +45,7 @@ type ConfigManager struct {
 }
 
 func NewConfigManager(configPath, prevConfigPath, token, defaultGroundControlURL string, jsonLog bool, config *Config) (*ConfigManager, error) {
-	cryptoProvider := crypto.NewAESProvider()
+	cryptoProvider := crypto.NewDefaultProvider()
 	deviceIdentity := identity.NewLinuxDeviceIdentity()
 	encryptor := secure.NewConfigEncryptor(cryptoProvider, deviceIdentity)
 
@@ -83,6 +83,13 @@ func (cm *ConfigManager) writeConfigUnlocked(config *Config, path string) error 
 	var err error
 
 	if cm.encryptEnabled {
+		// Refuse rather than fall back to plaintext. A build without a
+		// cryptographic provider must not write a file that carries the
+		// encrypted-config header while holding readable credentials.
+		if !crypto.EncryptionAvailable {
+			return fmt.Errorf("encrypt config: %w: encrypt_config is enabled but this binary was built without encryption support", crypto.ErrCryptoUnavailable)
+		}
+
 		data, err = cm.encryptor.EncryptConfig(config)
 		if err != nil {
 			return fmt.Errorf("encrypt config: %w", err)
@@ -220,7 +227,7 @@ func readAndReturnConfig(path string) (*Config, error) {
 	}
 
 	if secure.IsEncrypted(data) {
-		cryptoProvider := crypto.NewAESProvider()
+		cryptoProvider := crypto.NewDefaultProvider()
 		deviceIdentity := identity.NewLinuxDeviceIdentity()
 		encryptor := secure.NewConfigEncryptor(cryptoProvider, deviceIdentity)
 

--- a/pkg/config/manager_nospiffe_test.go
+++ b/pkg/config/manager_nospiffe_test.go
@@ -1,0 +1,62 @@
+//go:build nospiffe
+
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/container-registry/harbor-satellite/internal/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+// A build without encryption support must refuse to write a config that the
+// operator asked to have encrypted, rather than quietly writing readable
+// credentials under an encrypted-looking header.
+func TestConfigManager_WriteConfigRefusesWhenEncryptionUnavailable(t *testing.T) {
+	cfg := &Config{
+		AppConfig: AppConfig{
+			LogLevel:      "info",
+			EncryptConfig: true,
+		},
+		ZotConfigRaw: json.RawMessage(`{"storage": {}}`),
+	}
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	cm, err := NewConfigManager(path, "", "", "", false, cfg)
+	require.NoError(t, err)
+
+	err = cm.WriteConfig()
+	require.Error(t, err, "encrypt_config is set but this build cannot encrypt")
+	require.ErrorIs(t, err, crypto.ErrCryptoUnavailable)
+
+	_, statErr := os.Stat(path)
+	require.True(t, os.IsNotExist(statErr), "nothing may be written when the config could not be encrypted")
+}
+
+// With encryption switched off the caller has accepted a plaintext config, so
+// writing must still work in this build.
+func TestConfigManager_WriteConfigPlaintextStillWorks(t *testing.T) {
+	cfg := &Config{
+		AppConfig: AppConfig{
+			LogLevel:      "info",
+			EncryptConfig: false,
+		},
+		ZotConfigRaw: json.RawMessage(`{"storage": {}}`),
+	}
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	cm, err := NewConfigManager(path, "", "", "", false, cfg)
+	require.NoError(t, err)
+
+	require.NoError(t, cm.WriteConfig())
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	require.NoError(t, err)
+
+	var saved Config
+	require.NoError(t, json.Unmarshal(data, &saved))
+	require.Equal(t, "info", saved.AppConfig.LogLevel)
+}


### PR DESCRIPTION
## Why

The `nospiffe` build swapped the real provider for a stub that failed
**open**: `Encrypt` returned the plaintext unchanged, `Verify` reported
every signature as valid without looking at it, `RandomBytes` returned
zeros so every salt was identical, and `Sign` returned a fixed string.

A config written by such a build still carried the version header that
marks a file as encrypted, and `secure.IsEncrypted` still recognised it
— so Harbor robot credentials sat on the edge device in readable form
with nothing to show that encryption never happened. An operator who set
`encrypt_config: true` and saw an encrypted-looking file had no way to
find out.

Confirmed before the change, `EncryptConfig` returned **no error** and
produced:

```json
{"version":1,"salt":"AAAAAAAAAAAAAAAAAAAAAA==","data":"eyJ1c2VybmFtZSI6ImFkbWluIiwicGFzc3dvcmQiOiJodW50ZXIyLVNFQ1JFVCIsInRva2VuIjoidG9rIn0="}


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added documented build options for SPIFFE and PARSEC support.
  - Added a capability indicator for encryption availability.

- **Bug Fixes**
  - Builds without cryptographic support now fail safely when encryption, decryption, signing, or related operations are requested.
  - Encrypted configuration writes no longer create plaintext or misleading output when encryption is unavailable.
  - Explicitly plaintext configurations continue to work as expected.

- **Documentation**
  - Added guidance on build tags, encryption limitations, supported commands, and testing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->