### PR TITLE
fix(config): use XDG/FHS defaults for registry data directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ graph TB
 
 ### Registry Data Directory
 
-The satellite stores registry data in a configurable location. By default, it uses a `zot` subdirectory inside the configuration directory (`~/.config/satellite/zot`).
+The satellite stores registry data in a configurable location. By default, it uses `/var/lib/satellite/registry` when running as root (`uid=0`), or `$XDG_DATA_HOME/satellite/registry` (`~/.local/share/satellite/registry`) for standard users.
 
 You can override the storage location using:
 

--- a/cmd/satellite/main.go
+++ b/cmd/satellite/main.go
@@ -99,7 +99,7 @@ func main() {
 	flag.StringVar(&opts.RegistryUsername, "registry-username", opts.RegistryUsername, "External registry username")
 	flag.StringVar(&opts.RegistryPassword, "registry-password", "", "External registry password")
 	flag.StringVar(&opts.ConfigDir, "config-dir", opts.ConfigDir, "Configuration directory path (default: ~/.config/satellite)")
-	flag.StringVar(&opts.RegistryDataDir, "registry-data-dir", opts.RegistryDataDir, "Registry data directory (overrides default storage path derived from config-dir)")
+	flag.StringVar(&opts.RegistryDataDir, "registry-data-dir", opts.RegistryDataDir, "Registry data directory. Defaults to /var/lib/satellite/registry for root, or `$XDG_DATA_HOME/satellite/registry` (`~/.local/share/satellite/registry`) for standard users.")
 	flag.StringVar(&shutdownTimeout, "shutdown-timeout", shutdownTimeout, "Graceful shutdown timeout (e.g., '30s'). Defaults to SHUTDOWN_TIMEOUT env var or 30s")
 	flag.BoolVar(&opts.NoRegistryFallback, "no-registry-fallback", opts.NoRegistryFallback, "Disable all CRI registry fallback configuration")
 	flag.BoolVar(&opts.FallbackOnly, "fallback-only", false, "Apply CRI registry fallback configs and exit without starting satellite")
@@ -131,11 +131,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Override ZotStorageDir if --registry-data-dir flag or env var is set
-	if opts.RegistryDataDir != "" {
-		pathConfig.ZotStorageDir = opts.RegistryDataDir
-	}
-
 	// For --fallback-only mode, relax token/gc-url requirements
 	if !opts.FallbackOnly {
 		if !opts.SPIFFEEnabled && (opts.Token == "" || opts.GroundControlURL == "") {
@@ -157,6 +152,16 @@ func main() {
 	if opts.BYORegistry && opts.RegistryURL == "" {
 		fmt.Println("Missing required argument: --registry-url is required when --byo-registry is enabled.")
 		os.Exit(1)
+	}
+
+	if !opts.FallbackOnly && !opts.BYORegistry {
+		zotStorageDir, err := config.ResolveRegistryDataDir(opts.RegistryDataDir)
+		if err != nil {
+			fmt.Printf("Error resolving registry data directory: %v\n", err)
+			os.Exit(1)
+		}
+
+		pathConfig.ZotStorageDir = zotStorageDir
 	}
 
 	err = run(opts, pathConfig, shutdownTimeout)

--- a/examples/config.example.json
+++ b/examples/config.example.json
@@ -54,7 +54,7 @@
   "zot_config": {
     "distSpecVersion": "1.1.0",
     "storage": {
-      "rootDirectory": "./zot"
+      "rootDirectory": ""
     },
     "http": {
       "address": "0.0.0.0",

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -31,7 +31,7 @@ const BringOwnRegistry bool = false
 const DefaultZotConfigJSON = `{
   "distSpecVersion": "1.1.0",
   "storage": {
-    "rootDirectory": "./zot"
+    "rootDirectory": ""
   },
   "http": {
     "address": "0.0.0.0",

--- a/pkg/config/paths.go
+++ b/pkg/config/paths.go
@@ -88,7 +88,6 @@ func ResolvePathConfig(configDir string) (*PathConfig, error) {
 		ConfigFile:     filepath.Join(expanded, "config.json"),
 		PrevConfigFile: filepath.Join(expanded, "prev_config.json"),
 		ZotTempConfig:  filepath.Join(expanded, "zot-hot.json"),
-		ZotStorageDir:  filepath.Join(expanded, "zot"),
 		StateFile:      filepath.Join(expanded, "state.json"),
 	}, nil
 }
@@ -114,4 +113,58 @@ func BuildZotConfigWithStoragePath(storageDir string) (string, error) {
 	}
 
 	return string(updatedJSON), nil
+}
+
+func ResolveRegistryDataDir(registryDataDir string) (string, error) {
+	return resolveRegistryDataDir(registryDataDir, os.Geteuid)
+}
+
+func resolveRegistryDataDir(registryDataDir string, getUidFunc func() int) (string, error) {
+	dataDir := registryDataDir
+
+	if registryDataDir == "" {
+		var err error
+		dataDir, err = defaultRegistryDataDir(getUidFunc)
+		if err != nil {
+			return "", fmt.Errorf("default registry data dir path: %w", err)
+		}
+	}
+
+	expanded, err := expandPath(dataDir)
+	if err != nil {
+		return "", fmt.Errorf("expand registry data dir path %s: %w", dataDir, err)
+	}
+
+	expanded, err = filepath.Abs(expanded)
+	if err != nil {
+		return "", fmt.Errorf("resolve absolute registry data dir path: %w", err)
+	}
+
+	if err := ensureDir(expanded); err != nil {
+		return "", err
+	}
+
+	return expanded, nil
+}
+
+func DefaultRegistryDataDir() (string, error) {
+	return defaultRegistryDataDir(os.Geteuid)
+}
+
+func defaultRegistryDataDir(getUidFunc func() int) (string, error) {
+	uid := getUidFunc()
+	if uid == 0 {
+		return filepath.Join("/var", "lib", "satellite", "registry"), nil
+	}
+
+	if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" && filepath.IsAbs(xdg) {
+		return filepath.Join(xdg, "satellite", "registry"), nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("get home directory: %w", err)
+	}
+
+	return filepath.Join(home, ".local", "share", "satellite", "registry"), nil
 }

--- a/pkg/config/paths_test.go
+++ b/pkg/config/paths_test.go
@@ -155,7 +155,6 @@ func TestResolvePathConfig(t *testing.T) {
 			require.Equal(t, filepath.Join(pathConfig.ConfigDir, "config.json"), pathConfig.ConfigFile)
 			require.Equal(t, filepath.Join(pathConfig.ConfigDir, "prev_config.json"), pathConfig.PrevConfigFile)
 			require.Equal(t, filepath.Join(pathConfig.ConfigDir, "zot-hot.json"), pathConfig.ZotTempConfig)
-			require.Equal(t, filepath.Join(pathConfig.ConfigDir, "zot"), pathConfig.ZotStorageDir)
 		})
 	}
 }
@@ -173,4 +172,107 @@ func TestBuildZotConfigWithStoragePath(t *testing.T) {
 	storage, ok := parsed["storage"].(map[string]any)
 	require.True(t, ok, "storage section should exist")
 	require.Equal(t, storagePath, storage["rootDirectory"])
+}
+
+func TestResolveRegistryDataDir(t *testing.T) {
+	nonRootUser := func() int { return 1000 }
+
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T) (string, string)
+		expectErr bool
+	}{
+		{
+			name: "Override default when registryDataDir is provided",
+			setup: func(t *testing.T) (string, string) {
+				dir := filepath.Join(t.TempDir(), "custom-registry")
+				return dir, dir
+			},
+			expectErr: false,
+		},
+		{
+			name: "Empty registryDataDir should use default",
+			setup: func(t *testing.T) (string, string) {
+				xdgDir := t.TempDir()
+				t.Setenv("XDG_DATA_HOME", xdgDir)
+				expected := filepath.Join(xdgDir, "satellite", "registry")
+				return "", expected
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, expected := tt.setup(t)
+			result, err := resolveRegistryDataDir(input, nonRootUser)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, expected, result)
+			require.DirExists(t, result)
+		})
+	}
+}
+
+func TestDefaultRegistryDataDir(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	rootUser := func() int { return 0 }
+	nonRootUser := func() int { return 1 }
+
+	tests := []struct {
+		name             string
+		expectErr        bool
+		runUser          func() int
+		expected         string
+		xdgDataHomeValue string
+	}{
+		{
+			name:             "Root user",
+			runUser:          rootUser,
+			expectErr:        false,
+			xdgDataHomeValue: "",
+			expected:         filepath.Join("/var", "lib", "satellite", "registry"),
+		},
+		{
+			name:             "Non-root user with XDG_DATA_HOME is set and abs",
+			runUser:          nonRootUser,
+			expectErr:        false,
+			xdgDataHomeValue: filepath.Join("/tmp", "xdg", "path"),
+			expected:         filepath.Join("/tmp", "xdg", "path", "satellite", "registry"),
+		},
+		{
+			name:             "Non-root user with XDG_DATA_HOME is set but not abs",
+			runUser:          nonRootUser,
+			expectErr:        false,
+			xdgDataHomeValue: filepath.Join("xdg", "path"),
+			expected:         filepath.Join(home, ".local", "share", "satellite", "registry"),
+		},
+		{
+			name:             "Non-root user with XDG_DATA_HOME is not set",
+			runUser:          nonRootUser,
+			expectErr:        false,
+			xdgDataHomeValue: "",
+			expected:         filepath.Join(home, ".local", "share", "satellite", "registry"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_DATA_HOME", tt.xdgDataHomeValue)
+
+			result, err := defaultRegistryDataDir(tt.runUser)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
 }


### PR DESCRIPTION

- Fixes: #230

## Description

#260 added `--registry-data-dir`/`REGISTRY_DATA_DIR` as an override, but the default path (no flag/env set) still derived from the config directory rather than following XDG/FHS conventions, as #230 asked for. 
This adds that: 
- root is `/var/lib/satellite/registry`.
- non-root is `$XDG_DATA_HOME/satellite/registry`, falling back to `~/.local/share/satellite/registry`.

An earlier follow-up (#473) attempted this but was closed after going stale on review.
This stays scoped to just the remaining items from #230.

## Changes
- `pkg/config/paths.go`: `DefaultRegistryDataDir()` / `ResolveRegistryDataDir()`
- `cmd/satellite/main.go`: wired resolver in place of override-only logic
- `examples/config.example.json`, `constants.go`: cleared stale `./zot` default

## Testing
- Added table-driven tests covering root/non-root, XDG set/unset/relative
- `go test ./... -v -count=1` passing
- `task e2e-test` passing
- `task e2e-byo` passing
- `task e2e-spiffe` passing
- `task lint` passing

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Registry data storage now uses platform- and user-appropriate default directories.
  * Added support for custom registry data directory paths.
  * Configured directories are expanded, created when needed, and checked for writability.
* **Documentation**
  * Updated command-line help, README guidance, and example configuration to reflect the new defaults.
* **Bug Fixes**
  * Registry path resolution now consistently validates and reports errors before startup continues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->