### PR TITLE
fix: close audit logger transports during shutdown

### DIFF
--- a/cmd/groundcontrol/server/main.go
+++ b/cmd/groundcontrol/server/main.go
@@ -72,4 +72,7 @@ func main() {
 	if err := httpServer.Shutdown(shutdownCtx); err != nil {
 		log.Printf("HTTP shutdown error: %v", err)
 	}
+	if err := serverResult.AuditLogger.Close(); err != nil {
+		log.Printf("Audit logger shutdown error: %v", err)
+	}
 }

--- a/cmd/satellite/main.go
+++ b/cmd/satellite/main.go
@@ -431,10 +431,10 @@ func run(opts SatelliteOptions, pathConfig *config.PathConfig, shutdownTimeout s
 		}
 	}
 
-	return gracefulShutdown(ctx, log, s, wg, shutdownTimeout)
+	return gracefulShutdown(ctx, log, s, wg, audit, shutdownTimeout)
 }
 
-func gracefulShutdown(ctx context.Context, log *zerolog.Logger, s *satellite.Satellite, wg *errgroup.Group, shutdownTimeout string) error {
+func gracefulShutdown(ctx context.Context, log *zerolog.Logger, s *satellite.Satellite, wg *errgroup.Group, audit *logger.AuditLogger, shutdownTimeout string) error {
 	// Wait until context is cancelled
 	<-ctx.Done()
 
@@ -479,9 +479,19 @@ func gracefulShutdown(ctx context.Context, log *zerolog.Logger, s *satellite.Sat
 		} else {
 			log.Info().Msg("State persisted successfully")
 		}
+
+		if err := audit.Close(); err != nil {
+			log.Warn().Err(err).Msg("Failed to close audit logger during shutdown")
+		}
+
 		log.Info().Msg("Graceful shutdown completed successfully")
 	case <-shutdownCtx.Done():
 		log.Warn().Msg("Shutdown timeout exceeded, forcing exit")
+
+		if err := audit.Close(); err != nil {
+			log.Warn().Err(err).Msg("Failed to close audit logger during shutdown")
+		}
+
 		return fmt.Errorf("graceful shutdown timeout exceeded")
 	}
 

--- a/internal/groundcontrol/logger/audit.go
+++ b/internal/groundcontrol/logger/audit.go
@@ -305,6 +305,15 @@ func closeAll(ts []Transport) {
 	}
 }
 
+// Close releases all active audit log transports.
+func (a *AuditLogger) Close() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	closeAll(a.transports)
+	return nil
+}
+
 // ensureWritable verifies that path can be created and written to now.
 // lumberjack opens its file lazily on first write and silently tolerates write
 // errors, so without this probe an unwritable path would look enabled while

--- a/internal/groundcontrol/logger/audit_test.go
+++ b/internal/groundcontrol/logger/audit_test.go
@@ -51,6 +51,7 @@ func TestAuditLogger_WritesStructuredEvent(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "audit.log")
 	a, err := NewAuditLogger(fileSyslogConfig(path), ComponentSatellite)
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, a.Close()) })
 	require.True(t, a.Enabled())
 
 	a.Log(AuditEvent{
@@ -102,6 +103,7 @@ func TestAuditLogger_DerivesDefaultSeverityAndOmitsEmptyFields(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "audit.log")
 	a, err := NewAuditLogger(fileSyslogConfig(path), ComponentSatellite)
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, a.Close()) })
 
 	a.Log(AuditEvent{
 		Operation:    OpRegister,
@@ -124,6 +126,7 @@ func TestAuditLogger_EmptyRequiredFieldsGetSentinel(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "audit.log")
 	a, err := NewAuditLogger(fileSyslogConfig(path), ComponentSatellite)
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, a.Close()) })
 
 	// A caller that forgets the required fields must not produce an event_type
 	// with empty segments ("user..success" / "..") that would become a broken
@@ -141,6 +144,7 @@ func TestAuditLogger_SeverityOverride(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "audit.log")
 	a, err := NewAuditLogger(fileSyslogConfig(path), ComponentSatellite)
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, a.Close()) })
 
 	a.Log(AuditEvent{
 		Operation:    OpDeregister,
@@ -157,6 +161,7 @@ func TestAuditLogger_UniqueEventIDs(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "audit.log")
 	a, err := NewAuditLogger(fileSyslogConfig(path), ComponentSatellite)
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, a.Close()) })
 
 	for range 5 {
 		a.Log(AuditEvent{Operation: OpRegister, ResourceType: ResSatellite, Outcome: OutcomeSuccess})

--- a/internal/groundcontrol/logger/syslog_test.go
+++ b/internal/groundcontrol/logger/syslog_test.go
@@ -38,6 +38,7 @@ func TestSyslog_FileTargetWritesRFC5424(t *testing.T) {
 		},
 	}, ComponentSatellite)
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, a.Close()) })
 	require.True(t, a.Enabled())
 
 	a.Log(AuditEvent{

--- a/internal/groundcontrol/server/server.go
+++ b/internal/groundcontrol/server/server.go
@@ -71,6 +71,7 @@ type ServerResult struct {
 	SPIFFEProvider spiffe.Provider
 	SPIFFEConfig   *spiffe.Config
 	EmbeddedSpire  *spiffe.EmbeddedSpireServer
+	AuditLogger    *auditlog.AuditLogger
 }
 
 func NewServer() *ServerResult {
@@ -232,6 +233,7 @@ func NewServer() *ServerResult {
 		SPIFFEProvider: spiffeProvider,
 		SPIFFEConfig:   spiffeCfg,
 		EmbeddedSpire:  embeddedSpire,
+		AuditLogger:    auditLogger,
 	}
 }
 

--- a/internal/logger/audit.go
+++ b/internal/logger/audit.go
@@ -311,6 +311,15 @@ func closeAll(ts []Transport) {
 	}
 }
 
+// Close releases all active audit log transports.
+func (a *AuditLogger) Close() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	closeAll(a.transports)
+	return nil
+}
+
 // ensureWritable verifies that path can be created and written to now.
 // lumberjack opens its file lazily on first write and silently tolerates write
 // errors, so without this probe an unwritable path would look enabled while

--- a/internal/logger/audit_test.go
+++ b/internal/logger/audit_test.go
@@ -52,6 +52,9 @@ func TestAuditLogger_WritesStructuredEvent(t *testing.T) {
 	a, err := NewAuditLogger(fileSyslogConfig(path), ComponentSatellite)
 	require.NoError(t, err)
 	require.True(t, a.Enabled())
+	t.Cleanup(func() {
+		require.NoError(t, a.Close())
+	})
 
 	a.Log(AuditEvent{
 		Operation:    OpLogin,
@@ -102,6 +105,9 @@ func TestAuditLogger_DerivesDefaultSeverityAndOmitsEmptyFields(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "audit.log")
 	a, err := NewAuditLogger(fileSyslogConfig(path), ComponentSatellite)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, a.Close())
+	})
 
 	a.Log(AuditEvent{
 		Operation:    OpRegister,
@@ -124,6 +130,9 @@ func TestAuditLogger_EmptyRequiredFieldsGetSentinel(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "audit.log")
 	a, err := NewAuditLogger(fileSyslogConfig(path), ComponentSatellite)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, a.Close())
+	})
 
 	// A caller that forgets the required fields must not produce an event_type
 	// with empty segments ("user..success" / "..") that would become a broken
@@ -141,6 +150,9 @@ func TestAuditLogger_SeverityOverride(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "audit.log")
 	a, err := NewAuditLogger(fileSyslogConfig(path), ComponentSatellite)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, a.Close())
+	})
 
 	a.Log(AuditEvent{
 		Operation:    OpDeregister,
@@ -157,6 +169,9 @@ func TestAuditLogger_UniqueEventIDs(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "audit.log")
 	a, err := NewAuditLogger(fileSyslogConfig(path), ComponentSatellite)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, a.Close())
+	})
 
 	for range 5 {
 		a.Log(AuditEvent{Operation: OpRegister, ResourceType: ResSatellite, Outcome: OutcomeSuccess})

--- a/internal/logger/syslog_test.go
+++ b/internal/logger/syslog_test.go
@@ -39,6 +39,7 @@ func TestSyslog_FileTargetWritesRFC5424(t *testing.T) {
 		},
 	}, ComponentSatellite)
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, a.Close()) })
 	require.True(t, a.Enabled())
 
 	a.Log(AuditEvent{


### PR DESCRIPTION
## Summary

- Add `Close()` to the audit logger to release all active audit log transports.
- Close the audit logger during graceful shutdown for both Satellite and Ground Control.
- Add audit logger cleanup to logger and syslog tests to prevent file handles from remaining open.
- Keep the existing Unix file-permission assertion while allowing the test to pass on Windows.

## Why

Audit log transports using file-backed syslog/lumberjack targets can keep file handles open after tests or application shutdown.

On Windows, this caused temporary directory cleanup failures because the audit log file was still locked by the running process.

This change ensures that audit logger transports are explicitly closed during application shutdown and test cleanup, preventing file-lock issues and ensuring resources are released properly.

## Testing

- `go test ./... -count=1` ✅
- `git diff --check` ✅

All tests pass locally on Windows.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

