### PR TITLE
fix(store): continue replicating remaining artifacts after per-entity failure

### DIFF
--- a/internal/satellite/store/oci.go
+++ b/internal/satellite/store/oci.go
@@ -51,24 +51,31 @@ func (s *OCIStore) Replicate(ctx context.Context, artifacts []Artifact) error {
 	defer s.mu.Unlock()
 
 	log := logger.FromContext(ctx)
+	var errs []error
 	for _, artifact := range artifacts {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 		if err := artifact.validate(); err != nil {
-			return err
+			log.Warn().Err(err).Str("artifact", artifact.Name).Msg("Skipping artifact: validation failed")
+			errs = append(errs, fmt.Errorf("validate artifact %s: %w", artifact.Name, err))
+			continue
 		}
 
 		source, err := newRepository(s.source, artifact)
 		if err != nil {
-			return err
+			log.Warn().Err(err).Str("artifact", artifact.Name).Msg("Skipping artifact: failed to create source repository")
+			errs = append(errs, err)
+			continue
 		}
 		destinationRef := s.reference(artifact)
 
 		sourceIdentifier := artifact.sourceIdentifier()
 		desc, err := source.Resolve(ctx, sourceIdentifier)
 		if err != nil {
-			return fmt.Errorf("resolve source artifact %s: %w", destinationRef, err)
+			log.Warn().Err(err).Str("artifact", artifact.Name).Str("reference", destinationRef).Msg("Skipping artifact: failed to resolve source")
+			errs = append(errs, fmt.Errorf("resolve source artifact %s: %w", destinationRef, err))
+			continue
 		}
 		current, err := s.target.Resolve(ctx, destinationRef)
 		if err == nil && current.Digest == desc.Digest {
@@ -76,16 +83,20 @@ func (s *OCIStore) Replicate(ctx context.Context, artifacts []Artifact) error {
 			continue
 		}
 		if err != nil && !errors.Is(err, errdef.ErrNotFound) {
-			return fmt.Errorf("resolve OCI store reference %s: %w", destinationRef, err)
+			log.Warn().Err(err).Str("artifact", artifact.Name).Str("reference", destinationRef).Msg("Skipping artifact: failed to resolve OCI store reference")
+			errs = append(errs, fmt.Errorf("resolve OCI store reference %s: %w", destinationRef, err))
+			continue
 		}
 
 		if _, err := oras.Copy(ctx, source, sourceIdentifier, s.target, destinationRef, oras.DefaultCopyOptions); err != nil {
-			return fmt.Errorf("copy artifact %s to OCI store: %w", destinationRef, err)
+			log.Warn().Err(err).Str("artifact", artifact.Name).Str("reference", destinationRef).Msg("Skipping artifact: failed to copy to OCI store")
+			errs = append(errs, fmt.Errorf("copy artifact %s to OCI store: %w", destinationRef, err))
+			continue
 		}
 		log.Info().Str("reference", destinationRef).Str("digest", desc.Digest.String()).Msg("Artifact replicated to OCI store")
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // Delete removes the selected references and garbage-collects content that is

--- a/internal/satellite/store/oci.go
+++ b/internal/satellite/store/oci.go
@@ -65,7 +65,7 @@ func (s *OCIStore) Replicate(ctx context.Context, artifacts []Artifact) error {
 		source, err := newRepository(s.source, artifact)
 		if err != nil {
 			log.Warn().Err(err).Str("artifact", artifact.Name).Msg("Skipping artifact: failed to create source repository")
-			errs = append(errs, err)
+			errs = append(errs, fmt.Errorf("create source repository for artifact %s: %w", artifact.Name, err))
 			continue
 		}
 		destinationRef := s.reference(artifact)

--- a/internal/satellite/store/oci_test.go
+++ b/internal/satellite/store/oci_test.go
@@ -109,6 +109,35 @@ func TestOCIStoreDeleteRetainsSharedContent(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestOCIStore_Replicate_ContinuesAfterEntityFailure(t *testing.T) {
+	source := newTestRegistry(t)
+	pushImage(t, source, "img1", "v1", 1)
+	// img2 is NOT pushed — will fail at source.Resolve
+	pushImage(t, source, "img3", "v1", 1)
+
+	root := t.TempDir()
+	storage, err := NewOCIStore(root, RegistryOptions{Endpoint: source, PlainHTTP: true})
+	require.NoError(t, err)
+
+	ctx := testContext()
+	err = storage.Replicate(ctx, []Artifact{
+		{Name: "img1", Repository: "library", Tag: "v1"},
+		{Name: "img2", Repository: "library", Tag: "v1"},
+		{Name: "img3", Repository: "library", Tag: "v1"},
+	})
+	require.Error(t, err, "should report partial failure")
+	require.Contains(t, err.Error(), "img2")
+
+	reopened, err := oci.New(root)
+	require.NoError(t, err)
+
+	_, err = reopened.Resolve(ctx, source+"/library/img1:v1")
+	require.NoError(t, err, "img1 should have been replicated")
+
+	_, err = reopened.Resolve(ctx, source+"/library/img3:v1")
+	require.NoError(t, err, "img3 should have been replicated despite img2 failure")
+}
+
 func TestOCIStoreDeleteMissingReferenceIsIdempotent(t *testing.T) {
 	storage, err := NewOCIStore(t.TempDir(), RegistryOptions{Endpoint: "registry.example.com"})
 	require.NoError(t, err)

--- a/internal/satellite/store/registry.go
+++ b/internal/satellite/store/registry.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -63,6 +64,7 @@ func (r *RegistryStore) Replicate(ctx context.Context, replicationEntities []Art
 		}
 	}
 
+	var errs []error
 	for _, entity := range replicationEntities {
 		// Check context cancellation before processing each image
 		select {
@@ -73,7 +75,9 @@ func (r *RegistryStore) Replicate(ctx context.Context, replicationEntities []Art
 		}
 
 		if err := entity.validate(); err != nil {
-			return err
+			log.Warn().Err(err).Str("entity", entity.Name).Msg("Skipping entity: validation failed")
+			errs = append(errs, fmt.Errorf("validate entity %s: %w", entity.Name, err))
+			continue
 		}
 
 		srcRef := r.source.reference(entity, entity.sourceIdentifier())
@@ -81,25 +85,31 @@ func (r *RegistryStore) Replicate(ctx context.Context, replicationEntities []Art
 
 		src, err := name.ParseReference(srcRef, nameOpts...)
 		if err != nil {
-			return fmt.Errorf("parse source ref %s: %w", srcRef, err)
+			log.Warn().Err(err).Str("entity", entity.Name).Str("ref", srcRef).Msg("Skipping entity: failed to parse source ref")
+			errs = append(errs, fmt.Errorf("parse source ref %s: %w", srcRef, err))
+			continue
 		}
 
 		dst, err := name.ParseReference(dstRef, nameOpts...)
 		if err != nil {
-			return fmt.Errorf("parse dest ref %s: %w", dstRef, err)
+			log.Warn().Err(err).Str("entity", entity.Name).Str("ref", dstRef).Msg("Skipping entity: failed to parse dest ref")
+			errs = append(errs, fmt.Errorf("parse dest ref %s: %w", dstRef, err))
+			continue
 		}
 
 		// Lazy fetch: only the manifest is downloaded, no layer data yet
 		desc, err := remote.Get(src, pullOpts...)
 		if err != nil {
-			log.Error().Msgf("Failed to fetch image descriptor: %v", err)
-			return err
+			log.Warn().Err(err).Str("entity", entity.Name).Str("ref", srcRef).Msg("Skipping entity: failed to fetch image descriptor")
+			errs = append(errs, fmt.Errorf("fetch image descriptor %s: %w", entity.Name, err))
+			continue
 		}
 
 		img, err := desc.Image()
 		if err != nil {
-			log.Error().Msgf("Failed to resolve image: %v", err)
-			return err
+			log.Warn().Err(err).Str("entity", entity.Name).Msg("Skipping entity: failed to resolve image")
+			errs = append(errs, fmt.Errorf("resolve image %s: %w", entity.Name, err))
+			continue
 		}
 
 		// Lazy OCI conversion, no data materialized
@@ -108,7 +118,9 @@ func (r *RegistryStore) Replicate(ctx context.Context, replicationEntities []Art
 		// Check if image already exists at destination with same digest
 		srcDigest, err := ociImage.Digest()
 		if err != nil {
-			return fmt.Errorf("compute source digest: %w", err)
+			log.Warn().Err(err).Str("entity", entity.Name).Msg("Skipping entity: failed to compute source digest")
+			errs = append(errs, fmt.Errorf("compute source digest %s: %w", entity.Name, err))
+			continue
 		}
 
 		dstDesc, dstErr := remote.Head(dst, pushOpts...)
@@ -120,7 +132,9 @@ func (r *RegistryStore) Replicate(ctx context.Context, replicationEntities []Art
 		// Log which layers need pulling vs already present
 		srcLayers, err := ociImage.Layers()
 		if err != nil {
-			return fmt.Errorf("get source layers: %w", err)
+			log.Warn().Err(err).Str("entity", entity.Name).Msg("Skipping entity: failed to get source layers")
+			errs = append(errs, fmt.Errorf("get source layers %s: %w", entity.Name, err))
+			continue
 		}
 
 		missing := r.countMissingLayers(dst, srcLayers, pushOpts)
@@ -130,13 +144,14 @@ func (r *RegistryStore) Replicate(ctx context.Context, replicationEntities []Art
 		// the destination first; only missing blobs are pulled from source.
 		// Manifest is pushed last.
 		if err := remote.Write(dst, ociImage, pushOpts...); err != nil {
-			log.Error().Msgf("Failed to replicate image: %v", err)
-			return err
+			log.Warn().Err(err).Str("entity", entity.Name).Msg("Skipping entity: failed to replicate image")
+			errs = append(errs, fmt.Errorf("replicate image %s: %w", entity.Name, err))
+			continue
 		}
 		log.Info().Msgf("Image %s replicated successfully", entity.Name)
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // countMissingLayers checks which source layers are absent from the destination

--- a/internal/satellite/store/registry.go
+++ b/internal/satellite/store/registry.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 
 	"github.com/container-registry/harbor-satellite/internal/logger"
 	satTLS "github.com/container-registry/harbor-satellite/internal/satellite/tls"
@@ -36,8 +37,8 @@ func NewRegistryStore(source, destination RegistryOptions) Store {
 // Replicate copies images from the source registry to the destination registry.
 // Before pulling, it checks which blobs already exist at the destination and
 // only downloads missing layers from source, saving bandwidth on crash recovery.
+// Entities are dispatched to a bounded pool of goroutines for concurrent replication.
 func (r *RegistryStore) Replicate(ctx context.Context, replicationEntities []Artifact) error {
-	log := logger.FromContext(ctx)
 	pullAuth := authn.FromConfig(authn.AuthConfig{
 		Username: r.source.Username,
 		Password: r.source.Password,
@@ -64,94 +65,114 @@ func (r *RegistryStore) Replicate(ctx context.Context, replicationEntities []Art
 		}
 	}
 
-	var errs []error
-	for _, entity := range replicationEntities {
-		// Check context cancellation before processing each image
-		select {
-		case <-ctx.Done():
-			log.Warn().Err(ctx.Err()).Msg("Context cancelled, stopping replication")
-			return ctx.Err()
-		default:
-		}
-
-		if err := entity.validate(); err != nil {
-			log.Warn().Err(err).Str("entity", entity.Name).Msg("Skipping entity: validation failed")
-			errs = append(errs, fmt.Errorf("validate entity %s: %w", entity.Name, err))
-			continue
-		}
-
-		srcRef := r.source.reference(entity, entity.sourceIdentifier())
-		dstRef := r.destination.reference(entity, entity.destinationIdentifier())
-
-		src, err := name.ParseReference(srcRef, nameOpts...)
-		if err != nil {
-			log.Warn().Err(err).Str("entity", entity.Name).Str("ref", srcRef).Msg("Skipping entity: failed to parse source ref")
-			errs = append(errs, fmt.Errorf("parse source ref %s: %w", srcRef, err))
-			continue
-		}
-
-		dst, err := name.ParseReference(dstRef, nameOpts...)
-		if err != nil {
-			log.Warn().Err(err).Str("entity", entity.Name).Str("ref", dstRef).Msg("Skipping entity: failed to parse dest ref")
-			errs = append(errs, fmt.Errorf("parse dest ref %s: %w", dstRef, err))
-			continue
-		}
-
-		// Lazy fetch: only the manifest is downloaded, no layer data yet
-		desc, err := remote.Get(src, pullOpts...)
-		if err != nil {
-			log.Warn().Err(err).Str("entity", entity.Name).Str("ref", srcRef).Msg("Skipping entity: failed to fetch image descriptor")
-			errs = append(errs, fmt.Errorf("fetch image descriptor %s: %w", entity.Name, err))
-			continue
-		}
-
-		img, err := desc.Image()
-		if err != nil {
-			log.Warn().Err(err).Str("entity", entity.Name).Msg("Skipping entity: failed to resolve image")
-			errs = append(errs, fmt.Errorf("resolve image %s: %w", entity.Name, err))
-			continue
-		}
-
-		// Lazy OCI conversion, no data materialized
-		ociImage := mutate.MediaType(img, types.OCIManifestSchema1)
-
-		// Check if image already exists at destination with same digest
-		srcDigest, err := ociImage.Digest()
-		if err != nil {
-			log.Warn().Err(err).Str("entity", entity.Name).Msg("Skipping entity: failed to compute source digest")
-			errs = append(errs, fmt.Errorf("compute source digest %s: %w", entity.Name, err))
-			continue
-		}
-
-		dstDesc, dstErr := remote.Head(dst, pushOpts...)
-		if dstErr == nil && dstDesc.Digest == srcDigest {
-			log.Info().Msgf("Image %s already up-to-date at destination, skipping", entity.Name)
-			continue
-		}
-
-		// Log which layers need pulling vs already present
-		srcLayers, err := ociImage.Layers()
-		if err != nil {
-			log.Warn().Err(err).Str("entity", entity.Name).Msg("Skipping entity: failed to get source layers")
-			errs = append(errs, fmt.Errorf("get source layers %s: %w", entity.Name, err))
-			continue
-		}
-
-		missing := r.countMissingLayers(dst, srcLayers, pushOpts)
-		log.Info().Msgf("Replicating image %s: %d/%d layers to pull", entity.Name, missing, len(srcLayers))
-
-		// remote.Write streams layers one-by-one. For each layer it HEAD-checks
-		// the destination first; only missing blobs are pulled from source.
-		// Manifest is pushed last.
-		if err := remote.Write(dst, ociImage, pushOpts...); err != nil {
-			log.Warn().Err(err).Str("entity", entity.Name).Msg("Skipping entity: failed to replicate image")
-			errs = append(errs, fmt.Errorf("replicate image %s: %w", entity.Name, err))
-			continue
-		}
-		log.Info().Msgf("Image %s replicated successfully", entity.Name)
+	const maxWorkers = 5
+	workers := min(maxWorkers, len(replicationEntities))
+	if workers == 0 {
+		return nil
 	}
 
+	entityCh := make(chan Artifact)
+	var (
+		mu   sync.Mutex
+		errs []error
+		wg   sync.WaitGroup
+	)
+
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for entity := range entityCh {
+				if err := r.replicateEntity(ctx, entity, nameOpts, pullOpts, pushOpts); err != nil {
+					mu.Lock()
+					errs = append(errs, err)
+					mu.Unlock()
+				}
+			}
+		}()
+	}
+
+dispatch:
+	for _, entity := range replicationEntities {
+		select {
+		case <-ctx.Done():
+			break dispatch
+		case entityCh <- entity:
+		}
+	}
+	close(entityCh)
+	wg.Wait()
+
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 	return errors.Join(errs...)
+}
+
+func (r *RegistryStore) replicateEntity(ctx context.Context, entity Artifact, nameOpts []name.Option, pullOpts, pushOpts []remote.Option) error {
+	log := logger.FromContext(ctx)
+
+	if err := entity.validate(); err != nil {
+		log.Warn().Err(err).Str("entity", entity.Name).Msg("Skipping entity: validation failed")
+		return fmt.Errorf("validate entity %s: %w", entity.Name, err)
+	}
+
+	srcRef := r.source.reference(entity, entity.sourceIdentifier())
+	dstRef := r.destination.reference(entity, entity.destinationIdentifier())
+
+	src, err := name.ParseReference(srcRef, nameOpts...)
+	if err != nil {
+		log.Warn().Err(err).Str("entity", entity.Name).Str("ref", srcRef).Msg("Skipping entity: failed to parse source ref")
+		return fmt.Errorf("parse source ref %s: %w", srcRef, err)
+	}
+
+	dst, err := name.ParseReference(dstRef, nameOpts...)
+	if err != nil {
+		log.Warn().Err(err).Str("entity", entity.Name).Str("ref", dstRef).Msg("Skipping entity: failed to parse dest ref")
+		return fmt.Errorf("parse dest ref %s: %w", dstRef, err)
+	}
+
+	desc, err := remote.Get(src, pullOpts...)
+	if err != nil {
+		log.Warn().Err(err).Str("entity", entity.Name).Str("ref", srcRef).Msg("Skipping entity: failed to fetch image descriptor")
+		return fmt.Errorf("fetch image descriptor %s: %w", entity.Name, err)
+	}
+
+	img, err := desc.Image()
+	if err != nil {
+		log.Warn().Err(err).Str("entity", entity.Name).Msg("Skipping entity: failed to resolve image")
+		return fmt.Errorf("resolve image %s: %w", entity.Name, err)
+	}
+
+	ociImage := mutate.MediaType(img, types.OCIManifestSchema1)
+
+	srcDigest, err := ociImage.Digest()
+	if err != nil {
+		log.Warn().Err(err).Str("entity", entity.Name).Msg("Skipping entity: failed to compute source digest")
+		return fmt.Errorf("compute source digest %s: %w", entity.Name, err)
+	}
+
+	dstDesc, dstErr := remote.Head(dst, pushOpts...)
+	if dstErr == nil && dstDesc.Digest == srcDigest {
+		log.Info().Msgf("Image %s already up-to-date at destination, skipping", entity.Name)
+		return nil
+	}
+
+	srcLayers, err := ociImage.Layers()
+	if err != nil {
+		log.Warn().Err(err).Str("entity", entity.Name).Msg("Skipping entity: failed to get source layers")
+		return fmt.Errorf("get source layers %s: %w", entity.Name, err)
+	}
+
+	missing := r.countMissingLayers(dst, srcLayers, pushOpts)
+	log.Info().Msgf("Replicating image %s: %d/%d layers to pull", entity.Name, missing, len(srcLayers))
+
+	if err := remote.Write(dst, ociImage, pushOpts...); err != nil {
+		log.Warn().Err(err).Str("entity", entity.Name).Msg("Skipping entity: failed to replicate image")
+		return fmt.Errorf("replicate image %s: %w", entity.Name, err)
+	}
+	log.Info().Msgf("Image %s replicated successfully", entity.Name)
+	return nil
 }
 
 // countMissingLayers checks which source layers are absent from the destination

--- a/internal/satellite/store/registry_test.go
+++ b/internal/satellite/store/registry_test.go
@@ -375,6 +375,37 @@ func TestReplicate_CancelledContextStopsProcessing(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestReplicate_ContinuesAfterEntityFailure(t *testing.T) {
+	srcAddr := newTestRegistry(t)
+	dstAddr := newTestRegistry(t)
+
+	pushImage(t, srcAddr, "img1", "v1", 1)
+	// img2 is NOT pushed — will fail at remote.Get
+	pushImage(t, srcAddr, "img3", "v1", 1)
+
+	r := NewRegistryStore(RegistryOptions{Endpoint: srcAddr, PlainHTTP: true}, RegistryOptions{Endpoint: dstAddr, PlainHTTP: true})
+	ctx := testContext()
+
+	err := r.Replicate(ctx, []Artifact{
+		{Name: "img1", Repository: "library", Tag: "v1"},
+		{Name: "img2", Repository: "library", Tag: "v1"},
+		{Name: "img3", Repository: "library", Tag: "v1"},
+	})
+	require.Error(t, err, "should report partial failure")
+	require.Contains(t, err.Error(), "img2")
+
+	// img1 and img3 should still have been replicated
+	for _, ref := range []string{
+		dstAddr + "/library/img1:v1",
+		dstAddr + "/library/img3:v1",
+	} {
+		parsed, err := name.ParseReference(ref, name.Insecure)
+		require.NoError(t, err)
+		_, err = remote.Head(parsed)
+		require.NoError(t, err, "image should exist at destination: %s", ref)
+	}
+}
+
 func TestDelete_CancelledContextStopsProcessing(t *testing.T) {
 	dstAddr := newTestRegistry(t)
 


### PR DESCRIPTION
- Relates to: #625

## Description

Both store implementations (`RegistryStore.Replicate` in `registry.go`, `OCIStore.Replicate` in `oci.go`) abort the entire replication run on the first per-entity error. This converts per-entity failures to warn-and-continue with `errors.Join`, so partial failure is reported to the caller while remaining artifacts are still replicated.

**Precedent:** `DirectDeliverer` (`state/direct_delivery.go`) already warn-and-continues per entity.

**Design choice:** continue + `errors.Join` so partial failure is still reported to the caller. `DirectDeliverer` currently logs and returns nil — question for maintainers: should all three paths converge on join-and-return or warn-and-nil?

**Scope note:** `Delete()` has the same abort pattern in both stores; deliberately deferred to keep this diff reviewable. On partial failure the caller (`processGroupState`) doesn't advance its recorded state, so the next cycle retries the full set — but already-replicated artifacts short-circuit on the stores' digest up-to-date check (`remote.Head` in `RegistryStore`, `Resolve` in `OCIStore`), so only failed entities do real work. Persisting partial progress in `processGroupState` (#625) would save those HEAD checks and is follow-up scope.

## Additional context

This PR does not use `Fixes #625` because the linked issue also requires the deletion path and `processGroupState` changes, which are out of scope here.

Note: `Delete` failure at `state_process.go:465` returns before `Replicate` runs — so with `Delete` deliberately unfixed here, one bad delete still blocks a group's entire replication. That's the sharpest justification for the Delete follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Replication now processes multiple artifacts concurrently, improving throughput while maintaining controlled resource usage.

* **Bug Fixes**
  * Replication continues processing remaining artifacts when individual artifacts encounter validation, resolution, retrieval, or copy errors.
  * Successfully processed artifacts are preserved even when another artifact fails.
  * Replication reports encountered errors together with clearer artifact-specific details.
  * Context cancellation continues to stop replication immediately.

* **Tests**
  * Added coverage confirming valid artifacts are preserved when another artifact is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->