### PR TITLE
ci: parallelize release publishing with prebuilt image binaries

### DIFF
--- a/.github/actions/publish-and-sign/action.yaml
+++ b/.github/actions/publish-and-sign/action.yaml
@@ -9,7 +9,7 @@ inputs:
     description: "Source tags used for intermediate platform images"
     required: false
   PUBLISH_MODE:
-    description: "Publish mode: all, platform, or manifest"
+    description: "Publish mode: all, platform, manifest, or prebuilt"
     required: false
     default: all
   PLATFORM:
@@ -18,6 +18,18 @@ inputs:
   ARCH_SUFFIX:
     description: "Architecture suffix for temporary image tags, e.g. amd64"
     required: false
+  SATELLITE_BINARY_PATH:
+    description: "Path to pre-built satellite binary (used with PUBLISH_MODE: prebuilt)"
+    required: false
+    default: ""
+  GC_BINARY_PATH:
+    description: "Path to pre-built ground-control binary (used with PUBLISH_MODE: prebuilt)"
+    required: false
+    default: ""
+  ARCH:
+    description: "Target architecture for prebuilt mode, e.g. amd64"
+    required: false
+    default: ""
   ARCH_SUFFIXES:
     description: "Space-separated architecture suffixes to combine into the final manifest"
     required: false
@@ -52,6 +64,7 @@ runs:
         version: 3.x
 
     - name: Set up Docker Buildx with remote BuildKit
+      if: inputs.PUBLISH_MODE == 'platform' || inputs.PUBLISH_MODE == 'all'
       shell: bash
       env:
         BUILDER_SUFFIX: ${{ inputs.PUBLISH_MODE }}-${{ inputs.PLATFORM }}
@@ -63,6 +76,7 @@ runs:
         docker buildx inspect "$BUILDER_NAME" --bootstrap
 
     - name: Provide envsubst for Cosign installer
+      if: inputs.PUBLISH_MODE != 'prebuilt'
       shell: bash
       run: |
         if command -v envsubst >/dev/null 2>&1; then
@@ -88,9 +102,11 @@ runs:
         echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
 
     - name: Install Cosign
+      if: inputs.PUBLISH_MODE != 'prebuilt'
       uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
     - name: Check Env Variables
+      if: inputs.PUBLISH_MODE != 'prebuilt'
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
@@ -110,11 +126,15 @@ runs:
         PLATFORM: ${{ inputs.PLATFORM }}
         ARCH_SUFFIX: ${{ inputs.ARCH_SUFFIX }}
         ARCH_SUFFIXES: ${{ inputs.ARCH_SUFFIXES }}
+        SATELLITE_BINARY: ${{ inputs.SATELLITE_BINARY_PATH }}
+        GC_BINARY: ${{ inputs.GC_BINARY_PATH }}
+        ARCH: ${{ inputs.ARCH }}
       run: |
         for attempt in 1 2 3; do
           case "$PUBLISH_MODE" in
             platform) publish_cmd=(task publish-platform) ;;
             manifest) publish_cmd=(task publish-manifest-and-sign) ;;
+            prebuilt) publish_cmd=(task publish-platform-prebuilt) ;;
             all)      publish_cmd=(task publish-and-sign) ;;
             *)
               echo "Unsupported PUBLISH_MODE: $PUBLISH_MODE" >&2
@@ -130,6 +150,12 @@ runs:
 
           if [ "$attempt" -eq 3 ]; then
             exit "$status"
+          fi
+
+          if [ "$PUBLISH_MODE" = "prebuilt" ] || [ "$PUBLISH_MODE" = "manifest" ]; then
+            echo "Publish attempt $attempt failed with status $status; retrying after backoff..."
+            sleep $((attempt * 20))
+            continue
           fi
 
           echo "Publish attempt $attempt failed with status $status; resetting remote BuildKit builder before retry..."

--- a/.github/actions/publish-and-sign/action.yaml
+++ b/.github/actions/publish-and-sign/action.yaml
@@ -130,6 +130,12 @@ runs:
         GC_BINARY: ${{ inputs.GC_BINARY_PATH }}
         ARCH: ${{ inputs.ARCH }}
       run: |
+        echo "Publish target: registry=$REGISTRY project=$PROJECT_NAME mode=$PUBLISH_MODE"
+        if [ "$REGISTRY" = "ghcr.io" ] && [[ "$PROJECT_NAME" != */* ]]; then
+          echo "For ghcr.io, PROJECT_NAME must include the owner, for example: ${GITHUB_REPOSITORY:-owner/repo}" >&2
+          exit 2
+        fi
+
         for attempt in 1 2 3; do
           case "$PUBLISH_MODE" in
             platform) publish_cmd=(task publish-platform) ;;

--- a/.github/actions/publish-and-sign/action.yaml
+++ b/.github/actions/publish-and-sign/action.yaml
@@ -138,10 +138,46 @@ runs:
 
         for attempt in 1 2 3; do
           case "$PUBLISH_MODE" in
-            platform) publish_cmd=(task publish-platform) ;;
-            manifest) publish_cmd=(task publish-manifest-and-sign) ;;
-            prebuilt) publish_cmd=(task publish-platform-prebuilt) ;;
-            all)      publish_cmd=(task publish-and-sign) ;;
+            platform)
+              publish_cmd=(
+                task publish-platform
+                REGISTRY="$REGISTRY"
+                PROJECT_NAME="$PROJECT_NAME"
+                TAG="$TAG"
+                SOURCE_IMAGE_TAGS="$SOURCE_IMAGE_TAGS"
+                PLATFORM="$PLATFORM"
+                ARCH_SUFFIX="$ARCH_SUFFIX"
+              )
+              ;;
+            manifest)
+              publish_cmd=(
+                task publish-manifest-and-sign
+                REGISTRY="$REGISTRY"
+                PROJECT_NAME="$PROJECT_NAME"
+                TAG="$TAG"
+                SOURCE_IMAGE_TAGS="$SOURCE_IMAGE_TAGS"
+                ARCH_SUFFIXES="$ARCH_SUFFIXES"
+              )
+              ;;
+            prebuilt)
+              publish_cmd=(
+                task publish-platform-prebuilt
+                REGISTRY="$REGISTRY"
+                PROJECT_NAME="$PROJECT_NAME"
+                TAG="$TAG"
+                ARCH="$ARCH"
+                SATELLITE_BINARY="$SATELLITE_BINARY"
+                GC_BINARY="$GC_BINARY"
+              )
+              ;;
+            all)
+              publish_cmd=(
+                task publish-and-sign
+                REGISTRY="$REGISTRY"
+                PROJECT_NAME="$PROJECT_NAME"
+                TAG="$TAG"
+              )
+              ;;
             *)
               echo "Unsupported PUBLISH_MODE: $PUBLISH_MODE" >&2
               exit 2

--- a/.github/actions/publish-and-sign/action.yaml
+++ b/.github/actions/publish-and-sign/action.yaml
@@ -59,7 +59,7 @@ runs:
         cache: false
 
     - name: Install Task
-      uses: arduino/setup-task@v2
+      uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
       with:
         version: 3.x
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,7 +71,7 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
           REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS }}
           REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
-          PROJECT_NAME: ${{ vars.PROJECT_NAME }}
+          PROJECT_NAME: ${{ vars.PROJECT_NAME || github.repository }}
 
   create-latest-manifest:
     needs: [setup, push-latest-images]
@@ -98,7 +98,7 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
           REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS }}
           REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
-          PROJECT_NAME: ${{ vars.PROJECT_NAME }}
+          PROJECT_NAME: ${{ vars.PROJECT_NAME || github.repository }}
 
   cleanup-temp-tags:
     needs: [setup, create-latest-manifest]
@@ -125,7 +125,7 @@ jobs:
           REGISTRY: ${{ vars.REGISTRY_ADDRESS }}
           REG_USER: ${{ vars.REGISTRY_USERNAME }}
           REG_PASS: ${{ secrets.REGISTRY_PASSWORD }}
-          PROJECT_NAME: ${{ vars.PROJECT_NAME }}
+          PROJECT_NAME: ${{ vars.PROJECT_NAME || github.repository }}
           SOURCE_IMAGE_TAGS: latest-${{ github.sha }}
           ARCH_SUFFIXES: ${{ needs.setup.outputs.arch_suffixes }}
         run: task cleanup-platform-tags
@@ -224,6 +224,14 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
+      - name: Print release image target
+        run: |
+          echo "REGISTRY_ADDRESS=${{ vars.REGISTRY_ADDRESS }}"
+          echo "REGISTRY_USERNAME=${{ vars.REGISTRY_USERNAME }}"
+          echo "PROJECT_NAME=${{ vars.PROJECT_NAME || github.repository }}"
+          echo "IMAGE_TAG=${{ github.ref_name }}"
+          echo "ARCH=${{ matrix.arch }}"
+
       - name: Publish Release Platform Image
         uses: ./.github/actions/publish-and-sign
         with:
@@ -236,7 +244,7 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
           REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS }}
           REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
-          PROJECT_NAME: ${{ vars.PROJECT_NAME }}
+          PROJECT_NAME: ${{ vars.PROJECT_NAME || github.repository }}
 
   create-release-manifest:
     needs: [release-setup, publish-release-images]
@@ -263,7 +271,7 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
           REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS }}
           REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
-          PROJECT_NAME: ${{ vars.PROJECT_NAME }}
+          PROJECT_NAME: ${{ vars.PROJECT_NAME || github.repository }}
 
   cleanup-release-temp-tags:
     needs: [release-setup, create-release-manifest]
@@ -290,7 +298,7 @@ jobs:
           REGISTRY: ${{ vars.REGISTRY_ADDRESS }}
           REG_USER: ${{ vars.REGISTRY_USERNAME }}
           REG_PASS: ${{ secrets.REGISTRY_PASSWORD }}
-          PROJECT_NAME: ${{ vars.PROJECT_NAME }}
+          PROJECT_NAME: ${{ vars.PROJECT_NAME || github.repository }}
           SOURCE_IMAGE_TAGS: ${{ github.ref_name }}
           ARCH_SUFFIXES: ${{ needs.release-setup.outputs.arch_suffixes }}
         run: task cleanup-platform-tags

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -130,57 +130,201 @@ jobs:
           ARCH_SUFFIXES: ${{ needs.setup.outputs.arch_suffixes }}
         run: task cleanup-platform-tags
 
-  publish-release:
+  release-setup:
+    permissions: {}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    outputs:
+      arches: ${{ steps.arch-list.outputs.arches }}
+      arch_suffixes: ${{ steps.arch-list.outputs.arch_suffixes }}
+    steps:
+      - name: Emit supported architectures
+        id: arch-list
+        run: |
+          ARCHES='["amd64","arm64","ppc64le","s390x","riscv64"]'
+          echo "arches=$ARCHES" >> "$GITHUB_OUTPUT"
+          echo "arch_suffixes=amd64 arm64 ppc64le s390x riscv64" >> "$GITHUB_OUTPUT"
+
+  build-release-binaries:
+    needs: [release-setup]
     permissions:
-      contents: write
-      packages: write
-      id-token: write
-    runs-on: container-registry
-    if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
+      contents: read
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ${{ fromJSON(needs.release-setup.outputs.arches) }}
     steps:
       - name: Checkout repo
-        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
-
-      - name: Publish and Sign Tagged Image
-        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
-        uses: ./.github/actions/publish-and-sign
-        with:
-          IMAGE_TAGS: "latest,${{ github.ref_name }}"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
-          REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS }}
-          REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
-          PROJECT_NAME: ${{ vars.PROJECT_NAME }}
+          persist-credentials: false
 
       - name: Setup Go
-        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26.5"
           cache: false
 
       - name: Install Task
-        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        with:
+          version: 3.x
+          repo-token: ${{ github.token }}
+
+      - name: Build release binaries
+        run: |
+          task _build:cross-compile \
+            COMPONENT=satellite \
+            GOARCH=${{ matrix.arch }} \
+            VERSION=${{ github.ref_name }} \
+            GIT_COMMIT=${{ github.sha }} \
+            OUTPUT=bin/release/satellite-linux-${{ matrix.arch }}
+          task _build:cross-compile \
+            COMPONENT=groundcontrol/server \
+            GOARCH=${{ matrix.arch }} \
+            VERSION=${{ github.ref_name }} \
+            GIT_COMMIT=${{ github.sha }} \
+            OUTPUT=bin/release/ground-control-linux-${{ matrix.arch }}
+
+      - name: Upload release binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-binaries-${{ matrix.arch }}
+          path: bin/release/*
+          if-no-files-found: error
+
+  publish-release-images:
+    needs: [release-setup, build-release-binaries]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ${{ fromJSON(needs.release-setup.outputs.arches) }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download release binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: release-binaries-${{ matrix.arch }}
+          path: bin/release
+
+      - name: Publish Release Platform Image
+        uses: ./.github/actions/publish-and-sign
+        with:
+          IMAGE_TAGS: ${{ github.ref_name }}
+          PUBLISH_MODE: prebuilt
+          SATELLITE_BINARY_PATH: bin/release/satellite-linux-${{ matrix.arch }}
+          GC_BINARY_PATH: bin/release/ground-control-linux-${{ matrix.arch }}
+          ARCH: ${{ matrix.arch }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+          REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS }}
+          REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
+          PROJECT_NAME: ${{ vars.PROJECT_NAME }}
+
+  create-release-manifest:
+    needs: [release-setup, publish-release-images]
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Create and Sign Release Manifest
+        uses: ./.github/actions/publish-and-sign
+        with:
+          IMAGE_TAGS: latest,${{ github.ref_name }}
+          SOURCE_IMAGE_TAGS: ${{ github.ref_name }},${{ github.ref_name }}
+          PUBLISH_MODE: manifest
+          ARCH_SUFFIXES: ${{ needs.release-setup.outputs.arch_suffixes }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+          REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS }}
+          REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
+          PROJECT_NAME: ${{ vars.PROJECT_NAME }}
+
+  cleanup-release-temp-tags:
+    needs: [release-setup, create-release-manifest]
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Task
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        with:
+          version: 3.x
+          repo-token: ${{ github.token }}
+
+      - name: Delete temporary release platform tags
+        continue-on-error: true
+        env:
+          REGISTRY: ${{ vars.REGISTRY_ADDRESS }}
+          REG_USER: ${{ vars.REGISTRY_USERNAME }}
+          REG_PASS: ${{ secrets.REGISTRY_PASSWORD }}
+          PROJECT_NAME: ${{ vars.PROJECT_NAME }}
+          SOURCE_IMAGE_TAGS: ${{ github.ref_name }}
+          ARCH_SUFFIXES: ${{ needs.release-setup.outputs.arch_suffixes }}
+        run: task cleanup-platform-tags
+
+  publish-release:
+    needs: [create-release-manifest]
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26.5"
+          cache: false
+
+      - name: Install Task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
           repo-token: ${{ github.token }}
 
       - name: Install GoReleaser
-        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           install-only: true
 
       - name: Install Syft
-        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - name: Create Release
-        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: task release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -224,14 +224,6 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: Print release image target
-        run: |
-          echo "REGISTRY_ADDRESS=${{ vars.REGISTRY_ADDRESS }}"
-          echo "REGISTRY_USERNAME=${{ vars.REGISTRY_USERNAME }}"
-          echo "PROJECT_NAME=${{ vars.PROJECT_NAME || github.repository }}"
-          echo "IMAGE_TAG=${{ github.ref_name }}"
-          echo "ARCH=${{ matrix.arch }}"
-
       - name: Publish Release Platform Image
         uses: ./.github/actions/publish-and-sign
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
     tags:
+      # Tag push protection (restricting who may create v*.*.* tags) must be
+      # enforced via GitHub repository tag-protection rules or rulesets, not
+      # here. Ensure only release administrators have permission to push these
+      # tags in the repository settings.
       - "v*.*.*"
   pull_request:
     paths-ignore:
@@ -175,19 +179,23 @@ jobs:
           repo-token: ${{ github.token }}
 
       - name: Build release binaries
+        env:
+          RELEASE_VERSION: ${{ github.ref_name }}
+          RELEASE_COMMIT: ${{ github.sha }}
+          RELEASE_ARCH: ${{ matrix.arch }}
         run: |
           task _build:cross-compile \
             COMPONENT=satellite \
-            GOARCH=${{ matrix.arch }} \
-            VERSION=${{ github.ref_name }} \
-            GIT_COMMIT=${{ github.sha }} \
-            OUTPUT=bin/release/satellite-linux-${{ matrix.arch }}
+            GOARCH="$RELEASE_ARCH" \
+            VERSION="$RELEASE_VERSION" \
+            GIT_COMMIT="$RELEASE_COMMIT" \
+            OUTPUT=bin/release/satellite-linux-"$RELEASE_ARCH"
           task _build:cross-compile \
             COMPONENT=groundcontrol/server \
-            GOARCH=${{ matrix.arch }} \
-            VERSION=${{ github.ref_name }} \
-            GIT_COMMIT=${{ github.sha }} \
-            OUTPUT=bin/release/ground-control-linux-${{ matrix.arch }}
+            GOARCH="$RELEASE_ARCH" \
+            VERSION="$RELEASE_VERSION" \
+            GIT_COMMIT="$RELEASE_COMMIT" \
+            OUTPUT=bin/release/ground-control-linux-"$RELEASE_ARCH"
 
       - name: Upload release binaries
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -198,7 +198,7 @@ jobs:
             OUTPUT=bin/release/ground-control-linux-"$RELEASE_ARCH"
 
       - name: Upload release binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: release-binaries-${{ matrix.arch }}
           path: bin/release/*
@@ -224,13 +224,13 @@ jobs:
           persist-credentials: false
 
       - name: Download release binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: release-binaries-${{ matrix.arch }}
           path: bin/release
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Publish Release Platform Image
         uses: ./.github/actions/publish-and-sign

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -221,6 +221,9 @@ jobs:
           name: release-binaries-${{ matrix.arch }}
           path: bin/release
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Publish Release Platform Image
         uses: ./.github/actions/publish-and-sign
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -209,9 +209,6 @@ release:
   replace_existing_draft: true
   replace_existing_artifacts: true
   disable: false # Ensure release publishing is enabled
-  github:
-    owner: container-registry # Your GitHub repository owner
-    name: harbor-satellite # Your GitHub repository name
 changelog:
   use: github
   filters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
+# Global build args must be declared before the first FROM to be usable in
+# FROM directives (Docker multi-stage scoping rule).
+#
+#   Prebuilt path:    docker buildx build --build-arg BUILDER_MODE=prebuilt
+#                                         --build-arg PREBUILT_BINARY=./prebuilt-binary ...
+#   From-source path: docker buildx build ...   (default; BUILDER_MODE=source)
+ARG BUILDER_MODE=source
+
 # ── Prebuilt path ────────────────────────────────────────────────────────────
 # Used when a cross-compiled binary is supplied via the build context.
 # Only installs ca-certificates; no Go toolchain, no module download, no
-# source copy. The binary is copied in from the build-context path set by
-# the caller (publish-platform-prebuilt task).
+# source copy.
 FROM alpine:3.20 AS builder-prebuilt
 
 RUN apk add --no-cache ca-certificates
@@ -33,15 +40,9 @@ ARG COMPONENT=satellite
 RUN CGO_ENABLED=0 GOOS=linux go build -tags "${GO_TAGS}" -o /app-bin ./cmd/${COMPONENT}
 
 # ── Builder selector ──────────────────────────────────────────────────────────
-# BuildKit evaluates ARGs in FROM directives, allowing the caller to choose
-# the builder stage at build time:
-#
-#   Prebuilt:    docker buildx build --build-arg BUILDER_MODE=prebuilt
-#                                    --build-arg PREBUILT_BINARY=./prebuilt-binary ...
-#   From source: docker buildx build ...   (default; no extra args required)
-#
-# The runtime stage always COPYs /app-bin from whichever builder was selected.
-ARG BUILDER_MODE=source
+# BUILDER_MODE is declared globally above (before the first FROM) so Docker
+# can evaluate it here. Defaults to 'source'; pass --build-arg BUILDER_MODE=prebuilt
+# to select the lightweight prebuilt stage.
 FROM builder-${BUILDER_MODE} AS builder
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,12 @@ COPY . .
 # Pass --build-arg GO_TAGS=parsec to opt into the PARSEC code path.
 ARG GO_TAGS=""
 ARG COMPONENT=satellite
-RUN CGO_ENABLED=0 GOOS=linux go build -tags "${GO_TAGS}" -o /app-bin ./cmd/${COMPONENT}
+ARG PREBUILT_BINARY=""
+RUN if [ -n "$PREBUILT_BINARY" ]; then \
+      cp "$PREBUILT_BINARY" /app-bin; \
+    else \
+      CGO_ENABLED=0 GOOS=linux go build -tags "${GO_TAGS}" -o /app-bin ./cmd/${COMPONENT}; \
+    fi
 
 # Runtime stage
 FROM alpine:3.20

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,22 @@
-# Build stage
-FROM golang:1.26.5-alpine AS builder
+# ── Prebuilt path ────────────────────────────────────────────────────────────
+# Used when a cross-compiled binary is supplied via the build context.
+# Only installs ca-certificates; no Go toolchain, no module download, no
+# source copy. The binary is copied in from the build-context path set by
+# the caller (publish-platform-prebuilt task).
+FROM alpine:3.20 AS builder-prebuilt
+
+RUN apk add --no-cache ca-certificates
+
+ARG PREBUILT_BINARY=""
+COPY ${PREBUILT_BINARY} /app-bin
+
+# ── From-source path ─────────────────────────────────────────────────────────
+# Full in-Docker Go build. Git is required by go mod download for
+# VCS-stamped dependencies.
+FROM golang:1.26.5-alpine AS builder-source
 
 WORKDIR /app
 
-# Install git for go mod download
 RUN apk add --no-cache git ca-certificates
 
 # Copy go mod files first for better caching
@@ -17,14 +30,21 @@ COPY . .
 # Pass --build-arg GO_TAGS=parsec to opt into the PARSEC code path.
 ARG GO_TAGS=""
 ARG COMPONENT=satellite
-ARG PREBUILT_BINARY=""
-RUN if [ -n "$PREBUILT_BINARY" ]; then \
-      cp "$PREBUILT_BINARY" /app-bin; \
-    else \
-      CGO_ENABLED=0 GOOS=linux go build -tags "${GO_TAGS}" -o /app-bin ./cmd/${COMPONENT}; \
-    fi
+RUN CGO_ENABLED=0 GOOS=linux go build -tags "${GO_TAGS}" -o /app-bin ./cmd/${COMPONENT}
 
-# Runtime stage
+# ── Builder selector ──────────────────────────────────────────────────────────
+# BuildKit evaluates ARGs in FROM directives, allowing the caller to choose
+# the builder stage at build time:
+#
+#   Prebuilt:    docker buildx build --build-arg BUILDER_MODE=prebuilt
+#                                    --build-arg PREBUILT_BINARY=./prebuilt-binary ...
+#   From source: docker buildx build ...   (default; no extra args required)
+#
+# The runtime stage always COPYs /app-bin from whichever builder was selected.
+ARG BUILDER_MODE=source
+FROM builder-${BUILDER_MODE} AS builder
+
+# ── Runtime stage ─────────────────────────────────────────────────────────────
 FROM alpine:3.20
 
 RUN apk add --no-cache ca-certificates tzdata curl
@@ -34,7 +54,7 @@ WORKDIR /app
 # Copy binary and Ground Control migrations from builder. The migrations copy is
 # harmless for the satellite image and keeps one Dockerfile for both binaries.
 COPY --from=builder /app-bin /app/app
-COPY --from=builder /app/internal/groundcontrol/sql/schema /migrations
+COPY --from=builder-source /app/internal/groundcontrol/sql/schema /migrations
 
 # Create data directory
 RUN mkdir -p /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,10 @@ RUN CGO_ENABLED=0 GOOS=linux go build -tags "${GO_TAGS}" -o /app-bin ./cmd/${COM
 # BUILDER_MODE is declared globally above (before the first FROM) so Docker
 # can evaluate it here. Defaults to 'source'; pass --build-arg BUILDER_MODE=prebuilt
 # to select the lightweight prebuilt stage.
+#
+# DL3006 does not apply: this FROM names a prior stage (builder-source or
+# builder-prebuilt), not an untagged registry image.
+# hadolint ignore=DL3006
 FROM builder-${BUILDER_MODE} AS builder
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,10 +52,12 @@ RUN apk add --no-cache ca-certificates tzdata curl
 
 WORKDIR /app
 
-# Copy binary and Ground Control migrations from builder. The migrations copy is
-# harmless for the satellite image and keeps one Dockerfile for both binaries.
+# Copy the binary from whichever builder stage was selected, and migrations
+# from the build context (so the Go build is never forced in prebuilt mode).
 COPY --from=builder /app-bin /app/app
-COPY --from=builder-source /app/internal/groundcontrol/sql/schema /migrations
+# Copy migrations directly from the build context (not from builder-source) so
+# the Go build stage is never forced to run in prebuilt mode.
+COPY internal/groundcontrol/sql/schema /migrations
 
 # Create data directory
 RUN mkdir -p /data

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -166,7 +166,7 @@ tasks:
     vars:
       TAG: '{{.TAG | default .Env.TAG | default "dev"}}'
       REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
-      PROJECT_NAME: "{{.Env.PROJECT_NAME | default .PROJECT_NAME}}"
+      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
     cmds:
       - task: _publish:image-and-sign
         vars:
@@ -190,7 +190,7 @@ tasks:
         sh: |
           printf '%s' "{{.SOURCE_TAGS}}" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/^v//' | awk 'NF { printf "%s%s-{{.ARCH_SUFFIX}}", sep, $0; sep="," }'
       REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
-      PROJECT_NAME: "{{.Env.PROJECT_NAME | default .PROJECT_NAME}}"
+      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
       PLATFORM: "{{.PLATFORM | default .Env.PLATFORM}}"
       ARCH_SUFFIX: "{{.ARCH_SUFFIX | default .Env.ARCH_SUFFIX}}"
     preconditions:
@@ -219,7 +219,7 @@ tasks:
     vars:
       TAG: '{{.TAG | default .Env.TAG | default "dev"}}'
       REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
-      PROJECT_NAME: "{{.Env.PROJECT_NAME | default .PROJECT_NAME}}"
+      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
       ARCH: "{{.ARCH | default .Env.ARCH}}"
       SATELLITE_BINARY: "{{.SATELLITE_BINARY | default .Env.SATELLITE_BINARY}}"
       GC_BINARY: "{{.GC_BINARY | default .Env.GC_BINARY}}"
@@ -239,7 +239,7 @@ tasks:
       TAG: '{{.TAG | default .Env.TAG | default "dev"}}'
       SOURCE_TAGS: "{{.SOURCE_IMAGE_TAGS | default .SOURCE_TAG | default .TAG}}"
       REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
-      PROJECT_NAME: "{{.Env.PROJECT_NAME | default .PROJECT_NAME}}"
+      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
       ARCH_SUFFIXES: "{{.ARCH_SUFFIXES | default .Env.ARCH_SUFFIXES | default .PLATFORMS_LINUX}}"
     cmds:
       - task: _publish:manifest-and-sign
@@ -263,7 +263,7 @@ tasks:
     desc: Delete temporary per-arch source tags from the registry after manifest assembly
     vars:
       REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
-      PROJECT_NAME: "{{.Env.PROJECT_NAME | default .PROJECT_NAME}}"
+      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
       SOURCE_TAGS: "{{.SOURCE_IMAGE_TAGS | default .Env.SOURCE_IMAGE_TAGS}}"
       ARCH_SUFFIXES: "{{.ARCH_SUFFIXES | default .Env.ARCH_SUFFIXES}}"
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -214,6 +214,25 @@ tasks:
           IMAGE_TAGS: "{{.PLATFORM_IMAGE_TAGS}}"
           PLATFORMS: "{{.PLATFORM}}"
 
+  publish-platform-prebuilt:
+    desc: Build and push single-arch images using pre-built binaries (used by CI release matrix)
+    vars:
+      TAG: '{{.TAG | default .Env.TAG | default "dev"}}'
+      REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
+      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
+      ARCH: "{{.ARCH | default .Env.ARCH}}"
+      SATELLITE_BINARY: "{{.SATELLITE_BINARY | default .Env.SATELLITE_BINARY}}"
+      GC_BINARY: "{{.GC_BINARY | default .Env.GC_BINARY}}"
+    cmds:
+      - task: _publish:platform-prebuilt
+        vars:
+          REGISTRY: "{{.REGISTRY}}"
+          PROJECT_NAME: "{{.PROJECT_NAME}}"
+          IMAGE_TAG: "{{.TAG}}"
+          ARCH: "{{.ARCH}}"
+          SATELLITE_BINARY: "{{.SATELLITE_BINARY}}"
+          GC_BINARY: "{{.GC_BINARY}}"
+
   publish-manifest-and-sign:
     desc: Create and sign multi-arch manifests for both components
     vars:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -166,7 +166,7 @@ tasks:
     vars:
       TAG: '{{.TAG | default .Env.TAG | default "dev"}}'
       REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
-      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
+      PROJECT_NAME: "{{.Env.PROJECT_NAME | default .PROJECT_NAME}}"
     cmds:
       - task: _publish:image-and-sign
         vars:
@@ -190,7 +190,7 @@ tasks:
         sh: |
           printf '%s' "{{.SOURCE_TAGS}}" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/^v//' | awk 'NF { printf "%s%s-{{.ARCH_SUFFIX}}", sep, $0; sep="," }'
       REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
-      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
+      PROJECT_NAME: "{{.Env.PROJECT_NAME | default .PROJECT_NAME}}"
       PLATFORM: "{{.PLATFORM | default .Env.PLATFORM}}"
       ARCH_SUFFIX: "{{.ARCH_SUFFIX | default .Env.ARCH_SUFFIX}}"
     preconditions:
@@ -219,7 +219,7 @@ tasks:
     vars:
       TAG: '{{.TAG | default .Env.TAG | default "dev"}}'
       REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
-      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
+      PROJECT_NAME: "{{.Env.PROJECT_NAME | default .PROJECT_NAME}}"
       ARCH: "{{.ARCH | default .Env.ARCH}}"
       SATELLITE_BINARY: "{{.SATELLITE_BINARY | default .Env.SATELLITE_BINARY}}"
       GC_BINARY: "{{.GC_BINARY | default .Env.GC_BINARY}}"
@@ -239,7 +239,7 @@ tasks:
       TAG: '{{.TAG | default .Env.TAG | default "dev"}}'
       SOURCE_TAGS: "{{.SOURCE_IMAGE_TAGS | default .SOURCE_TAG | default .TAG}}"
       REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
-      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
+      PROJECT_NAME: "{{.Env.PROJECT_NAME | default .PROJECT_NAME}}"
       ARCH_SUFFIXES: "{{.ARCH_SUFFIXES | default .Env.ARCH_SUFFIXES | default .PLATFORMS_LINUX}}"
     cmds:
       - task: _publish:manifest-and-sign
@@ -263,7 +263,7 @@ tasks:
     desc: Delete temporary per-arch source tags from the registry after manifest assembly
     vars:
       REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
-      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
+      PROJECT_NAME: "{{.Env.PROJECT_NAME | default .PROJECT_NAME}}"
       SOURCE_TAGS: "{{.SOURCE_IMAGE_TAGS | default .Env.SOURCE_IMAGE_TAGS}}"
       ARCH_SUFFIXES: "{{.ARCH_SUFFIXES | default .Env.ARCH_SUFFIXES}}"
     cmds:

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,17 @@
+// Package version exposes build-time metadata that is stamped into binaries
+// via Go linker -X flags in taskfiles/build.yml and .goreleaser.yaml.
+//
+// The variables are package-level vars (not consts) so the linker can
+// overwrite them at link time:
+//
+//	-X github.com/container-registry/harbor-satellite/internal/version.Version=v1.2.3
+//	-X github.com/container-registry/harbor-satellite/internal/version.GitCommit=abc1234
+package version
+
+// Version is the release tag (e.g. "v1.2.3") stamped at build time.
+// Falls back to "dev" when the binary is built without ldflags.
+var Version = "dev"
+
+// GitCommit is the full Git commit SHA stamped at build time.
+// Falls back to "unknown" when the binary is built without ldflags.
+var GitCommit = "unknown"

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,16 +1,91 @@
 package version_test
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	v "github.com/container-registry/harbor-satellite/internal/version"
 )
 
 func TestDefaults(t *testing.T) {
-	if v.Version == "" {
-		t.Fatal("Version must not be empty")
+	if v.Version != "dev" {
+		t.Errorf("expected default Version to be %q, got %q", "dev", v.Version)
 	}
-	if v.GitCommit == "" {
-		t.Fatal("GitCommit must not be empty")
+	if v.GitCommit != "unknown" {
+		t.Errorf("expected default GitCommit to be %q, got %q", "unknown", v.GitCommit)
+	}
+}
+
+func TestBuildStamping(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping build integration test in short mode")
+	}
+
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go binary not found in PATH")
+	}
+
+	// Create temp directory inside the module tree so Go allows importing internal packages
+	tempDir, err := os.MkdirTemp(".", "testbuild_*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
+
+	mainFile := filepath.Join(tempDir, "main.go")
+	binFile := filepath.Join(tempDir, "version_test_bin")
+
+	mainCode := `package main
+
+import (
+	"fmt"
+	"github.com/container-registry/harbor-satellite/internal/version"
+)
+
+func main() {
+	fmt.Printf("%s|%s\n", version.Version, version.GitCommit)
+}
+`
+
+	if err := os.WriteFile(mainFile, []byte(mainCode), 0o600); err != nil {
+		t.Fatalf("failed to write test main file: %v", err)
+	}
+
+	pkgPath := "github.com/container-registry/harbor-satellite/internal/version"
+	expectedVersion := "v1.2.3"
+	expectedCommit := "abc1234def5678"
+
+	ldflags := "-X " + pkgPath + ".Version=" + expectedVersion + " -X " + pkgPath + ".GitCommit=" + expectedCommit
+
+	cmd := exec.Command(goBin, "build", "-ldflags", ldflags, "-o", binFile, mainFile)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to build test binary with ldflags: %v\nOutput: %s", err, string(output))
+	}
+
+	runCmd := exec.Command(binFile)
+	runOutput, err := runCmd.Output()
+	if err != nil {
+		t.Fatalf("failed to run test binary: %v", err)
+	}
+
+	parts := strings.Split(strings.TrimSpace(string(runOutput)), "|")
+	if len(parts) != 2 {
+		t.Fatalf("unexpected output format: %q", string(runOutput))
+	}
+
+	gotVersion, gotCommit := parts[0], parts[1]
+
+	if gotVersion != expectedVersion {
+		t.Errorf("expected stamped Version %q, got %q", expectedVersion, gotVersion)
+	}
+	if gotCommit != expectedCommit {
+		t.Errorf("expected stamped GitCommit %q, got %q", expectedCommit, gotCommit)
 	}
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -2,6 +2,7 @@ package version_test
 
 import (
 	"testing"
+
 	v "github.com/container-registry/harbor-satellite/internal/version"
 )
 

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,15 @@
+package version_test
+
+import (
+	"testing"
+	v "github.com/container-registry/harbor-satellite/internal/version"
+)
+
+func TestDefaults(t *testing.T) {
+	if v.Version == "" {
+		t.Fatal("Version must not be empty")
+	}
+	if v.GitCommit == "" {
+		t.Fatal("GitCommit must not be empty")
+	}
+}

--- a/taskfiles/build.yml
+++ b/taskfiles/build.yml
@@ -163,11 +163,15 @@ tasks:
       - mkdir -p $(dirname {{.OUTPUT}})
       - |
         echo "Cross-compiling {{.COMPONENT}} for {{.GOOS}}/{{.GOARCH}}..."
+        # Export as env vars so their values are never interpolated into shell
+        # source; the shell expands $VERSION/$GIT_COMMIT safely at runtime.
+        export VERSION={{.VERSION | shellQuote}}
+        export GIT_COMMIT={{.GIT_COMMIT | shellQuote}}
         CGO_ENABLED=0 GOOS={{.GOOS}} GOARCH={{.GOARCH}} go build \
           -trimpath \
           -ldflags "-w -s \
-            -X github.com/container-registry/harbor-satellite/internal/version.GitCommit={{.GIT_COMMIT}} \
-            -X github.com/container-registry/harbor-satellite/internal/version.Version={{.VERSION}}" \
+            -X github.com/container-registry/harbor-satellite/internal/version.GitCommit=$GIT_COMMIT \
+            -X github.com/container-registry/harbor-satellite/internal/version.Version=$VERSION" \
           -o {{.OUTPUT}} \
           ./cmd/{{.COMPONENT}}
         echo "Built {{.OUTPUT}}"

--- a/taskfiles/build.yml
+++ b/taskfiles/build.yml
@@ -142,3 +142,33 @@ tasks:
           echo "  {{.ITEM.GOOS}}/{{.ITEM.GOARCH}}..."
           GOOS={{.ITEM.GOOS}} GOARCH={{.ITEM.GOARCH}} go build -o {{.BIN_DIR}}/groundcontrol/groundcontrol-{{.ITEM.GOOS}}-{{.ITEM.GOARCH}} ./cmd/groundcontrol/cli
     silent: true
+
+  cross-compile:
+    desc: Cross-compile a single component for a target GOOS/GOARCH (used by CI release matrix)
+    vars:
+      COMPONENT: "{{.COMPONENT}}"
+      GOARCH: "{{.GOARCH}}"
+      GOOS: '{{.GOOS | default "linux"}}'
+      OUTPUT: "{{.OUTPUT}}"
+      VERSION: '{{.VERSION | default "dev"}}'
+      GIT_COMMIT: '{{.GIT_COMMIT | default "unknown"}}'
+    preconditions:
+      - sh: test -n "{{.COMPONENT}}"
+        msg: "COMPONENT is required."
+      - sh: test -n "{{.GOARCH}}"
+        msg: "GOARCH is required."
+      - sh: test -n "{{.OUTPUT}}"
+        msg: "OUTPUT is required."
+    cmds:
+      - mkdir -p $(dirname {{.OUTPUT}})
+      - |
+        echo "Cross-compiling {{.COMPONENT}} for {{.GOOS}}/{{.GOARCH}}..."
+        CGO_ENABLED=0 GOOS={{.GOOS}} GOARCH={{.GOARCH}} go build \
+          -trimpath \
+          -ldflags "-w -s \
+            -X github.com/container-registry/harbor-satellite/internal/version.GitCommit={{.GIT_COMMIT}} \
+            -X github.com/container-registry/harbor-satellite/internal/version.Version={{.VERSION}}" \
+          -o {{.OUTPUT}} \
+          ./cmd/{{.COMPONENT}}
+        echo "Built {{.OUTPUT}}"
+    silent: true

--- a/taskfiles/publish.yml
+++ b/taskfiles/publish.yml
@@ -323,6 +323,7 @@ tasks:
           TAG=$(echo "{{.IMAGE_TAG}}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/^v//')
           TAG="${TAG}-{{.ARCH}}"
           IMAGE_ADDR="{{.REGISTRY}}/{{.PROJECT_NAME}}/$COMPONENT:$TAG"
+          echo "Image target: $IMAGE_ADDR"
           echo "Building $COMPONENT for linux/{{.ARCH}} using pre-built binary..."
           cp "$BINARY" ./prebuilt-binary
           chmod +x ./prebuilt-binary

--- a/taskfiles/publish.yml
+++ b/taskfiles/publish.yml
@@ -49,7 +49,7 @@ tasks:
     desc: Build and push multi-arch container image
     vars:
       REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
-      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
+      PROJECT_NAME: "{{.Env.PROJECT_NAME | default .PROJECT_NAME}}"
       COMPONENT: "{{.COMPONENT | default .Env.COMPONENT | default \"satellite\"}}"
       IMAGE_TAGS: "{{.IMAGE_TAGS | default .Env.IMAGE_TAGS | default \"dev\"}}"
       PLATFORMS: "{{.PLATFORMS | default \"linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/riscv64\"}}"
@@ -122,7 +122,7 @@ tasks:
     desc: Build, push, and sign multi-arch container image with Cosign
     vars:
       REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
-      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
+      PROJECT_NAME: "{{.Env.PROJECT_NAME | default .PROJECT_NAME}}"
       COMPONENT: "{{.COMPONENT | default .Env.COMPONENT | default \"satellite\"}}"
       IMAGE_TAGS: "{{.IMAGE_TAGS | default .Env.IMAGE_TAGS | default \"dev\"}}"
     preconditions:
@@ -154,7 +154,7 @@ tasks:
     desc: Create and sign a multi-arch image manifest from arch-specific tags
     vars:
       REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
-      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
+      PROJECT_NAME: "{{.Env.PROJECT_NAME | default .PROJECT_NAME}}"
       COMPONENT: "{{.COMPONENT | default .Env.COMPONENT | default \"satellite\"}}"
       IMAGE_TAGS: "{{.IMAGE_TAGS | default .Env.IMAGE_TAGS | default \"dev\"}}"
       SOURCE_IMAGE_TAGS: "{{.SOURCE_IMAGE_TAGS | default .Env.SOURCE_IMAGE_TAGS | default .IMAGE_TAGS | default .Env.IMAGE_TAGS | default \"dev\"}}"
@@ -225,7 +225,7 @@ tasks:
     desc: Delete temporary per-arch source tags from Harbor after manifest assembly
     vars:
       REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
-      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
+      PROJECT_NAME: "{{.Env.PROJECT_NAME | default .PROJECT_NAME}}"
       SOURCE_IMAGE_TAGS: "{{.SOURCE_IMAGE_TAGS | default .Env.SOURCE_IMAGE_TAGS}}"
       ARCH_SUFFIXES: "{{.ARCH_SUFFIXES | default .Env.ARCH_SUFFIXES}}"
     preconditions:
@@ -276,7 +276,7 @@ tasks:
     desc: Build and push a single-arch image for both components using pre-built binaries
     vars:
       REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
-      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
+      PROJECT_NAME: "{{.Env.PROJECT_NAME | default .PROJECT_NAME}}"
       IMAGE_TAG: "{{.IMAGE_TAG | default .Env.IMAGE_TAG}}"
       ARCH: "{{.ARCH | default .Env.ARCH}}"
       SATELLITE_BINARY: "{{.SATELLITE_BINARY | default .Env.SATELLITE_BINARY}}"

--- a/taskfiles/publish.yml
+++ b/taskfiles/publish.yml
@@ -245,7 +245,7 @@ tasks:
         for component in satellite ground-control; do
           for suffix in {{.ARCH_SUFFIXES}}; do
             for source_tag in "${source_tags_arr[@]}"; do
-              source_tag=$(echo "$source_tag" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+              source_tag=$(echo "$source_tag" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/^v//')
               [ -z "$source_tag" ] && continue
               tag="${source_tag}-${suffix}"
               url="https://{{.REGISTRY}}/api/v2.0/projects/{{.PROJECT_NAME}}/repositories/${component}/artifacts/${tag}/tags/${tag}"
@@ -270,6 +270,72 @@ tasks:
           echo "Warning: some tag deletions returned unexpected status codes (see above)." >&2
         fi
         exit 0  # cleanup is best-effort; never block CI
+    silent: true
+
+  platform-prebuilt:
+    desc: Build and push a single-arch image for both components using pre-built binaries
+    vars:
+      REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
+      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
+      IMAGE_TAG: "{{.IMAGE_TAG | default .Env.IMAGE_TAG}}"
+      ARCH: "{{.ARCH | default .Env.ARCH}}"
+      SATELLITE_BINARY: "{{.SATELLITE_BINARY | default .Env.SATELLITE_BINARY}}"
+      GC_BINARY: "{{.GC_BINARY | default .Env.GC_BINARY}}"
+    preconditions:
+      - sh: test -n "{{.REGISTRY}}"
+        msg: "REGISTRY is required. Set via task var or REGISTRY env var."
+      - sh: test -n "{{.PROJECT_NAME}}"
+        msg: "PROJECT_NAME is required. Set via task var or PROJECT_NAME env var."
+      - sh: test -n "{{.IMAGE_TAG}}"
+        msg: "IMAGE_TAG is required."
+      - sh: test -n "{{.ARCH}}"
+        msg: "ARCH is required."
+      - sh: test -n "{{.SATELLITE_BINARY}}"
+        msg: "SATELLITE_BINARY is required."
+      - sh: test -n "{{.GC_BINARY}}"
+        msg: "GC_BINARY is required."
+      - sh: test -f "{{.SATELLITE_BINARY}}"
+        msg: "Satellite binary not found at SATELLITE_BINARY path."
+      - sh: test -f "{{.GC_BINARY}}"
+        msg: "Ground-control binary not found at GC_BINARY path."
+    cmds:
+      - |
+        set -e
+        if [ -n "$REG_USER" ] && [ -n "$REG_PASS" ]; then
+          echo "$REG_PASS" | docker login {{.REGISTRY}} -u "$REG_USER" --password-stdin
+        fi
+      - |
+        set -e
+        cleanup() {
+          rm -f ./prebuilt-binary
+        }
+        trap cleanup EXIT
+
+        for COMPONENT in satellite ground-control; do
+          if [ "$COMPONENT" = "satellite" ]; then
+            BINARY="{{.SATELLITE_BINARY}}"
+            BUILD_COMPONENT="satellite"
+          else
+            BINARY="{{.GC_BINARY}}"
+            BUILD_COMPONENT="groundcontrol/server"
+          fi
+
+          TAG=$(echo "{{.IMAGE_TAG}}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/^v//')
+          TAG="${TAG}-{{.ARCH}}"
+          IMAGE_ADDR="{{.REGISTRY}}/{{.PROJECT_NAME}}/$COMPONENT:$TAG"
+          echo "Building $COMPONENT for linux/{{.ARCH}} using pre-built binary..."
+          cp "$BINARY" ./prebuilt-binary
+          chmod +x ./prebuilt-binary
+          docker buildx build \
+            --platform linux/{{.ARCH}} \
+            --build-arg PREBUILT_BINARY=./prebuilt-binary \
+            --build-arg COMPONENT=$BUILD_COMPONENT \
+            -t "$IMAGE_ADDR" \
+            --push \
+            .
+          rm -f ./prebuilt-binary
+          echo "Pushed $IMAGE_ADDR"
+        done
     silent: true
 
   snapshot-release:

--- a/taskfiles/publish.yml
+++ b/taskfiles/publish.yml
@@ -122,7 +122,7 @@ tasks:
     desc: Build, push, and sign multi-arch container image with Cosign
     vars:
       REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
-      PROJECT_NAME: "{{.Env.PROJECT_NAME | default .PROJECT_NAME}}"
+      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
       COMPONENT: "{{.COMPONENT | default .Env.COMPONENT | default \"satellite\"}}"
       IMAGE_TAGS: "{{.IMAGE_TAGS | default .Env.IMAGE_TAGS | default \"dev\"}}"
     preconditions:
@@ -154,7 +154,7 @@ tasks:
     desc: Create and sign a multi-arch image manifest from arch-specific tags
     vars:
       REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
-      PROJECT_NAME: "{{.Env.PROJECT_NAME | default .PROJECT_NAME}}"
+      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
       COMPONENT: "{{.COMPONENT | default .Env.COMPONENT | default \"satellite\"}}"
       IMAGE_TAGS: "{{.IMAGE_TAGS | default .Env.IMAGE_TAGS | default \"dev\"}}"
       SOURCE_IMAGE_TAGS: "{{.SOURCE_IMAGE_TAGS | default .Env.SOURCE_IMAGE_TAGS | default .IMAGE_TAGS | default .Env.IMAGE_TAGS | default \"dev\"}}"
@@ -225,7 +225,7 @@ tasks:
     desc: Delete temporary per-arch source tags from Harbor after manifest assembly
     vars:
       REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
-      PROJECT_NAME: "{{.Env.PROJECT_NAME | default .PROJECT_NAME}}"
+      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
       SOURCE_IMAGE_TAGS: "{{.SOURCE_IMAGE_TAGS | default .Env.SOURCE_IMAGE_TAGS}}"
       ARCH_SUFFIXES: "{{.ARCH_SUFFIXES | default .Env.ARCH_SUFFIXES}}"
     preconditions:
@@ -276,7 +276,7 @@ tasks:
     desc: Build and push a single-arch image for both components using pre-built binaries
     vars:
       REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
-      PROJECT_NAME: "{{.Env.PROJECT_NAME | default .PROJECT_NAME}}"
+      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
       IMAGE_TAG: "{{.IMAGE_TAG | default .Env.IMAGE_TAG}}"
       ARCH: "{{.ARCH | default .Env.ARCH}}"
       SATELLITE_BINARY: "{{.SATELLITE_BINARY | default .Env.SATELLITE_BINARY}}"

--- a/taskfiles/publish.yml
+++ b/taskfiles/publish.yml
@@ -49,7 +49,7 @@ tasks:
     desc: Build and push multi-arch container image
     vars:
       REGISTRY: "{{.REGISTRY | default .Env.REGISTRY}}"
-      PROJECT_NAME: "{{.Env.PROJECT_NAME | default .PROJECT_NAME}}"
+      PROJECT_NAME: "{{.PROJECT_NAME | default .Env.PROJECT_NAME}}"
       COMPONENT: "{{.COMPONENT | default .Env.COMPONENT | default \"satellite\"}}"
       IMAGE_TAGS: "{{.IMAGE_TAGS | default .Env.IMAGE_TAGS | default \"dev\"}}"
       PLATFORMS: "{{.PLATFORMS | default \"linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/riscv64\"}}"
@@ -329,6 +329,7 @@ tasks:
           chmod +x ./prebuilt-binary
           docker buildx build \
             --platform linux/{{.ARCH}} \
+            --build-arg BUILDER_MODE=prebuilt \
             --build-arg PREBUILT_BINARY=./prebuilt-binary \
             --build-arg COMPONENT=$BUILD_COMPONENT \
             -t "$IMAGE_ADDR" \


### PR DESCRIPTION
- Fixes: #650 

## Description

This PR parallelizes the tagged release pipeline.

The release flow now builds release binaries in a per-architecture matrix on GitHub-hosted runners, uploads those binaries as workflow artifacts, and reuses them when building the per-architecture container images. The per-arch images are then combined into signed multi-arch manifests for the release tags.

It also adds the supporting Task targets and Dockerfile changes needed to inject pre-built binaries into image builds, avoiding a second Go build inside Docker during release image publishing.

## Additional context

Validated the full release workflow in my fork with tag `v0.0.15-test` (https://github.com/cotishq/harbor-satellite/actions/runs/33269638818)

The following jobs completed successfully:

- `build-release-binaries` matrix
- `publish-release-images` matrix
- `create-release-manifest`
- `cleanup-release-temp-tags`
- `publish-release`

<img width="1901" height="710" alt="image" src="https://github.com/user-attachments/assets/78784ebb-3481-417f-a5d0-4264b7650d9f" />




<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-satellite/pull/651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for publishing architecture-specific container images from prebuilt binaries.
  - Added cross-compilation for release binaries targeting specific operating systems and architectures.
  - Release workflows now build, publish, sign, and assemble multi-architecture image manifests in separate stages.

- **Improvements**
  - Project and repository names resolve more reliably during publishing and cleanup.
  - Release configuration targets the active repository automatically.
  - Publishing retries use streamlined handling.
  - Builds include version and commit metadata.
  - Container builds support selecting source-based or prebuilt binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->