### PR TITLE
Persist and Reconcile Group State Correctly During Config Hot Reloads

### DIFF
--- a/internal/groundcontrol/server/config_handlers.go
+++ b/internal/groundcontrol/server/config_handlers.go
@@ -518,6 +518,8 @@ func (s *Server) SetSatelliteConfig(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+
+	s.groupStateCache.set(sat.Name, groupStates)
 	committed = true
 
 	WriteJSONResponse(w, http.StatusOK, map[string]string{})

--- a/internal/groundcontrol/server/config_handlers.go
+++ b/internal/groundcontrol/server/config_handlers.go
@@ -486,7 +486,6 @@ func (s *Server) SetSatelliteConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: Store the groupStates in memory to survive hot reloads
 	var groupStates []string
 	for _, group := range groupList {
 		grp, err := q.GetGroupByID(r.Context(), group.GroupID)
@@ -501,6 +500,8 @@ func (s *Server) SetSatelliteConfig(w http.ResponseWriter, r *http.Request) {
 		}
 		groupStates = append(groupStates, utils.AssembleGroupState(grp.GroupName))
 	}
+
+	groupStates = s.groupStateCache.reconcile(sat.Name, groupStates)
 
 	err = createOrUpdateSatStateArtifact(r.Context(), sat.Name, groupStates, req.ConfigName)
 	if err != nil {

--- a/internal/groundcontrol/server/helpers_test.go
+++ b/internal/groundcontrol/server/helpers_test.go
@@ -62,17 +62,22 @@ func TestServerGroupStateCache_ReconcilePreservesLastKnownState(t *testing.T) {
 	require.Equal(t, []string{"group:a", "group:b"}, cache.reconcile("edge-sat-1", nil))
 	require.Equal(t, []string{"group:a", "group:b"}, cache.get("edge-sat-1"))
 
-	updated := []string{"group:b"}
-	require.Equal(t, updated, cache.reconcile("edge-sat-1", updated))
+	duplicates := []string{"group:a", "group:a", "", "group:b"}
+	require.Equal(t, []string{"group:a", "group:b"}, cache.reconcile("edge-sat-1", duplicates))
 	require.Equal(t, []string{"group:a", "group:b"}, cache.get("edge-sat-1"))
 
 	filteredEmpty := []string{"", ""}
 	require.Equal(t, []string{"group:a", "group:b"}, cache.reconcile("edge-sat-1", filteredEmpty))
 	require.Equal(t, []string{"group:a", "group:b"}, cache.get("edge-sat-1"))
 
-	removed := []string{"group:c"}
-	require.Equal(t, removed, cache.reconcile("edge-sat-1", removed))
-	require.Equal(t, []string{"group:a", "group:b"}, cache.get("edge-sat-1"))
+	states := []string{"group:a", "group:b"}
+	cache.set("edge-sat-2", states)
+	states[0] = "mutated"
+	require.Equal(t, []string{"group:a", "group:b"}, cache.get("edge-sat-2"))
+
+	cache.delete("edge-sat-1")
+	require.Nil(t, cache.get("edge-sat-1"))
+	require.Nil(t, cache.reconcile("edge-sat-1", nil))
 }
 
 func TestVerifyRobotCredentials(t *testing.T) {

--- a/internal/groundcontrol/server/helpers_test.go
+++ b/internal/groundcontrol/server/helpers_test.go
@@ -64,11 +64,15 @@ func TestServerGroupStateCache_ReconcilePreservesLastKnownState(t *testing.T) {
 
 	updated := []string{"group:b"}
 	require.Equal(t, updated, cache.reconcile("edge-sat-1", updated))
-	require.Equal(t, updated, cache.get("edge-sat-1"))
+	require.Equal(t, []string{"group:a", "group:b"}, cache.get("edge-sat-1"))
+
+	filteredEmpty := []string{"", ""}
+	require.Equal(t, []string{"group:a", "group:b"}, cache.reconcile("edge-sat-1", filteredEmpty))
+	require.Equal(t, []string{"group:a", "group:b"}, cache.get("edge-sat-1"))
 
 	removed := []string{"group:c"}
 	require.Equal(t, removed, cache.reconcile("edge-sat-1", removed))
-	require.Equal(t, removed, cache.get("edge-sat-1"))
+	require.Equal(t, []string{"group:a", "group:b"}, cache.get("edge-sat-1"))
 }
 
 func TestVerifyRobotCredentials(t *testing.T) {

--- a/internal/groundcontrol/server/helpers_test.go
+++ b/internal/groundcontrol/server/helpers_test.go
@@ -55,6 +55,22 @@ func TestHashRobotCredentials(t *testing.T) {
 	})
 }
 
+func TestServerGroupStateCache_ReconcilePreservesLastKnownState(t *testing.T) {
+	cache := newSatelliteGroupStateCache()
+	cache.set("edge-sat-1", []string{"group:a", "group:b"})
+
+	require.Equal(t, []string{"group:a", "group:b"}, cache.reconcile("edge-sat-1", nil))
+	require.Equal(t, []string{"group:a", "group:b"}, cache.get("edge-sat-1"))
+
+	updated := []string{"group:b"}
+	require.Equal(t, updated, cache.reconcile("edge-sat-1", updated))
+	require.Equal(t, updated, cache.get("edge-sat-1"))
+
+	removed := []string{"group:c"}
+	require.Equal(t, removed, cache.reconcile("edge-sat-1", removed))
+	require.Equal(t, removed, cache.get("edge-sat-1"))
+}
+
 func TestVerifyRobotCredentials(t *testing.T) {
 	secret := "correct-secret"
 	storedHash, err := crypto.HashSecret(secret)

--- a/internal/groundcontrol/server/satellite_handlers.go
+++ b/internal/groundcontrol/server/satellite_handlers.go
@@ -1055,6 +1055,7 @@ func (s *Server) DeleteSatellite(w http.ResponseWriter, r *http.Request, satelli
 		})
 		return
 	}
+	s.groupStateCache.delete(satellite)
 	committed = true
 
 	actor := "unknown"

--- a/internal/groundcontrol/server/server.go
+++ b/internal/groundcontrol/server/server.go
@@ -79,7 +79,13 @@ func (c *satelliteGroupStateCache) reconcile(satelliteName string, current []str
 		merged = append(merged, state)
 	}
 
-	c.set(satelliteName, merged)
+	if len(merged) == 0 {
+		if len(cachedStates) > 0 {
+			return cachedStates
+		}
+		return nil
+	}
+
 	return merged
 }
 

--- a/internal/groundcontrol/server/server.go
+++ b/internal/groundcontrol/server/server.go
@@ -53,6 +53,15 @@ func (c *satelliteGroupStateCache) get(satelliteName string) []string {
 	return append([]string(nil), states...)
 }
 
+func (c *satelliteGroupStateCache) delete(satelliteName string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.states, satelliteName)
+}
+
 func (c *satelliteGroupStateCache) reconcile(satelliteName string, current []string) []string {
 	cachedStates := c.get(satelliteName)
 
@@ -63,9 +72,6 @@ func (c *satelliteGroupStateCache) reconcile(satelliteName string, current []str
 		return nil
 	}
 
-	// The current reload result is the source of truth. We only retain the previous
-	// cache when the reload result is empty or incomplete, and we always remove stale
-	// entries that are no longer present in the latest state.
 	merged := make([]string, 0, len(current))
 	seen := make(map[string]struct{}, len(current))
 	for _, state := range current {

--- a/internal/groundcontrol/server/server.go
+++ b/internal/groundcontrol/server/server.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	_ "github.com/lib/pq"
@@ -21,6 +22,67 @@ import (
 	"github.com/container-registry/harbor-satellite/internal/groundcontrol/spiffe"
 )
 
+type satelliteGroupStateCache struct {
+	mu     sync.RWMutex
+	states map[string][]string
+}
+
+func newSatelliteGroupStateCache() *satelliteGroupStateCache {
+	return &satelliteGroupStateCache{states: make(map[string][]string)}
+}
+
+func (c *satelliteGroupStateCache) set(satelliteName string, states []string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.states[satelliteName] = append([]string(nil), states...)
+}
+
+func (c *satelliteGroupStateCache) get(satelliteName string) []string {
+	if c == nil {
+		return nil
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	states, ok := c.states[satelliteName]
+	if !ok {
+		return nil
+	}
+	return append([]string(nil), states...)
+}
+
+func (c *satelliteGroupStateCache) reconcile(satelliteName string, current []string) []string {
+	cachedStates := c.get(satelliteName)
+
+	if len(current) == 0 {
+		if len(cachedStates) > 0 {
+			return cachedStates
+		}
+		return nil
+	}
+
+	// The current reload result is the source of truth. We only retain the previous
+	// cache when the reload result is empty or incomplete, and we always remove stale
+	// entries that are no longer present in the latest state.
+	merged := make([]string, 0, len(current))
+	seen := make(map[string]struct{}, len(current))
+	for _, state := range current {
+		if state == "" {
+			continue
+		}
+		if _, ok := seen[state]; ok {
+			continue
+		}
+		seen[state] = struct{}{}
+		merged = append(merged, state)
+	}
+
+	c.set(satelliteName, merged)
+	return merged
+}
+
 type Server struct {
 	port           int
 	db             *sql.DB
@@ -30,6 +92,7 @@ type Server struct {
 	embeddedSpire  *spiffe.EmbeddedSpireServer
 	spireClient    *spiffe.ServerClient
 	spireEnabled   bool
+	groupStateCache *satelliteGroupStateCache
 
 	// External SPIRE server metadata (used when embeddedSpire is nil)
 	spireServerAddress string
@@ -148,14 +211,15 @@ func NewServer() *ServerResult {
 	}
 
 	newServer := &Server{
-		port:           cfg.Server.Port,
-		db:             db,
-		dbQueries:      dbQueries,
-		rateLimiter:    rateLimiter,
-		spiffeProvider: spiffeProvider,
-		embeddedSpire:  embeddedSpire,
-		spireClient:    spireClient,
-		spireEnabled:   spiffeCfg.Enabled || cfg.EmbeddedSPIRE.Enabled || cfg.SPIRE.ServerSocket != "",
+		port:            cfg.Server.Port,
+		db:              db,
+		dbQueries:       dbQueries,
+		rateLimiter:     rateLimiter,
+		spiffeProvider:  spiffeProvider,
+		embeddedSpire:   embeddedSpire,
+		spireClient:     spireClient,
+		spireEnabled:    spiffeCfg.Enabled || cfg.EmbeddedSPIRE.Enabled || cfg.SPIRE.ServerSocket != "",
+		groupStateCache: newSatelliteGroupStateCache(),
 
 		spireServerAddress: spireServerAddress,
 		spireServerPort:    spireServerPort,


### PR DESCRIPTION
## Summary

This PR fixes a state consistency issue in the Ground Control config reload flow.

During a config hot reload, satellite group state could be rebuilt without properly preserving the previous valid state. This could leave satellites with stale or incomplete group assignments after a reload.

This change adds a small in-memory cache for satellite group state and reconciles the cached state with the newly calculated state before publishing the updated artifact.

## Problem

When the configuration changes, the reload flow can lose the previous valid group-state information. If the new reload result is empty or incomplete, there is no reliable way to recover the last known state.

This can cause:

* Stale or incorrect group membership
* Inconsistent replication state
* Incorrect artifact rollout behavior
* Additional manual recovery in edge deployments

There was also an existing TODO in the config handler about keeping `groupStates` in memory across hot reloads.

## What Changed

* Added an in-memory cache for each satellite's group state.
* Reconciled cached state with the newly calculated state during config reloads.
* Preserved the latest valid non-empty group state when a reload produces an empty result.
* Removed stale entries when they are no longer present in the current configuration.
* Deduplicated group-state entries and ignored empty values.
* Added a regression test covering the fallback and reconciliation behavior.

## Why This Matters

Satellite group membership is important for reliable artifact distribution and replication.

By keeping the last known valid state and reconciling it during reloads, the system is less likely to drift into an inconsistent state when configurations are updated or reloaded.

This is especially important in edge environments, where configuration changes and hot reloads are common.

## Validation

The change is intentionally limited to the config reload and group-state reconciliation flow. It does not change unrelated behavior or expand the scope of the project.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved previously known satellite group states when configuration reloads provide incomplete data.
  * Removed duplicate or empty group-state entries during satellite configuration updates.
  * Improved consistency of satellite state artifacts across hot reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->