### PR TITLE
fix: preserve errors in state and config logging paths

### DIFF
--- a/internal/groundcontrol/server/config_handlers.go
+++ b/internal/groundcontrol/server/config_handlers.go
@@ -412,7 +412,7 @@ func (s *Server) UpdateConfig(w http.ResponseWriter, r *http.Request, configName
 func (s *Server) ListConfigs(w http.ResponseWriter, r *http.Request) {
 	result, err := s.dbQueries.ListConfigs(r.Context())
 	if err != nil {
-		fmt.Println("Could not list configs: ", err)
+		log.Println("Could not list configs: ", err)
 		HandleAppError(w, err)
 		return
 	}
@@ -423,7 +423,7 @@ func (s *Server) ListConfigs(w http.ResponseWriter, r *http.Request) {
 func (s *Server) GetConfig(w http.ResponseWriter, r *http.Request, configName string) {
 	result, err := s.dbQueries.GetConfigByName(r.Context(), configName)
 	if err != nil {
-		fmt.Println("Could not get config: ", err)
+		log.Println("Could not get config: ", err)
 		HandleAppError(w, &AppError{
 			Message: fmt.Sprintf("Config not found: %v", err),
 			Code:    http.StatusNotFound,

--- a/internal/groundcontrol/server/config_handlers_test.go
+++ b/internal/groundcontrol/server/config_handlers_test.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 
@@ -198,8 +197,9 @@ func TestListConfigsLogsDBError(t *testing.T) {
 	mock.ExpectQuery("SELECT .+ FROM configs").WillReturnError(fmt.Errorf("db boom"))
 
 	var buf bytes.Buffer
+	previousWriter := log.Writer()
 	log.SetOutput(&buf)
-	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+	t.Cleanup(func() { log.SetOutput(previousWriter) })
 
 	rr := httptest.NewRecorder()
 	server.ListConfigs(rr, httptest.NewRequest(http.MethodGet, "/api/configs", nil))
@@ -217,8 +217,9 @@ func TestGetConfigLogsDBError(t *testing.T) {
 		WillReturnError(sql.ErrNoRows)
 
 	var buf bytes.Buffer
+	previousWriter := log.Writer()
 	log.SetOutput(&buf)
-	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+	t.Cleanup(func() { log.SetOutput(previousWriter) })
 
 	req := httptest.NewRequest(http.MethodGet, "/api/configs/missing", nil)
 	req = mux.SetURLVars(req, map[string]string{"config": "missing"})

--- a/internal/groundcontrol/server/config_handlers_test.go
+++ b/internal/groundcontrol/server/config_handlers_test.go
@@ -5,8 +5,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -189,4 +191,43 @@ func TestConfigMergePatchPreservesExplicitNull(t *testing.T) {
 			require.JSONEq(t, tt.input, string(encoded))
 		})
 	}
+}
+
+func TestListConfigsLogsDBError(t *testing.T) {
+	server, mock := newMockServer(t)
+	mock.ExpectQuery("SELECT .+ FROM configs").WillReturnError(fmt.Errorf("db boom"))
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	rr := httptest.NewRecorder()
+	server.ListConfigs(rr, httptest.NewRequest(http.MethodGet, "/api/configs", nil))
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+	require.Contains(t, buf.String(), "Could not list configs:")
+	require.Contains(t, buf.String(), "db boom")
+}
+
+func TestGetConfigLogsDBError(t *testing.T) {
+	server, mock := newMockServer(t)
+	mock.ExpectQuery("SELECT .+ FROM configs WHERE config_name").
+		WithArgs("missing").
+		WillReturnError(sql.ErrNoRows)
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	req := httptest.NewRequest(http.MethodGet, "/api/configs/missing", nil)
+	req = mux.SetURLVars(req, map[string]string{"config": "missing"})
+
+	rr := httptest.NewRecorder()
+	server.GetConfig(rr, req, "missing")
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+	require.Contains(t, buf.String(), "Could not get config:")
+	require.Contains(t, buf.String(), "sql: no rows in result set")
 }

--- a/internal/satellite/state/fetcher.go
+++ b/internal/satellite/state/fetcher.go
@@ -228,9 +228,9 @@ func (f *URLStateFetcher) extractArtifactJSON(url string, img v1.Image, out any,
 	return fmt.Errorf("artifacts.json not found in the state artifact")
 }
 
-func FromJSON(data []byte, reg StateReader) (StateReader, error) {
+func FromJSON(data []byte, reg StateReader, log *zerolog.Logger) (StateReader, error) {
 	if err := json.Unmarshal(data, &reg); err != nil {
-		fmt.Print("Error in unmarshalling")
+		log.Error().Err(err).Msg("Error in unmarshalling")
 		return nil, fmt.Errorf("unmarshal state: %w", err)
 	}
 	if reg.GetRegistryURL() == "" {

--- a/internal/satellite/state/fetcher_test.go
+++ b/internal/satellite/state/fetcher_test.go
@@ -1,0 +1,29 @@
+package state
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromJSONLogsStructuredUnmarshalError(t *testing.T) {
+	var buf bytes.Buffer
+	log := zerolog.New(&buf)
+
+	_, err := FromJSON([]byte("{invalid"), NewState(), &log)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unmarshal state")
+
+	got := buf.String()
+	require.NotEmpty(t, got)
+	require.True(t, json.Valid([]byte(got)))
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(got), &entry))
+	require.Equal(t, "error", entry["level"])
+	require.Contains(t, got, "Error in unmarshalling")
+	require.Contains(t, got, "invalid character")
+}

--- a/internal/satellite/state/fetcher_test.go
+++ b/internal/satellite/state/fetcher_test.go
@@ -17,6 +17,9 @@ func TestFromJSONLogsStructuredUnmarshalError(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unmarshal state")
 
+	var syntaxErr *json.SyntaxError
+	require.ErrorAs(t, err, &syntaxErr)
+
 	got := buf.String()
 	require.NotEmpty(t, got)
 	require.True(t, json.Valid([]byte(got)))
@@ -24,6 +27,9 @@ func TestFromJSONLogsStructuredUnmarshalError(t *testing.T) {
 	var entry map[string]any
 	require.NoError(t, json.Unmarshal([]byte(got), &entry))
 	require.Equal(t, "error", entry["level"])
-	require.Contains(t, got, "Error in unmarshalling")
-	require.Contains(t, got, "invalid character")
+	require.Equal(t, "Error in unmarshalling", entry["message"])
+
+	errorField, ok := entry["error"].(string)
+	require.True(t, ok)
+	require.Contains(t, errorField, "invalid character")
 }

--- a/internal/satellite/state/state_process.go
+++ b/internal/satellite/state/state_process.go
@@ -579,11 +579,11 @@ func (f *FetchAndReplicateStateProcess) RemoveNullTagArtifacts(state StateReader
 	return state
 }
 
-func ProcessState(state *StateReader) (*StateReader, error) {
+func ProcessState(state *StateReader, log *zerolog.Logger) (*StateReader, error) {
 	for _, artifact := range (*state).GetArtifacts() {
 		repo, image, err := utils.GetRepositoryAndImageNameFromArtifact(artifact.GetRepository())
 		if err != nil {
-			fmt.Printf("Error in getting repository and image name: %v", err)
+			log.Error().Err(err).Msg("Error in getting repository and image name")
 			return nil, err
 		}
 		artifact.SetRepository(repo)
@@ -600,7 +600,7 @@ func (f *FetchAndReplicateStateProcess) FetchAndProcessState(ctx context.Context
 		return nil, err
 	}
 	// update this function to now fetch the list of states from earlier
-	return ProcessState(&state)
+	return ProcessState(&state, log)
 }
 
 func (f *FetchAndReplicateStateProcess) LogChanges(deleteEntity, replicateEntity []Entity, log *zerolog.Logger) {

--- a/internal/satellite/state/state_process_test.go
+++ b/internal/satellite/state/state_process_test.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"bytes"
+	"encoding/json"
 	"path/filepath"
 	"testing"
 
@@ -310,4 +312,30 @@ func TestRemoveNullTagArtifacts(t *testing.T) {
 
 		require.Len(t, result.GetArtifacts(), 1)
 	})
+}
+
+func TestProcessStateLogsStructuredError(t *testing.T) {
+	var buf bytes.Buffer
+	log := zerolog.New(&buf)
+
+	var sr StateReader = &State{
+		Registry: "registry.example.com",
+		Artifacts: []Artifact{
+			{Repository: "missing-slash"},
+		},
+	}
+
+	_, err := ProcessState(&sr, &log)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid repository format")
+
+	got := buf.String()
+	require.NotEmpty(t, got)
+	require.True(t, json.Valid([]byte(got)))
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(got), &entry))
+	require.Equal(t, "error", entry["level"])
+	require.Contains(t, got, "Error in getting repository and image name")
+	require.Contains(t, got, "invalid repository format")
 }

--- a/internal/satellite/state/state_process_test.go
+++ b/internal/satellite/state/state_process_test.go
@@ -336,6 +336,9 @@ func TestProcessStateLogsStructuredError(t *testing.T) {
 	var entry map[string]any
 	require.NoError(t, json.Unmarshal([]byte(got), &entry))
 	require.Equal(t, "error", entry["level"])
-	require.Contains(t, got, "Error in getting repository and image name")
-	require.Contains(t, got, "invalid repository format")
+	require.Equal(t, "Error in getting repository and image name", entry["message"])
+
+	errorField, ok := entry["error"].(string)
+	require.True(t, ok)
+	require.Contains(t, errorField, "invalid repository format")
 }


### PR DESCRIPTION
## Summary

This change addresses the bare `fmt.Print*` logging paths identified
in #470 while following the logging architecture already used by the
repository.

### Satellite

- Pass the existing `*zerolog.Logger` into `ProcessState`.
- Replace the `fmt.Printf` error path with structured zerolog logging.
- Pass an explicit logger to `FromJSON`.
- Preserve the underlying unmarshalling error with `.Err(err)`.

This avoids using `zerolog.Ctx(...)` where a logger is not actually
present in the request context.

### Ground Control

- Replace the affected `fmt.Println` calls in `ListConfigs` and
  `GetConfig` with the standard-library `log` package.
- This follows the existing Ground Control handler convention and the
  approach discussed during review of the previous implementation in
  #471.

I intentionally did not introduce a new Ground Control application
logger or request-context logging infrastructure in this change.

## Background

PR #471 previously investigated this issue and revealed an important
constraint: `zerolog.Ctx(r.Context())` cannot safely be used in the
affected Ground Control handlers because the request context does not
contain an application zerolog logger.

Using it there could cause zerolog to use its disabled default logger
and silently discard errors.

PR #448's logger is also a separate audit logger and is not a
replacement for the application's error logger.

For Satellite, this change therefore follows the existing pattern of
passing the application logger explicitly.

## Tests

Added regression coverage for:

- structured Satellite error logging
- preservation of underlying errors
- valid JSON logging
- error log levels
- malformed JSON handling
- Ground Control database-error logging

Validation:

- `gofmt`: PASS
- `go vet ./internal/satellite/state`: PASS
- `go vet ./internal/groundcontrol/server`: PASS
- `go test ./internal/satellite/state`: PASS
- `go test ./internal/groundcontrol/server`: PASS
- targeted regression tests: PASS
- go build ./...: PASS — compiles all packages successfully, discards outputs by design

## Scope

This change deliberately does not introduce structured application
logging infrastructure into Ground Control. If maintainers want
Ground Control to support structured/JSON application logging, that
can be addressed as a separate follow-up.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting for configuration and satellite state processing failures.
  - Errors now appear in structured application logs while preserving existing HTTP status codes and validation behavior.

- **Tests**
  - Added coverage confirming database, parsing, and invalid repository errors are logged correctly.
  - Verified structured log output includes appropriate error details and valid formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->