### PR TITLE
fix(utils): reject empty repository and image names in GetRepositoryAndImageNameFromArtifact

### DIFF
--- a/internal/shared/utils/utils.go
+++ b/internal/shared/utils/utils.go
@@ -60,13 +60,17 @@ func HasInvalidPathChars(input string) bool {
 }
 
 func GetRepositoryAndImageNameFromArtifact(repository string) (string, string, error) {
+	repository = strings.TrimSpace(repository)
 	parts := strings.Split(repository, "/")
 	if len(parts) < 2 {
 		return "", "", fmt.Errorf("invalid repository format: %s. Expected format: repo/image", repository)
 	}
 
-	repo := parts[0]
-	image := strings.Join(parts[1:], "/")
+	repo := strings.TrimSpace(parts[0])
+	image := strings.TrimSpace(strings.Join(parts[1:], "/"))
+	if repo == "" || image == "" || strings.HasPrefix(image, "/") || strings.HasSuffix(image, "/") {
+		return "", "", fmt.Errorf("invalid repository format: %s. Expected non-empty repository and image names", repository)
+	}
 	return repo, image, nil
 }
 

--- a/internal/shared/utils/utils_test.go
+++ b/internal/shared/utils/utils_test.go
@@ -1,0 +1,179 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestGetRepositoryAndImageNameFromArtifact(t *testing.T) {
+	tests := []struct {
+		name          string
+		repository    string
+		expectedRepo  string
+		expectedImage string
+		expectError   bool
+	}{
+		{
+			name:          "valid repo/image string",
+			repository:    "library/ubuntu",
+			expectedRepo:  "library",
+			expectedImage: "ubuntu",
+			expectError:   false,
+		},
+		{
+			name:          "valid multi-segment repo/sub/image string",
+			repository:    "myorg/subteam/app",
+			expectedRepo:  "myorg",
+			expectedImage: "subteam/app",
+			expectError:   false,
+		},
+		{
+			name:          "valid string with surrounding whitespace",
+			repository:    "  library/ubuntu  ",
+			expectedRepo:  "library",
+			expectedImage: "ubuntu",
+			expectError:   false,
+		},
+		{
+			name:        "invalid single segment without slash",
+			repository:  "ubuntu",
+			expectError: true,
+		},
+		{
+			name:        "invalid empty repo segment starting with slash",
+			repository:  "/ubuntu",
+			expectError: true,
+		},
+		{
+			name:        "invalid empty image segment ending with slash",
+			repository:  "library/",
+			expectError: true,
+		},
+		{
+			name:        "invalid slash only",
+			repository:  "/",
+			expectError: true,
+		},
+		{
+			name:        "invalid double slash segment",
+			repository:  "library//ubuntu",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, image, err := GetRepositoryAndImageNameFromArtifact(tt.repository)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("GetRepositoryAndImageNameFromArtifact(%q) expected error, got nil", tt.repository)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("GetRepositoryAndImageNameFromArtifact(%q) unexpected error: %v", tt.repository, err)
+				}
+				if repo != tt.expectedRepo {
+					t.Errorf("GetRepositoryAndImageNameFromArtifact(%q) repo = %q, want %q", tt.repository, repo, tt.expectedRepo)
+				}
+				if image != tt.expectedImage {
+					t.Errorf("GetRepositoryAndImageNameFromArtifact(%q) image = %q, want %q", tt.repository, image, tt.expectedImage)
+				}
+			}
+		})
+	}
+}
+
+func TestFormatRegistryURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "https prefix trimmed",
+			input:    "https://registry.example.com",
+			expected: "registry.example.com",
+		},
+		{
+			name:     "http prefix trimmed",
+			input:    "http://localhost:5000",
+			expected: "localhost:5000",
+		},
+		{
+			name:     "no prefix unchanged",
+			input:    "harbor.local",
+			expected: "harbor.local",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatRegistryURL(tt.input); got != tt.expected {
+				t.Errorf("FormatRegistryURL(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHasInvalidPathChars(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "clean path",
+			input:    "valid/file/path.txt",
+			expected: false,
+		},
+		{
+			name:     "path with colon",
+			input:    "invalid:path",
+			expected: true,
+		},
+		{
+			name:     "path with wildcard",
+			input:    "path/*.txt",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasInvalidPathChars(tt.input); got != tt.expected {
+				t.Errorf("HasInvalidPathChars(%q) = %t, want %t", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsValidURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "valid http url",
+			input:    "http://example.com",
+			expected: true,
+		},
+		{
+			name:     "valid https url",
+			input:    "https://harbor.example.com/api",
+			expected: true,
+		},
+		{
+			name:     "plain string without scheme",
+			input:    "harbor.example.com",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsValidURL(tt.input); got != tt.expected {
+				t.Errorf("IsValidURL(%q) = %t, want %t", tt.input, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary
This PR fixes an issue in `GetRepositoryAndImageNameFromArtifact()` where malformed repository strings with empty repo or image segments (such as `/myimage`, `myrepo/`, `/`, `//`, or leading/trailing whitespace) returned empty strings without returning an error.

Fixes #662

### Changes
- Added validation in `internal/shared/utils/utils.go` to trim whitespace and enforce non-empty repository and image name segments.
- Added table-driven unit tests in `internal/shared/utils/utils_test.go` covering valid and malformed artifact repository inputs.

### Verification
- `gofmt -s -w internal/shared/utils` -> **PASS**
- `go vet ./internal/shared/utils/...` -> **PASS**
- `go test -v -cover ./internal/shared/utils/...` -> **PASS**
- `go test -v ./internal/shared/utils/...` -> **PASS**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact name validation by trimming unnecessary whitespace and rejecting empty names or invalid slash placement.
  * Added clearer handling for malformed repository and image paths.

* **Tests**
  * Added coverage for artifact parsing, registry URL formatting, invalid path characters, and URL validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->