### PR TITLE
docs: refresh satellite layout and config examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,11 +84,10 @@ When making changes, keep binary entrypoints in `cmd/` and implementation packag
 - internal/satellite/: Core orchestration logic
 - internal/satellite/state/: State management (replication, fetching, artifact handling, registration)
 - internal/satellite/store/: Local OCI layout and remote registry storage backends
-- internal/scheduler/: Cron-based job scheduling
-- internal/container_runtime/: CRI config management (Docker, containerd, CRI-O, Podman)
-- internal/server/: HTTP server for metrics and health
-- internal/watcher/: Config file watching for hot-reload
-- internal/hotreload/: Hot-reload mechanism
+- internal/satellite/scheduler/: Cron-based job scheduling
+- internal/satellite/container_runtime/: CRI config management (Docker, containerd, CRI-O, Podman)
+- internal/satellite/watcher/: Config file watching for hot-reload
+- internal/satellite/hotreload/: Hot-reload mechanism
 
 ### Ground Control Component Structure
 

--- a/docs/architecture/use-cases.md
+++ b/docs/architecture/use-cases.md
@@ -11,38 +11,25 @@ This document outlines the current use cases and deployment patterns for Harbor 
 {
   "state_config": {
     "auth": {
-      "name": "your_username",
-      "registry": "https://harbor.example.com",
-      "secret": "your_password"
+      "url": "https://harbor.example.com",
+      "username": "robot$satellite",
+      "password": ""
     },
-    "states": [
-      "project1",
-      "project2"
-    ]
+    "state": ""
   },
-  "environment_variables": {
-    "ground_control_url": "http://localhost:8080",
+  "app_config": {
+    "ground_control_url": "http://127.0.0.1:8080",
     "log_level": "info",
     "use_unsecure": false,
-    "token": "your_satellite_token",
-    "jobs": [
-      {
-        "name": "replicate_state",
-        "schedule": "@every 00h00m10s"
-      },
-      {
-        "name": "update_config",
-        "schedule": "@every 00h00m30s"
-      },
-      {
-        "name": "register_satellite",
-        "schedule": "@every 00h00m05s"
-      }
-    ],
+    "state_replication_interval": "@every 00h00m10s",
+    "register_satellite_interval": "@every 00h00m05s",
+    "heartbeat_interval": "@every 00h00m30s",
     "bring_own_registry": false
   }
 }
 ```
+
+The registration token is a CLI/env flag, not a config.json field. A fuller example is in [examples/config.example.json](../../examples/config.example.json).
 
 #### Use Cases
 - Remote deployments


### PR DESCRIPTION
- Fixes: #660 

## Description

Refresh contributor and architecture docs that still described the pre-ORAS Satellite layout and an old `config.json` shape.
- `CLAUDE.md`: point Satellite packages at `internal/satellite/{scheduler,container_runtime,watcher,hotreload}` and drop the leftover `internal/server/` entry (no metrics HTTP server in this tree).
- `docs/architecture/use-cases.md`: replace the Basic Edge Registry snippet (`environment_variables`, `jobs[]`, `auth.name/registry/secret`, `states[]`) with the current `state_config` / `app_config` fields. Note that the registration token is CLI/env, not JSON, and link `examples/config.example.json`.

## Additional context

Docs-only. Matches `pkg/config` and the current `internal/satellite/` tree after the ORAS layout change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Satellite architecture documentation to reflect the current package structure.
  * Revised the Basic Edge Registry configuration example with updated authentication, state, application settings, and interval fields.
  * Clarified that the registration token is provided through a CLI or environment flag rather than the configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->