### PR TITLE
fix(env): escape special characters in Database.URL connection string

### DIFF
--- a/internal/shared/env/utils.go
+++ b/internal/shared/env/utils.go
@@ -3,18 +3,20 @@ package env
 import (
 	"fmt"
 	"net"
+	"net/url"
 
 	auditlog "github.com/container-registry/harbor-satellite/internal/shared/logger"
 )
 
 func (d Database) URL() string {
-	return fmt.Sprintf(
-		"postgres://%s:%s@%s/%s?sslmode=disable",
-		d.Username,
-		d.Password,
-		net.JoinHostPort(d.Host, d.Port),
-		d.Database,
-	)
+	u := url.URL{
+		Scheme:   "postgres",
+		User:     url.UserPassword(d.Username, d.Password),
+		Host:     net.JoinHostPort(d.Host, d.Port),
+		Path:     "/" + d.Database,
+		RawQuery: "sslmode=disable",
+	}
+	return u.String()
 }
 
 func (h Harbor) Validate() error {

--- a/internal/shared/env/utils_test.go
+++ b/internal/shared/env/utils_test.go
@@ -1,0 +1,56 @@
+package env
+
+import (
+	"testing"
+)
+
+func TestDatabaseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		db       Database
+		expected string
+	}{
+		{
+			name: "standard credentials",
+			db: Database{
+				Username: "postgres",
+				Password: "secretpassword",
+				Host:     "localhost",
+				Port:     "5432",
+				Database: "harbor_satellite",
+			},
+			expected: "postgres://postgres:secretpassword@localhost:5432/harbor_satellite?sslmode=disable",
+		},
+		{
+			name: "special characters in password",
+			db: Database{
+				Username: "gc_user",
+				Password: "p@ss#word%123?",
+				Host:     "127.0.0.1",
+				Port:     "5432",
+				Database: "groundcontrol",
+			},
+			expected: "postgres://gc_user:p%40ss%23word%25123%3F@127.0.0.1:5432/groundcontrol?sslmode=disable",
+		},
+		{
+			name: "special characters in username",
+			db: Database{
+				Username: "user@domain.com",
+				Password: "secret",
+				Host:     "db.example.com",
+				Port:     "5432",
+				Database: "db",
+			},
+			expected: "postgres://user%40domain.com:secret@db.example.com:5432/db?sslmode=disable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.db.URL()
+			if got != tt.expected {
+				t.Errorf("Database.URL() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary
This PR fixes an issue in `Database.URL()` where raw string formatting was used to construct PostgreSQL connection URIs (`postgres://%s:%s@%s/%s?sslmode=disable`).

When `DB_USERNAME` or `DB_PASSWORD` contains special URL characters (e.g., `@`, `#`, `%`, `?`, `:`), raw string interpolation creates malformed DSN strings (for example, `postgres://user:p@ssword#123@host:5432/dbname?sslmode=disable`), causing standard Go database drivers (`lib/pq`, `pgx`) to fail parsing.

Fixes #659

### Changes
- Updated `Database.URL()` in `internal/shared/env/utils.go` to construct the PostgreSQL URI using `net/url.URL` and `url.UserPassword()`, cleanly URL-escaping user credentials.
- Added unit test cases in `internal/shared/env/utils_test.go` verifying standard credentials and credentials with special characters.

### Verification
- `go test -v -cover ./internal/shared/env/...` -> **PASS**
- `go vet ./internal/shared/env/...` -> **PASS**