### PR TITLE
fix(state): keep incomplete groups out of crash checkpoints

### DIFF
--- a/internal/satellite/state/state_process.go
+++ b/internal/satellite/state/state_process.go
@@ -117,13 +117,14 @@ func (f *FetchAndReplicateStateProcess) Execute(ctx context.Context) error {
 
 	f.mu.Lock()
 	changed := f.updateStateMap(satelliteState.States)
-	f.mu.Unlock()
-
+	var persistErr error
 	// Persist state if groups were added, removed, or swapped
 	if f.stateFilePath != "" && changed {
-		if err := f.PersistState(); err != nil {
-			log.Warn().Err(err).Msg("Failed to persist state after group changes")
-		}
+		persistErr = f.persistStateLocked()
+	}
+	f.mu.Unlock()
+	if persistErr != nil {
+		log.Warn().Err(persistErr).Msg("Failed to persist state after group changes")
 	}
 
 	// Create channels for results

--- a/internal/satellite/state/state_process.go
+++ b/internal/satellite/state/state_process.go
@@ -63,8 +63,10 @@ func NewFetchAndReplicateStateProcess(cm *config.ConfigManager, stateFilePath st
 }
 
 type StateMap struct {
-	url      string
-	State    StateReader
+	url   string
+	State StateReader
+	// A nil Entities slice marks a group that has not completed reconciliation.
+	// A completed group with no artifacts uses a non-nil empty slice.
 	Entities []Entity
 }
 
@@ -113,11 +115,13 @@ func (f *FetchAndReplicateStateProcess) Execute(ctx context.Context) error {
 		}
 	}
 
+	f.mu.Lock()
 	changed := f.updateStateMap(satelliteState.States)
+	f.mu.Unlock()
 
 	// Persist state if groups were added, removed, or swapped
 	if f.stateFilePath != "" && changed {
-		if err := SaveState(f.stateFilePath, f.stateMap, f.currentConfigDigest); err != nil {
+		if err := f.PersistState(); err != nil {
 			log.Warn().Err(err).Msg("Failed to persist state after group changes")
 		}
 	}
@@ -398,10 +402,8 @@ func (f *FetchAndReplicateStateProcess) reconcileRemoteConfig(
 		}
 		f.mu.Lock()
 		f.currentConfigDigest = configDigest
-		if f.stateFilePath != "" {
-			if err := SaveState(f.stateFilePath, f.stateMap, f.currentConfigDigest); err != nil {
-				configFetcherLog.Warn().Err(err).Msg("Failed to persist state to disk")
-			}
+		if err := f.persistStateLocked(); err != nil {
+			configFetcherLog.Warn().Err(err).Msg("Failed to persist state to disk")
 		}
 		f.mu.Unlock()
 	}
@@ -481,10 +483,8 @@ func (f *FetchAndReplicateStateProcess) processGroupState(
 	f.mu.Lock()
 	f.stateMap[index].State = newState
 	f.stateMap[index].Entities = FetchEntitiesFromState(newState)
-	if f.stateFilePath != "" {
-		if err := SaveState(f.stateFilePath, f.stateMap, f.currentConfigDigest); err != nil {
-			stateFetcherLog.Warn().Err(err).Msg("Failed to persist state to disk")
-		}
+	if err := f.persistStateLocked(); err != nil {
+		stateFetcherLog.Warn().Err(err).Msg("Failed to persist state to disk")
 	}
 	f.mu.Unlock()
 
@@ -562,10 +562,25 @@ func (f *FetchAndReplicateStateProcess) PersistState() error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
+	return f.persistStateLocked()
+}
+
+// persistStateLocked writes only fully reconciled groups. Callers must hold
+// f.mu so the snapshot cannot change while it is serialized.
+func (f *FetchAndReplicateStateProcess) persistStateLocked() error {
 	if f.stateFilePath == "" {
 		return nil
 	}
-	return SaveState(f.stateFilePath, f.stateMap, f.currentConfigDigest)
+
+	reconciled := make([]StateMap, 0, len(f.stateMap))
+	for _, stateMap := range f.stateMap {
+		if stateMap.Entities == nil {
+			continue
+		}
+		reconciled = append(reconciled, stateMap)
+	}
+
+	return SaveState(f.stateFilePath, reconciled, f.currentConfigDigest)
 }
 
 func (f *FetchAndReplicateStateProcess) RemoveNullTagArtifacts(state StateReader) StateReader {
@@ -609,7 +624,7 @@ func (f *FetchAndReplicateStateProcess) LogChanges(deleteEntity, replicateEntity
 }
 
 func FetchEntitiesFromState(state StateReader) []Entity {
-	var entities []Entity
+	entities := make([]Entity, 0)
 	for _, artifact := range state.GetArtifacts() {
 		for _, tag := range artifact.GetTags() {
 			entities = append(entities, Entity{

--- a/internal/satellite/state/state_process_test.go
+++ b/internal/satellite/state/state_process_test.go
@@ -249,6 +249,7 @@ func TestFetchEntitiesFromState(t *testing.T) {
 		}
 
 		entities := FetchEntitiesFromState(state)
+		require.NotNil(t, entities)
 		require.Empty(t, entities)
 	})
 }
@@ -277,6 +278,111 @@ func TestPersistState(t *testing.T) {
 	require.Len(t, loaded.Groups, 1)
 	require.Equal(t, "http://registry.example.com/group1", loaded.Groups[0].URL)
 	require.Equal(t, process.stateMap[0].Entities, loaded.Groups[0].Entities)
+}
+
+func TestPersistStateSkipsIncompleteGroups(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	process := &FetchAndReplicateStateProcess{
+		stateFilePath:       path,
+		currentConfigDigest: "sha256:config",
+		stateMap: []StateMap{
+			{
+				url: "http://registry.example.com/complete",
+				Entities: []Entity{
+					{Name: "alpine", Repository: "library", Tag: "latest", Digest: "sha256:abc123"},
+				},
+			},
+			{
+				url:      "http://registry.example.com/pending",
+				Entities: nil,
+			},
+		},
+	}
+
+	require.NoError(t, process.PersistState())
+
+	loaded, err := LoadState(path)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	require.Equal(t, "sha256:config", loaded.ConfigDigest)
+	require.Len(t, loaded.Groups, 1)
+	require.Equal(t, "http://registry.example.com/complete", loaded.Groups[0].URL)
+}
+
+func TestPersistStatePreservesCompletedEmptyGroup(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	process := &FetchAndReplicateStateProcess{
+		stateFilePath: path,
+		stateMap: []StateMap{
+			{
+				url:      "http://registry.example.com/empty",
+				Entities: []Entity{},
+			},
+		},
+	}
+
+	require.NoError(t, process.PersistState())
+
+	loaded, err := LoadState(path)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	require.Len(t, loaded.Groups, 1)
+	require.Equal(t, "http://registry.example.com/empty", loaded.Groups[0].URL)
+	require.NotNil(t, loaded.Groups[0].Entities)
+	require.Empty(t, loaded.Groups[0].Entities)
+}
+
+func TestPersistenceRecoveryRequeuesOnlyIncompleteGroups(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	completeURL := "http://registry.example.com/complete"
+	pendingURL := "http://registry.example.com/pending"
+	process := &FetchAndReplicateStateProcess{
+		stateFilePath: path,
+		stateMap: []StateMap{
+			{
+				url: completeURL,
+				Entities: []Entity{
+					{Name: "alpine", Repository: "library", Tag: "latest", Digest: "sha256:abc123"},
+				},
+			},
+			{url: pendingURL},
+		},
+	}
+	require.NoError(t, process.PersistState())
+
+	log := zerolog.Nop()
+	restarted := NewFetchAndReplicateStateProcess(nil, path, &log)
+	require.Len(t, restarted.stateMap, 1)
+	require.Equal(t, completeURL, restarted.stateMap[0].url)
+
+	require.True(t, restarted.updateStateMap([]string{completeURL, pendingURL}))
+	require.Len(t, restarted.stateMap, 2)
+	require.Equal(t, pendingURL, restarted.stateMap[1].url)
+	require.Nil(t, restarted.stateMap[1].Entities)
+}
+
+func TestPersistStateRemovesStaleGroupBeforeReplacementCompletes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	process := &FetchAndReplicateStateProcess{
+		stateFilePath: path,
+		stateMap: []StateMap{
+			{
+				url: "http://registry.example.com/stale",
+				Entities: []Entity{
+					{Name: "alpine", Repository: "library", Tag: "latest", Digest: "sha256:abc123"},
+				},
+			},
+		},
+	}
+	require.NoError(t, process.PersistState())
+
+	require.True(t, process.updateStateMap([]string{"http://registry.example.com/replacement"}))
+	require.NoError(t, process.PersistState())
+
+	loaded, err := LoadState(path)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	require.Empty(t, loaded.Groups)
 }
 
 func TestRemoveNullTagArtifacts(t *testing.T) {


### PR DESCRIPTION
- Fixes: #533

## Description

New group entries are added to `stateMap` with `Entities == nil` before reconciliation starts. That nil value means "pending", but it was being serialized to `state.json` like a completed checkpoint. If the satellite stopped in that window, restart loaded an incomplete group and treated it as having no prior entity state.

This keeps pending groups in memory but leaves them out of persisted checkpoints until reconciliation succeeds. Successfully reconciled groups with no artifacts now use an explicit empty slice, so real empty states are still persisted. Removed groups are still flushed immediately, and completed groups keep their incremental crash-recovery checkpoint.

Tests cover:
- mixed complete and pending groups
- completed empty groups
- restart recovery
- stale group replacement

## Additional context

Validated with:
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go vet ./...`
- `task build`
- `task lint`
- `task vuln`
- `task --force generate:ground-control` (no diff)
- recovery-focused tests repeated 50 times

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved state persistence and reconciliation reliability by preventing incomplete groups from being saved.
  * Preserved completed groups that contain no entities.
  * Improved recovery behavior so only incomplete groups are requeued.
  * Removed stale group state before replacement completes.
  * Ensured empty entity results are represented consistently.
  * Correctly selects local or remote storage based on configuration.

* **Tests**
  * Added coverage for storage selection, persistence behavior, recovery, and empty-state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->